### PR TITLE
Add unit coverage for question, web, mcp, todo and subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 [![npm](https://img.shields.io/npm/v/pi-code)](https://www.npmjs.com/package/pi-code)
 [![npm](https://img.shields.io/npm/dt/pi-code)](https://www.npmjs.com/package/pi-code)
 [![GitHub](https://img.shields.io/github/license/ilovepixelart/pi-code)](https://github.com/ilovepixelart/pi-code/blob/main/LICENSE)
+\
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ilovepixelart_pi-code&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ilovepixelart_pi-code)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ilovepixelart_pi-code&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ilovepixelart_pi-code)
+\
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ilovepixelart_pi-code&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=ilovepixelart_pi-code)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ilovepixelart_pi-code&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ilovepixelart_pi-code)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ilovepixelart_pi-code&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=ilovepixelart_pi-code)

--- a/extensions/claude-rules.ts
+++ b/extensions/claude-rules.ts
@@ -43,7 +43,7 @@ function parsePaths(frontmatter: string): string[] {
   if (inline) return splitInline(inline)
   const items: string[] = []
   for (let i = index + 1; i < lines.length; i++) {
-    const match = /^\s*-\s*(.+)$/.exec(lines[i])
+    const match = /^\s*-\s*(\S.*)$/.exec(lines[i])
     if (!match) break
     items.push(unquote(match[1].trim()))
   }

--- a/extensions/question.ts
+++ b/extensions/question.ts
@@ -65,6 +65,7 @@ export default function question(pi: ExtensionAPI) {
         let optionIndex = 0
         let editMode = false
         let cachedLines: string[] | undefined
+        let cachedWidth: number | undefined
 
         const editorTheme: EditorTheme = {
           borderColor: (s) => theme.fg('accent', s),
@@ -135,7 +136,7 @@ export default function question(pi: ExtensionAPI) {
         }
 
         function render(width: number): string[] {
-          if (cachedLines) return cachedLines
+          if (cachedLines && cachedWidth === width) return cachedLines
 
           const lines: string[] = []
           const add = (s: string) => lines.push(truncateToWidth(s, width))
@@ -180,6 +181,7 @@ export default function question(pi: ExtensionAPI) {
           }
           add(theme.fg('accent', '─'.repeat(width)))
 
+          cachedWidth = width
           cachedLines = lines
           return lines
         }
@@ -187,6 +189,7 @@ export default function question(pi: ExtensionAPI) {
         return {
           render,
           invalidate: () => {
+            cachedWidth = undefined
             cachedLines = undefined
           },
           handleInput,

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -29,14 +29,14 @@ const MAX_PARALLEL_TASKS = 8
 const MAX_CONCURRENCY = 4
 const COLLAPSED_ITEM_COUNT = 10
 
-function formatTokens(count: number): string {
+export function formatTokens(count: number): string {
   if (count < 1000) return count.toString()
   if (count < 10000) return `${(count / 1000).toFixed(1)}k`
   if (count < 1000000) return `${Math.round(count / 1000)}k`
   return `${(count / 1000000).toFixed(1)}M`
 }
 
-function formatUsageStats(
+export function formatUsageStats(
   usage: {
     input: number
     output: number
@@ -62,7 +62,7 @@ function formatUsageStats(
   return parts.join(' ')
 }
 
-function formatToolCall(toolName: string, args: Record<string, unknown>, themeFg: Theme['fg']): string {
+export function formatToolCall(toolName: string, args: Record<string, unknown>, themeFg: Theme['fg']): string {
   const shortenPath = (p: string) => {
     const home = os.homedir()
     return p.startsWith(home) ? `~${p.slice(home.length)}` : p
@@ -153,7 +153,7 @@ interface SubagentDetails {
   results: SingleResult[]
 }
 
-function getFinalOutput(messages: Message[]): string {
+export function getFinalOutput(messages: Message[]): string {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i]
     if (msg.role === 'assistant') {
@@ -167,7 +167,7 @@ function getFinalOutput(messages: Message[]): string {
 
 type DisplayItem = { type: 'text'; text: string } | { type: 'toolCall'; name: string; args: Record<string, unknown> }
 
-function getDisplayItems(messages: Message[]): DisplayItem[] {
+export function getDisplayItems(messages: Message[]): DisplayItem[] {
   const items: DisplayItem[] = []
   for (const msg of messages) {
     if (msg.role === 'assistant') {
@@ -180,7 +180,7 @@ function getDisplayItems(messages: Message[]): DisplayItem[] {
   return items
 }
 
-async function mapWithConcurrencyLimit<TIn, TOut>(items: TIn[], concurrency: number, fn: (item: TIn, index: number) => Promise<TOut>): Promise<TOut[]> {
+export async function mapWithConcurrencyLimit<TIn, TOut>(items: TIn[], concurrency: number, fn: (item: TIn, index: number) => Promise<TOut>): Promise<TOut[]> {
   if (items.length === 0) return []
   const limit = Math.max(1, Math.min(concurrency, items.length))
   const results: TOut[] = new Array(items.length)

--- a/tests/claude-rules.test.ts
+++ b/tests/claude-rules.test.ts
@@ -16,6 +16,11 @@ describe('parseFrontmatter', () => {
     expect(parseFrontmatter(md)).toEqual({ paths: ['src/**/*.ts', '**/*.test.ts'], body: 'Use strict types.' })
   })
 
+  it('ends the block list at a dash entry with no value', () => {
+    const md = '---\npaths:\n  - a.ts\n  -   \n  - b.ts\n---\nbody'
+    expect(parseFrontmatter(md).paths).toEqual(['a.ts'])
+  })
+
   it('parses an inline array of paths', () => {
     expect(parseFrontmatter('---\npaths: ["a.ts", "b.ts"]\n---\nbody').paths).toEqual(['a.ts', 'b.ts'])
   })

--- a/tests/git-checkpoint-more.test.ts
+++ b/tests/git-checkpoint-more.test.ts
@@ -1,0 +1,617 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import gitCheckpoint from '../extensions/git-checkpoint.ts'
+
+type Handler = (event: any, ctx: any) => Promise<unknown>
+
+/**
+ * The extension resolves its shadow repo under os.homedir(), so homedir is
+ * redirected at a per-test temp dir: without this the suite writes a real bare
+ * repo into the developer's ~/.pi/agent/checkpoints and carries it between runs.
+ */
+const hoisted = vi.hoisted(() => ({ home: '' }))
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: () => hoisted.home }
+})
+
+const SESSION_FILE_NAME = 'session-test.jsonl'
+
+const userEntry = {
+  type: 'message',
+  id: 'user0001',
+  parentId: null,
+  message: { role: 'user', content: 'refactor the config loader so it validates the schema up front' },
+}
+
+const messageEntry = (id: string, content: unknown) => ({ type: 'message', id, parentId: null, message: { role: 'user', content } })
+
+const checkpointEntry = (data: { entryId: string; ref: string; prompt: string; createdAt?: string }) => ({
+  type: 'custom',
+  customType: 'git-checkpoint',
+  data: { createdAt: '2026-07-20T08:00:00.000Z', ...data },
+})
+
+interface CtxOptions {
+  entries?: any[]
+  branch?: any[]
+  /** Answers consumed by ui.select in order: a number picks that option index, a string is returned verbatim, undefined cancels. */
+  answers?: Array<string | number | undefined>
+  hasUI?: boolean
+  cwd?: string
+  navigateTree?: (entryId: string, options: unknown) => Promise<unknown>
+}
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+/** Fresh repo, shadow home and extension instance so tests share no state and may run in any order. */
+function setup() {
+  const handlers = new Map<string, Handler>()
+  const commands = new Map<string, { handler: (args: string, ctx: any) => Promise<void> }>()
+  const appended: Array<{ customType: string; data: any }> = []
+  const notifications: string[] = []
+  const selects: Array<{ title: string; options: string[] }> = []
+  const execArgs: string[][] = []
+  const editorTexts: string[] = []
+  const navigations: string[] = []
+
+  const repo = mkdtempSync(join(tmpdir(), 'gcm-test-'))
+  hoisted.home = mkdtempSync(join(tmpdir(), 'gcm-home-'))
+  tempDirs.push(repo, hoisted.home)
+
+  const shadowHome = hoisted.home
+  const sessionFile = join(repo, SESSION_FILE_NAME)
+  execFileSync('git', ['init', '-qb', 'main'], { cwd: repo })
+  writeFileSync(join(repo, 'tracked.txt'), 'v1\n')
+
+  gitCheckpoint({
+    on: (name: string, fn: Handler) => handlers.set(name, fn),
+    registerCommand: (name: string, opts: any) => commands.set(name, opts),
+    appendEntry: (customType: string, data: any) => appended.push({ customType, data }),
+    exec: async (cmd: string, args: string[], options?: { cwd?: string }) => {
+      execArgs.push(args)
+      try {
+        return { stdout: execFileSync(cmd, args, { cwd: options?.cwd ?? repo, encoding: 'utf8' }), stderr: '', code: 0, killed: false }
+      } catch (err: any) {
+        return { stdout: err.stdout ?? '', stderr: err.stderr ?? String(err), code: err.status ?? 1, killed: false }
+      }
+    },
+  } as any)
+
+  const makeCtx = (options: CtxOptions = {}) => ({
+    cwd: options.cwd ?? repo,
+    hasUI: options.hasUI ?? true,
+    sessionManager: {
+      getEntries: () => options.entries ?? [],
+      getBranch: () => options.branch ?? [],
+      getSessionFile: () => sessionFile,
+    },
+    ui: {
+      select: async (title: string, choices: string[]) => {
+        selects.push({ title, options: [...choices] })
+        const answer = options.answers?.shift()
+        return typeof answer === 'number' ? choices[answer] : answer
+      },
+      notify: (msg: string, level: string) => notifications.push(`[${level}] ${msg}`),
+      setEditorText: (text: string) => editorTexts.push(text),
+    },
+    navigateTree:
+      options.navigateTree ??
+      (async (entryId: string) => {
+        navigations.push(entryId)
+        return { editorText: 'restored prompt', cancelled: false }
+      }),
+  })
+
+  return { handlers, commands, appended, notifications, selects, execArgs, editorTexts, navigations, repo, shadowHome, makeCtx }
+}
+
+type Harness = ReturnType<typeof setup>
+
+/** Drive one full turn so a real snapshot ref exists; shadowDir is only initialized by session_start. */
+async function checkpointOneTurn(t: Harness, branch: any[] = [userEntry]): Promise<void> {
+  await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx())
+  await t.handlers.get('turn_start')?.({ turnIndex: 0 }, t.makeCtx())
+  await t.handlers.get('turn_end')?.({ turnIndex: 0 }, t.makeCtx({ branch }))
+}
+
+const rewind = (t: Harness, options: CtxOptions) => t.commands.get('rewind')?.handler('', t.makeCtx(options))
+
+describe('shadow repo initialization', () => {
+  it('creates the bare repo under the session slug in the home directory', async () => {
+    const t = setup()
+
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx())
+
+    expect(existsSync(join(t.shadowHome, '.pi', 'agent', 'checkpoints', SESSION_FILE_NAME, 'HEAD'))).toBe(true)
+  })
+
+  it('configures the checkpoint committer identity on a freshly created shadow repo', async () => {
+    const t = setup()
+
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx())
+
+    const configured = t.execArgs.filter((args) => args[2] === 'config').map((args) => args.slice(2))
+    expect(configured).toEqual([
+      ['config', 'user.email', 'checkpoint@pi-code'],
+      ['config', 'user.name', 'pi-code-checkpoint'],
+    ])
+  })
+
+  it('reuses an existing shadow repo instead of re-initializing it', async () => {
+    const t = setup()
+
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx())
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx())
+
+    expect(t.execArgs.filter((args) => args[0] === 'init')).toHaveLength(1)
+  })
+
+  it('rehydrates checkpoints recorded in the session on resume', async () => {
+    const t = setup()
+    const entry = checkpointEntry({ entryId: 'user0001', ref: 'a'.repeat(40), prompt: 'earlier prompt' })
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries: [entry] }))
+    await rewind(t, { entries: [entry], answers: [undefined] })
+
+    expect(t.selects[0].options).toEqual([expect.stringContaining('earlier prompt')])
+  })
+
+  it('ignores session entries that are not checkpoints', async () => {
+    const t = setup()
+    const entries = [userEntry, { type: 'custom', customType: 'other-extension', data: { entryId: 'user0001' } }]
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries }))
+    await rewind(t, { entries, answers: [undefined] })
+
+    expect(t.notifications).toEqual(['[info] No checkpoints recorded yet'])
+  })
+
+  it('ignores a checkpoint entry that carries no entry id', async () => {
+    const t = setup()
+    const entries = [{ type: 'custom', customType: 'git-checkpoint', data: { ref: 'a'.repeat(40), prompt: 'orphan' } }]
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries }))
+    await rewind(t, { entries, answers: [undefined] })
+
+    expect(t.notifications).toEqual(['[info] No checkpoints recorded yet'])
+  })
+
+  it('drops in-memory checkpoints when a session starts with no recorded entries', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx())
+    await rewind(t, { answers: [undefined] })
+
+    expect(t.notifications).toEqual(['[info] No checkpoints recorded yet'])
+  })
+})
+
+describe('snapshotting', () => {
+  it('records no checkpoint when the shadow repo was never initialized', async () => {
+    const t = setup()
+
+    await t.handlers.get('turn_start')?.({ turnIndex: 0 }, t.makeCtx())
+    await t.handlers.get('turn_end')?.({ turnIndex: 0 }, t.makeCtx({ branch: [userEntry] }))
+
+    expect(t.appended).toEqual([])
+    expect(t.execArgs).toEqual([])
+  })
+
+  it('records no checkpoint for a turn that never started', async () => {
+    const t = setup()
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx())
+
+    await t.handlers.get('turn_end')?.({ turnIndex: 0 }, t.makeCtx({ branch: [userEntry] }))
+
+    expect(t.appended).toEqual([])
+  })
+
+  it('records no checkpoint when the branch holds no user message', async () => {
+    const t = setup()
+    const assistant = { type: 'message', id: 'asst0001', parentId: null, message: { role: 'assistant', content: 'done' } }
+
+    await checkpointOneTurn(t, [assistant])
+
+    expect(t.appended).toEqual([])
+  })
+
+  it('checkpoints an empty working tree with an empty commit', async () => {
+    const t = setup()
+    const empty = mkdtempSync(join(tmpdir(), 'gcm-empty-'))
+    tempDirs.push(empty)
+
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx({ cwd: empty }))
+    await t.handlers.get('turn_start')?.({ turnIndex: 0 }, t.makeCtx({ cwd: empty }))
+    await t.handlers.get('turn_end')?.({ turnIndex: 0 }, t.makeCtx({ cwd: empty, branch: [userEntry] }))
+
+    expect(t.appended).toHaveLength(1)
+    expect(t.appended[0].data.ref).toMatch(/^[0-9a-f]{40}$/)
+  })
+
+  it('keys the checkpoint on the last user message of the branch', async () => {
+    const t = setup()
+    const first = messageEntry('user0001', 'first prompt')
+    const second = messageEntry('user0002', 'second prompt')
+
+    await checkpointOneTurn(t, [first, second])
+
+    expect(t.appended[0].data.entryId).toBe('user0002')
+    expect(t.appended[0].data.prompt).toBe('second prompt')
+  })
+
+  it('appends the checkpoint under the git-checkpoint custom type', async () => {
+    const t = setup()
+
+    await checkpointOneTurn(t)
+
+    expect(t.appended.map((e) => e.customType)).toEqual(['git-checkpoint'])
+  })
+
+  it('keeps a 60-character prompt intact', async () => {
+    const t = setup()
+    const prompt = 'a'.repeat(60)
+
+    await checkpointOneTurn(t, [messageEntry('user0001', prompt)])
+
+    expect(t.appended[0].data.prompt).toBe(prompt)
+  })
+
+  it('truncates a 61-character prompt to 60 characters plus an ellipsis', async () => {
+    const t = setup()
+
+    await checkpointOneTurn(t, [messageEntry('user0001', 'b'.repeat(61))])
+
+    expect(t.appended[0].data.prompt).toBe(`${'b'.repeat(60)}…`)
+  })
+
+  it('collapses runs of whitespace in the prompt snippet', async () => {
+    const t = setup()
+
+    await checkpointOneTurn(t, [messageEntry('user0001', '  fix   the\n\tparser  ')])
+
+    expect(t.appended[0].data.prompt).toBe('fix the parser')
+  })
+
+  it('joins the text parts of a structured prompt and skips non-text parts', async () => {
+    const t = setup()
+    const content = [
+      { type: 'text', text: 'alpha' },
+      { type: 'image', source: 'x' },
+      { type: 'text', text: 'beta' },
+    ]
+
+    await checkpointOneTurn(t, [messageEntry('user0001', content)])
+
+    expect(t.appended[0].data.prompt).toBe('alpha beta')
+  })
+
+  it('records an empty prompt for content of an unsupported shape', async () => {
+    const t = setup()
+
+    await checkpointOneTurn(t, [messageEntry('user0001', { text: 'not an array' })])
+
+    expect(t.appended[0].data.prompt).toBe('')
+  })
+})
+
+describe('/rewind checkpoint picker', () => {
+  it('reports that nothing is recorded when no checkpoint exists', async () => {
+    const t = setup()
+
+    await rewind(t, {})
+
+    expect(t.notifications).toEqual(['[info] No checkpoints recorded yet'])
+    expect(t.selects).toEqual([])
+  })
+
+  it('does nothing at all without a UI', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await rewind(t, { hasUI: false, answers: [0, 'Code only'] })
+
+    expect(t.selects).toEqual([])
+    expect(t.notifications).toEqual([])
+  })
+
+  it('lists checkpoints newest first, numbered from one', async () => {
+    const t = setup()
+    const older = checkpointEntry({ entryId: 'user0001', ref: 'a'.repeat(40), prompt: 'older prompt' })
+    const newer = checkpointEntry({ entryId: 'user0002', ref: 'b'.repeat(40), prompt: 'newer prompt' })
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries: [older, newer] }))
+    await rewind(t, { entries: [older, newer], answers: [undefined] })
+
+    const [first, second] = t.selects[0].options
+    expect(first.startsWith('1. ')).toBe(true)
+    expect(first.endsWith('  newer prompt')).toBe(true)
+    expect(second.startsWith('2. ')).toBe(true)
+    expect(second.endsWith('  older prompt')).toBe(true)
+  })
+
+  it('marks a checkpoint that carries no code snapshot', async () => {
+    const t = setup()
+    const entry = checkpointEntry({ entryId: 'user0001', ref: '', prompt: 'no snapshot here' })
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries: [entry] }))
+    await rewind(t, { entries: [entry], answers: [undefined] })
+
+    expect(t.selects[0].options[0].endsWith('  no snapshot here [no code snapshot]')).toBe(true)
+  })
+
+  it('labels an empty prompt as (empty prompt)', async () => {
+    const t = setup()
+    const entry = checkpointEntry({ entryId: 'user0001', ref: 'a'.repeat(40), prompt: '' })
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries: [entry] }))
+    await rewind(t, { entries: [entry], answers: [undefined] })
+
+    expect(t.selects[0].options[0].endsWith('  (empty prompt)')).toBe(true)
+  })
+
+  it('asks under a rewind heading', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await rewind(t, { answers: [undefined] })
+
+    expect(t.selects[0].title).toBe('Rewind to checkpoint:')
+  })
+
+  it('stops without asking for a restore mode when the picker is cancelled', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await rewind(t, { answers: [undefined] })
+
+    expect(t.selects).toHaveLength(1)
+    expect(t.notifications).toEqual([])
+  })
+
+  it('stops without asking for a restore mode when the choice matches no checkpoint', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await rewind(t, { answers: ['7. not a real label'] })
+
+    expect(t.selects).toHaveLength(1)
+    expect(t.notifications).toEqual([])
+  })
+})
+
+describe('/rewind restore modes', () => {
+  it('offers code, conversation and combined restore', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await rewind(t, { branch: [userEntry], answers: [0, undefined] })
+
+    expect(t.selects[1]).toEqual({
+      title: 'Restore mode:',
+      options: ['Code and conversation', 'Conversation only', 'Code only'],
+    })
+  })
+
+  it('leaves everything untouched when the restore mode is cancelled', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+    writeFileSync(join(t.repo, 'tracked.txt'), 'edited after checkpoint\n')
+
+    await rewind(t, { branch: [userEntry], answers: [0, undefined] })
+
+    expect(readFileSync(join(t.repo, 'tracked.txt'), 'utf8')).toBe('edited after checkpoint\n')
+    expect(t.notifications).toEqual([])
+  })
+
+  it('restores the conversation without touching the code in conversation-only mode', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+    writeFileSync(join(t.repo, 'tracked.txt'), 'edited after checkpoint\n')
+
+    await rewind(t, { branch: [userEntry], answers: [0, 'Conversation only'] })
+
+    expect(readFileSync(join(t.repo, 'tracked.txt'), 'utf8')).toBe('edited after checkpoint\n')
+    expect(t.editorTexts).toEqual(['restored prompt'])
+    expect(t.notifications).toEqual(['[info] Rewind complete'])
+  })
+
+  it('navigates to the entry the checkpoint was keyed on', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await rewind(t, { branch: [userEntry], answers: [0, 'Conversation only'] })
+
+    expect(t.navigations).toEqual(['user0001'])
+  })
+
+  it('restores both the code and the conversation in combined mode', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+    writeFileSync(join(t.repo, 'tracked.txt'), 'edited after checkpoint\n')
+
+    await rewind(t, { branch: [userEntry], answers: [0, 'Code and conversation'] })
+
+    expect(readFileSync(join(t.repo, 'tracked.txt'), 'utf8')).toBe('v1\n')
+    expect(t.editorTexts).toEqual(['restored prompt'])
+    expect(t.notifications).toEqual(['[info] Rewind complete'])
+  })
+
+  it('does not complete the rewind when the conversation navigation is cancelled', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await rewind(t, {
+      branch: [userEntry],
+      answers: [0, 'Code and conversation'],
+      navigateTree: async () => ({ cancelled: true }),
+    })
+
+    expect(t.editorTexts).toEqual([])
+    expect(t.notifications).toEqual([])
+  })
+
+  it('leaves the editor alone when the navigation returns no editor text', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await rewind(t, {
+      branch: [userEntry],
+      answers: [0, 'Conversation only'],
+      navigateTree: async () => ({ cancelled: false }),
+    })
+
+    expect(t.editorTexts).toEqual([])
+    expect(t.notifications).toEqual(['[info] Rewind complete'])
+  })
+
+  it('reports the failure message when the conversation navigation throws', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await rewind(t, {
+      branch: [userEntry],
+      answers: [0, 'Conversation only'],
+      navigateTree: async () => {
+        throw new Error('branch is detached')
+      },
+    })
+
+    expect(t.notifications).toEqual(['[error] Conversation restore failed: branch is detached'])
+  })
+
+  it('stringifies a non-Error navigation failure', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await rewind(t, {
+      branch: [userEntry],
+      answers: [0, 'Conversation only'],
+      navigateTree: async () => {
+        throw 'plain string failure'
+      },
+    })
+
+    expect(t.notifications).toEqual(['[error] Conversation restore failed: plain string failure'])
+  })
+
+  it('warns but still completes when the chosen checkpoint has no code snapshot', async () => {
+    const t = setup()
+    const entry = checkpointEntry({ entryId: 'user0001', ref: '', prompt: 'no snapshot here' })
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries: [entry] }))
+    await rewind(t, { entries: [entry], answers: [0, 'Code only'] })
+
+    expect(t.notifications).toEqual(['[warning] Checkpoint has no code snapshot; code left untouched', '[info] Rewind complete'])
+  })
+
+  it('skips the conversation restore when the code restore fails', async () => {
+    const t = setup()
+    const entry = checkpointEntry({ entryId: 'user0001', ref: '0'.repeat(40), prompt: 'unknown ref' })
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries: [entry] }))
+    await rewind(t, { entries: [entry], answers: [0, 'Code and conversation'] })
+
+    expect(t.navigations).toEqual([])
+    expect(t.notifications).toHaveLength(1)
+    expect(t.notifications[0].startsWith('[warning] Code restore failed: ')).toBe(true)
+  })
+})
+
+describe('session_before_fork code restore', () => {
+  const forkEntry = checkpointEntry({ entryId: 'user0001', ref: 'a'.repeat(40), prompt: 'forked prompt' })
+
+  it('offers to restore the code state for the forked entry', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await t.handlers.get('session_before_fork')?.({ entryId: 'user0001' }, t.makeCtx({ answers: [undefined] }))
+
+    expect(t.selects).toEqual([{ title: 'Restore code state?', options: ['Yes, restore code to that point', 'No, keep current code'] }])
+  })
+
+  it('restores the working tree when the fork restore is accepted', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+    writeFileSync(join(t.repo, 'tracked.txt'), 'edited after checkpoint\n')
+
+    await t.handlers.get('session_before_fork')?.({ entryId: 'user0001' }, t.makeCtx({ answers: ['Yes, restore code to that point'] }))
+
+    expect(readFileSync(join(t.repo, 'tracked.txt'), 'utf8')).toBe('v1\n')
+    expect(t.notifications).toEqual(['[info] Code restored to checkpoint'])
+  })
+
+  it('keeps the current code when the fork restore is declined', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+    writeFileSync(join(t.repo, 'tracked.txt'), 'edited after checkpoint\n')
+
+    await t.handlers.get('session_before_fork')?.({ entryId: 'user0001' }, t.makeCtx({ answers: ['No, keep current code'] }))
+
+    expect(readFileSync(join(t.repo, 'tracked.txt'), 'utf8')).toBe('edited after checkpoint\n')
+    expect(t.notifications).toEqual([])
+  })
+
+  it('keeps the current code when the fork prompt is cancelled', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+    writeFileSync(join(t.repo, 'tracked.txt'), 'edited after checkpoint\n')
+
+    await t.handlers.get('session_before_fork')?.({ entryId: 'user0001' }, t.makeCtx({ answers: [undefined] }))
+
+    expect(readFileSync(join(t.repo, 'tracked.txt'), 'utf8')).toBe('edited after checkpoint\n')
+    expect(t.notifications).toEqual([])
+  })
+
+  it('warns when the fork restore fails', async () => {
+    const t = setup()
+    const entry = checkpointEntry({ entryId: 'user0001', ref: '0'.repeat(40), prompt: 'unknown ref' })
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries: [entry] }))
+    await t.handlers.get('session_before_fork')?.({ entryId: 'user0001' }, t.makeCtx({ entries: [entry], answers: ['Yes, restore code to that point'] }))
+
+    expect(t.notifications).toHaveLength(1)
+    expect(t.notifications[0].startsWith('[warning] Restore failed: ')).toBe(true)
+  })
+
+  it('asks nothing when the forked entry has no checkpoint', async () => {
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    await t.handlers.get('session_before_fork')?.({ entryId: 'user9999' }, t.makeCtx({ answers: [0] }))
+
+    expect(t.selects).toEqual([])
+  })
+
+  it('asks nothing when the forked checkpoint carries no code snapshot', async () => {
+    const t = setup()
+    const entry = checkpointEntry({ entryId: 'user0001', ref: '', prompt: 'no snapshot here' })
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries: [entry] }))
+    await t.handlers.get('session_before_fork')?.({ entryId: 'user0001' }, t.makeCtx({ entries: [entry], answers: [0] }))
+
+    expect(t.selects).toEqual([])
+  })
+
+  it('asks nothing without a UI', async () => {
+    const t = setup()
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries: [forkEntry] }))
+    await t.handlers.get('session_before_fork')?.({ entryId: 'user0001' }, t.makeCtx({ entries: [forkEntry], hasUI: false, answers: [0] }))
+
+    expect(t.selects).toEqual([])
+  })
+})

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -3,33 +3,68 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'no
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { beforeAll, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import gitCheckpoint, { sessionSlug } from '../extensions/git-checkpoint.ts'
 
 type Handler = (event: any, ctx: any) => Promise<unknown>
 
-describe('sessionSlug', () => {
-  it('slugs session file names and falls back to an ephemeral id', () => {
-    expect(sessionSlug('/x/y/2026-07-17T10-00-00.jsonl')).toBe('2026-07-17T10-00-00.jsonl')
-    expect(sessionSlug(undefined)).toContain('ephemeral-')
-  })
+/**
+ * The extension resolves its shadow repo under os.homedir(), so homedir is
+ * redirected at a per-test temp dir: without this the suite writes a real bare
+ * repo into the developer's ~/.pi/agent/checkpoints and carries it between runs.
+ */
+const hoisted = vi.hoisted(() => ({ home: '' }))
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: () => hoisted.home }
 })
 
-describe('shadow-repo checkpoint lifecycle', () => {
+const userEntry = {
+  type: 'message',
+  id: 'user0001',
+  parentId: null,
+  message: { role: 'user', content: 'refactor the config loader so it validates the schema up front' },
+}
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+/** Fresh repo, shadow home and extension instance so tests share no state and may run in any order. */
+function setup() {
   const handlers = new Map<string, Handler>()
   const commands = new Map<string, { handler: (args: string, ctx: any) => Promise<void> }>()
   const appended: Array<{ type: string; customType: string; data: any }> = []
   const notifications: string[] = []
-  let repo: string
-  let sessionFile: string
 
-  const userEntry = {
-    type: 'message',
-    id: 'user0001',
-    parentId: null,
-    message: { role: 'user', content: 'refactor the config loader so it validates the schema up front' },
-  }
+  const repo = mkdtempSync(join(tmpdir(), 'gcs-test-'))
+  hoisted.home = mkdtempSync(join(tmpdir(), 'gcs-home-'))
+  tempDirs.push(repo, hoisted.home)
+
+  const sessionFile = join(repo, 'session-test.jsonl')
+  execFileSync('git', ['init', '-qb', 'main'], { cwd: repo })
+  writeFileSync(join(repo, 'tracked.txt'), 'v1\n')
+  writeFileSync(join(repo, 'untracked.txt'), 'precious\n')
+
+  gitCheckpoint({
+    on: (name: string, fn: Handler) => handlers.set(name, fn),
+    registerCommand: (name: string, opts: any) => commands.set(name, opts),
+    appendEntry: (customType: string, data: any) => appended.push({ type: 'custom', customType, data }),
+    exec: async (cmd: string, args: string[], options?: { cwd?: string }) => {
+      try {
+        return { stdout: execFileSync(cmd, args, { cwd: options?.cwd ?? repo, encoding: 'utf8' }), stderr: '', code: 0, killed: false }
+      } catch (err: any) {
+        return { stdout: err.stdout ?? '', stderr: err.stderr ?? String(err), code: err.status ?? 1, killed: false }
+      }
+    },
+  } as any)
+
   const makeCtx = (entries: any[], branch: any[], selectAnswers: string[]) => ({
     cwd: repo,
     hasUI: true,
@@ -42,59 +77,68 @@ describe('shadow-repo checkpoint lifecycle', () => {
     navigateTree: async () => ({ editorText: 'restored prompt', cancelled: false }),
   })
 
-  beforeAll(() => {
-    repo = mkdtempSync(join(tmpdir(), 'gcs-test-'))
-    sessionFile = join(repo, 'session-test.jsonl')
-    execFileSync('git', ['init', '-qb', 'main'], { cwd: repo })
-    writeFileSync(join(repo, 'tracked.txt'), 'v1\n')
-    writeFileSync(join(repo, 'untracked.txt'), 'precious\n')
+  return { handlers, commands, appended, notifications, repo, makeCtx }
+}
 
-    gitCheckpoint({
-      on: (name: string, fn: Handler) => handlers.set(name, fn),
-      registerCommand: (name: string, opts: any) => commands.set(name, opts),
-      appendEntry: (customType: string, data: any) => appended.push({ type: 'custom', customType, data }),
-      exec: async (cmd: string, args: string[], options?: { cwd?: string }) => {
-        try {
-          return { stdout: execFileSync(cmd, args, { cwd: options?.cwd ?? repo, encoding: 'utf8' }), stderr: '', code: 0, killed: false }
-        } catch (err: any) {
-          return { stdout: err.stdout ?? '', stderr: err.stderr ?? String(err), code: err.status ?? 1, killed: false }
-        }
-      },
-    } as any)
+type Harness = ReturnType<typeof setup>
+
+/** Drive one full turn so a checkpoint exists; shadowDir is only initialized by session_start. */
+async function checkpointOneTurn(t: Harness, turnIndex = 0): Promise<void> {
+  await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx([], [], []))
+  await t.handlers.get('turn_start')?.({ turnIndex }, t.makeCtx([], [], []))
+  await t.handlers.get('turn_end')?.({ turnIndex }, t.makeCtx([], [userEntry], []))
+}
+
+const rewindLabel = (data: { createdAt: string; prompt: string }) => `1. ${new Date(data.createdAt).toLocaleTimeString()}  ${data.prompt}`
+
+describe('sessionSlug', () => {
+  it('slugs session file names and falls back to an ephemeral id', () => {
+    expect(sessionSlug('/x/y/2026-07-17T10-00-00.jsonl')).toBe('2026-07-17T10-00-00.jsonl')
+    expect(sessionSlug(undefined)).toContain('ephemeral-')
   })
+})
 
+describe('shadow-repo checkpoint lifecycle', () => {
   it('snapshots the whole tree including untracked files', async () => {
-    await handlers.get('session_start')?.({ reason: 'startup' }, makeCtx([], [], []))
-    await handlers.get('turn_start')?.({ turnIndex: 0 }, makeCtx([], [], []))
-    await handlers.get('turn_end')?.({ turnIndex: 0 }, makeCtx([], [userEntry], []))
-    expect(appended).toHaveLength(1)
-    expect(appended[0].data.ref).toMatch(/^[0-9a-f]{40}$/)
+    const t = setup()
+    await checkpointOneTurn(t)
+
+    expect(t.appended).toHaveLength(1)
+    expect(t.appended[0].data.ref).toMatch(/^[0-9a-f]{40}$/)
   })
 
   it('restore resets edits made after the checkpoint and resurrects deleted untracked files', async () => {
-    writeFileSync(join(repo, 'tracked.txt'), 'overwritten after checkpoint\n')
-    rmSync(join(repo, 'untracked.txt'))
+    const t = setup()
+    await checkpointOneTurn(t)
 
-    const label = `1. ${new Date(appended[0].data.createdAt).toLocaleTimeString()}  ${appended[0].data.prompt}`
-    await commands.get('rewind')?.handler('', makeCtx(appended, [userEntry], [label, 'Code only']))
+    writeFileSync(join(t.repo, 'tracked.txt'), 'overwritten after checkpoint\n')
+    rmSync(join(t.repo, 'untracked.txt'))
 
-    expect(readFileSync(join(repo, 'tracked.txt'), 'utf8')).toBe('v1\n')
-    expect(existsSync(join(repo, 'untracked.txt'))).toBe(true)
-    expect(readFileSync(join(repo, 'untracked.txt'), 'utf8')).toBe('precious\n')
-    expect(notifications.some((n) => n.includes('Rewind complete'))).toBe(true)
+    await t.commands.get('rewind')?.handler('', t.makeCtx(t.appended, [userEntry], [rewindLabel(t.appended[0].data), 'Code only']))
+
+    expect(readFileSync(join(t.repo, 'tracked.txt'), 'utf8')).toBe('v1\n')
+    expect(existsSync(join(t.repo, 'untracked.txt'))).toBe(true)
+    expect(readFileSync(join(t.repo, 'untracked.txt'), 'utf8')).toBe('precious\n')
+    expect(t.notifications.some((n) => n.includes('Rewind complete'))).toBe(true)
   })
 
   it('dedupes checkpoints per prompt and reuses HEAD for unchanged trees', async () => {
-    await handlers.get('turn_start')?.({ turnIndex: 1 }, makeCtx([], [userEntry], []))
-    await handlers.get('turn_end')?.({ turnIndex: 1 }, makeCtx([], [userEntry], []))
-    expect(appended).toHaveLength(1)
+    const t = setup()
+    await checkpointOneTurn(t, 0)
+
+    await t.handlers.get('turn_start')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry], []))
+    await t.handlers.get('turn_end')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry], []))
+
+    expect(t.appended).toHaveLength(1)
   })
 
   it('warns on an unknown ref instead of crashing', async () => {
+    const t = setup()
     const bad = { type: 'custom', customType: 'git-checkpoint', data: { entryId: 'user0002', ref: '0'.repeat(40), prompt: 'x', createdAt: new Date().toISOString() } }
-    await handlers.get('session_start')?.({ reason: 'resume' }, makeCtx([bad], [userEntry], []))
-    const label = `1. ${new Date(bad.data.createdAt).toLocaleTimeString()}  x`
-    await commands.get('rewind')?.handler('', makeCtx([bad], [userEntry], [label, 'Code only']))
-    expect(notifications.some((n) => n.startsWith('[warning] Code restore failed'))).toBe(true)
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx([bad], [userEntry], []))
+    await t.commands.get('rewind')?.handler('', t.makeCtx([bad], [userEntry], [rewindLabel(bad.data), 'Code only']))
+
+    expect(t.notifications.some((n) => n.startsWith('[warning] Code restore failed'))).toBe(true)
   })
 })

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -122,7 +122,7 @@ describe('shadow-repo checkpoint lifecycle', () => {
     expect(t.notifications.some((n) => n.includes('Rewind complete'))).toBe(true)
   })
 
-  it('dedupes checkpoints per prompt and reuses HEAD for unchanged trees', async () => {
+  it('dedupes checkpoints per prompt', async () => {
     const t = setup()
     await checkpointOneTurn(t, 0)
 
@@ -130,6 +130,20 @@ describe('shadow-repo checkpoint lifecycle', () => {
     await t.handlers.get('turn_end')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry], []))
 
     expect(t.appended).toHaveLength(1)
+  })
+
+  it('reuses the existing HEAD ref when the tree has not changed', async () => {
+    const t = setup()
+    await checkpointOneTurn(t, 0)
+
+    // A distinct prompt gets past the per-entry dedupe, so the snapshot runs
+    // again; with an untouched work tree it must resolve to the same commit.
+    const secondPrompt = { ...userEntry, id: 'user0002', message: { role: 'user', content: 'now add a regression test for it' } }
+    await t.handlers.get('turn_start')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry, secondPrompt], []))
+    await t.handlers.get('turn_end')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry, secondPrompt], []))
+
+    expect(t.appended).toHaveLength(2)
+    expect(t.appended[1].data.ref).toBe(t.appended[0].data.ref)
   })
 
   it('warns on an unknown ref instead of crashing', async () => {

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -1,0 +1,551 @@
+import type { EventEmitter as Emitter } from 'node:events'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import hooksExtension, { type HookRunner, interpretHookResult, loadHooks, matchingCommands, runHookCommand, runPreToolUse } from '../extensions/hooks.ts'
+
+/**
+ * Hook commands must never reach a real shell from this suite, so `spawn` is
+ * replaced by a scripted fake child process. `os.homedir()` is redirected at a
+ * temp dir so the extension reads throwaway settings instead of the developer's.
+ */
+interface Behavior {
+  stdout?: string[]
+  stderr?: string[]
+  code?: number | null
+  error?: Error
+  stdinError?: Error
+  hang?: boolean
+}
+
+interface SpawnRecord {
+  file: string
+  args: string[]
+  options: unknown
+  command: string
+  stdin: string
+  killSignals: string[]
+}
+
+const hoisted = vi.hoisted(() => ({
+  home: '',
+  calls: [] as SpawnRecord[],
+  behaviors: new Map<string, Behavior>(),
+  live: [] as Array<{ emit: (name: string, arg?: unknown) => boolean }>,
+}))
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: () => hoisted.home }
+})
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  const { EventEmitter } = await import('node:events')
+  return {
+    ...actual,
+    spawn: (file: string, args: string[], options: unknown) => {
+      const command = args[1] ?? ''
+      const behavior = hoisted.behaviors.get(command) ?? {}
+      const record: SpawnRecord = { file, args, options, command, stdin: '', killSignals: [] }
+      hoisted.calls.push(record)
+
+      const child = new EventEmitter() as Emitter & Record<string, unknown>
+      child.stdout = new EventEmitter()
+      child.stderr = new EventEmitter()
+      const stdin = new EventEmitter() as Emitter & Record<string, unknown>
+      stdin.end = (data: string) => {
+        record.stdin = data
+        if (behavior.stdinError) stdin.emit('error', behavior.stdinError)
+      }
+      child.stdin = stdin
+      child.kill = (signal: string) => {
+        record.killSignals.push(signal)
+        return true
+      }
+      hoisted.live.push(child)
+
+      // Microtask (not a timer) so scripted output still flows under fake timers.
+      queueMicrotask(() => {
+        for (const chunk of behavior.stdout ?? []) (child.stdout as Emitter).emit('data', chunk)
+        for (const chunk of behavior.stderr ?? []) (child.stderr as Emitter).emit('data', chunk)
+        if (behavior.error) return void child.emit('error', behavior.error)
+        if (behavior.hang) return
+        child.emit('close', behavior.code === undefined ? 0 : behavior.code)
+      })
+      return child
+    },
+  }
+})
+
+const script = (command: string, behavior: Behavior): void => {
+  hoisted.behaviors.set(command, behavior)
+}
+
+const commandsRun = (): string[] => hoisted.calls.map((call) => call.command)
+
+const recordFor = (command: string): SpawnRecord => {
+  const record = hoisted.calls.find((call) => call.command === command)
+  if (!record) throw new Error(`no spawn recorded for ${command}`)
+  return record
+}
+
+const tempDirs: string[] = []
+const tempDir = (prefix: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+/** Write a `.claude/<name>` settings file under `root` and return its directory. */
+const writeSettings = (root: string, name: string, hooks: unknown): void => {
+  mkdirSync(join(root, '.claude'), { recursive: true })
+  writeFileSync(join(root, '.claude', name), JSON.stringify({ hooks }))
+}
+
+beforeEach(() => {
+  hoisted.calls.length = 0
+  hoisted.live.length = 0
+  hoisted.behaviors.clear()
+  hoisted.home = tempDir('hooks-home-')
+})
+
+afterEach(() => {
+  // Release any child scripted to hang so its pending promise never leaks into the next test.
+  for (const child of hoisted.live.splice(0)) child.emit('close', 0)
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+type Handler = (event: Record<string, unknown>, ctx?: Record<string, unknown>) => Promise<unknown>
+
+/** Register the extension against a stub API and expose its three lifecycle handlers. */
+const setupExtension = () => {
+  const handlers = new Map<string, Handler>()
+  hooksExtension({ on: (name: string, fn: Handler) => handlers.set(name, fn) } as never)
+  const handler = (name: string): Handler => {
+    const found = handlers.get(name)
+    if (!found) throw new Error(`hooks extension did not register ${name}`)
+    return found
+  }
+  return {
+    registered: [...handlers.keys()],
+    sessionStart: (reason: string, ctx: Record<string, unknown>) => handler('session_start')({ reason }, ctx),
+    toolCall: (toolName: string, input: unknown) => handler('tool_call')({ toolName, input }),
+    toolEnd: (toolName: string, isError = false) => handler('tool_execution_end')({ toolName, isError }),
+  }
+}
+
+describe('runHookCommand process wiring', () => {
+  it('runs the command through /bin/sh by absolute path with all three streams piped', async () => {
+    await runHookCommand('guard.sh', {}, 5000)
+    const record = recordFor('guard.sh')
+    expect(record.file).toBe('/bin/sh')
+    expect(record.args).toEqual(['-c', 'guard.sh'])
+    expect(record.options).toEqual({ stdio: ['pipe', 'pipe', 'pipe'] })
+  })
+
+  it('writes the payload to stdin as JSON', async () => {
+    await runHookCommand('cat', { tool_name: 'bash', tool_input: { command: 'ls' } }, 5000)
+    expect(JSON.parse(recordFor('cat').stdin)).toEqual({ tool_name: 'bash', tool_input: { command: 'ls' } })
+  })
+
+  it('concatenates multiple stdout and stderr chunks in arrival order', async () => {
+    script('chatty', { stdout: ['one', 'two'], stderr: ['err1', 'err2'], code: 0 })
+    expect(await runHookCommand('chatty', {}, 5000)).toEqual({ code: 0, stdout: 'onetwo', stderr: 'err1err2' })
+  })
+
+  it('reports the exit code the process closed with', async () => {
+    script('fail', { stderr: ['boom'], code: 2 })
+    expect(await runHookCommand('fail', {}, 5000)).toEqual({ code: 2, stdout: '', stderr: 'boom' })
+  })
+
+  it('reports a signal-killed close (null exit code) as exit code 0', async () => {
+    script('killed', { code: null })
+    expect(await runHookCommand('killed', {}, 5000)).toEqual({ code: 0, stdout: '', stderr: '' })
+  })
+
+  it('resolves as a clean run when the process fails to spawn', async () => {
+    script('missing', { error: new Error('spawn /bin/sh ENOENT') })
+    expect(await runHookCommand('missing', {}, 5000)).toEqual({ code: 0, stdout: '', stderr: '' })
+  })
+
+  it('keeps output already received when the process then errors', async () => {
+    script('half', { stdout: ['partial'], error: new Error('EIO') })
+    expect(await runHookCommand('half', {}, 5000)).toEqual({ code: 0, stdout: 'partial', stderr: '' })
+  })
+
+  it('swallows an EPIPE from a hook that exits without reading stdin', async () => {
+    script('exit2', { stdinError: Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }), stderr: ['denied'], code: 2 })
+    expect(await runHookCommand('exit2', {}, 5000)).toEqual({ code: 2, stdout: '', stderr: 'denied' })
+  })
+})
+
+describe('runHookCommand timeout', () => {
+  it('does not kill the child before the timeout elapses', async () => {
+    vi.useFakeTimers()
+    script('slow', { hang: true })
+    void runHookCommand('slow', {}, 1000)
+    await vi.advanceTimersByTimeAsync(999)
+    expect(recordFor('slow').killSignals).toEqual([])
+  })
+
+  it('kills the child with SIGKILL once the timeout elapses', async () => {
+    vi.useFakeTimers()
+    script('slow', { hang: true })
+    void runHookCommand('slow', {}, 1000)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(recordFor('slow').killSignals).toEqual(['SIGKILL'])
+  })
+
+  it('cancels the kill timer once the process closes on its own', async () => {
+    vi.useFakeTimers()
+    script('quick', { code: 0 })
+    expect(await runHookCommand('quick', {}, 1000)).toEqual({ code: 0, stdout: '', stderr: '' })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(recordFor('quick').killSignals).toEqual([])
+  })
+})
+
+describe('hook timeout configuration', () => {
+  const runnerRecording = (seen: number[]): HookRunner => {
+    return async (_command, _payload, ms) => {
+      seen.push(ms)
+      return { code: 0, stdout: '', stderr: '' }
+    }
+  }
+
+  it('defaults to 60 seconds when the hook declares no timeout', async () => {
+    const seen: number[] = []
+    await runPreToolUse({ PreToolUse: [{ hooks: [{ command: 'a' }] }] }, 'bash', {}, runnerRecording(seen))
+    expect(seen).toEqual([60_000])
+  })
+
+  it('converts a declared timeout from seconds to milliseconds', async () => {
+    const seen: number[] = []
+    await runPreToolUse({ PreToolUse: [{ hooks: [{ command: 'a', timeout: 5 }] }] }, 'bash', {}, runnerRecording(seen))
+    expect(seen).toEqual([5000])
+  })
+
+  it('honors an explicit timeout of 0 rather than falling back to the default', async () => {
+    const seen: number[] = []
+    await runPreToolUse({ PreToolUse: [{ hooks: [{ command: 'a', timeout: 0 }] }] }, 'bash', {}, runnerRecording(seen))
+    expect(seen).toEqual([0])
+  })
+})
+
+describe('interpretHookResult defaults and precedence', () => {
+  it('falls back to "Blocked by hook" when exit 2 leaves stderr empty', () => {
+    expect(interpretHookResult(2, '', '   \n  ')).toEqual({ block: true, reason: 'Blocked by hook' })
+  })
+
+  it('trims surrounding whitespace off the stderr reason', () => {
+    expect(interpretHookResult(2, '', '  no force push \n')).toEqual({ block: true, reason: 'no force push' })
+  })
+
+  it('blocks on exit 2 even when stdout says the tool is allowed', () => {
+    const allow = JSON.stringify({ hookSpecificOutput: { permissionDecision: 'allow' } })
+    expect(interpretHookResult(2, allow, 'still denied')).toEqual({ block: true, reason: 'still denied' })
+  })
+
+  it('falls back to "Blocked by hook" when a deny decision omits its reason', () => {
+    const out = JSON.stringify({ hookSpecificOutput: { permissionDecision: 'deny' } })
+    expect(interpretHookResult(0, out, '')).toEqual({ block: true, reason: 'Blocked by hook' })
+  })
+
+  it('falls back to "Blocked by hook" when a legacy block decision omits its reason', () => {
+    expect(interpretHookResult(0, JSON.stringify({ decision: 'block' }), '')).toEqual({ block: true, reason: 'Blocked by hook' })
+  })
+
+  it('allows an explicit permissionDecision of allow', () => {
+    const out = JSON.stringify({ hookSpecificOutput: { permissionDecision: 'allow', permissionDecisionReason: 'fine' } })
+    expect(interpretHookResult(0, out, '')).toEqual({ block: false })
+  })
+
+  it('allows a legacy decision of approve', () => {
+    expect(interpretHookResult(0, JSON.stringify({ decision: 'approve', reason: 'fine' }), '')).toEqual({ block: false })
+  })
+
+  it('allows a non-zero exit that is not 2, since only 2 blocks', () => {
+    expect(interpretHookResult(1, '', 'script crashed')).toEqual({ block: false })
+  })
+
+  it('allows when stdout is not valid JSON', () => {
+    expect(interpretHookResult(0, 'not json at all {', '')).toEqual({ block: false })
+  })
+
+  it('allows when stdout is JSON null rather than an object', () => {
+    expect(interpretHookResult(0, 'null', '')).toEqual({ block: false })
+  })
+})
+
+describe('runPreToolUse hook sequencing', () => {
+  it('returns the first blocking verdict and skips the remaining hooks', async () => {
+    const run: string[] = []
+    const runner: HookRunner = async (command) => {
+      run.push(command)
+      return command === 'second' ? { code: 2, stdout: '', stderr: 'denied by second' } : { code: 0, stdout: '', stderr: '' }
+    }
+    const config = { PreToolUse: [{ hooks: [{ command: 'first' }, { command: 'second' }, { command: 'third' }] }] }
+    expect(await runPreToolUse(config, 'bash', {}, runner)).toEqual({ block: true, reason: 'denied by second' })
+    expect(run).toEqual(['first', 'second'])
+  })
+
+  it('allows the tool when every matching hook passes', async () => {
+    const run: string[] = []
+    const runner: HookRunner = async (command) => {
+      run.push(command)
+      return { code: 0, stdout: '', stderr: '' }
+    }
+    const config = { PreToolUse: [{ hooks: [{ command: 'first' }, { command: 'second' }] }] }
+    expect(await runPreToolUse(config, 'bash', {}, runner)).toEqual({ block: false })
+    expect(run).toEqual(['first', 'second'])
+  })
+
+  it('allows the tool when the config declares no PreToolUse hooks at all', async () => {
+    const runner: HookRunner = async () => ({ code: 2, stdout: '', stderr: 'denied' })
+    expect(await runPreToolUse({}, 'bash', {}, runner)).toEqual({ block: false })
+  })
+})
+
+describe('matchingCommands edge shapes', () => {
+  it('returns nothing when the event has no matcher list', () => {
+    expect(matchingCommands(undefined, 'bash')).toEqual([])
+  })
+
+  it('returns nothing for a matching entry that declares no hooks', () => {
+    expect(matchingCommands([{ matcher: 'Bash' } as never], 'bash')).toEqual([])
+  })
+
+  it('falls back to case-insensitive literal equality when the matcher is an invalid regex', () => {
+    const hook = { matcher: 'Bash(', hooks: [{ command: 'lit' }] }
+    expect(matchingCommands([hook], 'bash(')).toEqual([{ command: 'lit' }])
+    expect(matchingCommands([hook], 'bash')).toEqual([])
+  })
+
+  it('anchors the matcher so a partial tool-name match does not fire', () => {
+    const hook = { matcher: 'Bash', hooks: [{ command: 'guard' }] }
+    expect(matchingCommands([hook], 'bashful')).toEqual([])
+    expect(matchingCommands([hook], 'rebash')).toEqual([])
+  })
+
+  it('collects hooks from every applying entry in declaration order', () => {
+    const entries = [
+      { matcher: '*', hooks: [{ command: 'all' }] },
+      { matcher: 'Bash', hooks: [{ command: 'bash-only' }] },
+      { matcher: 'Edit', hooks: [{ command: 'edit-only' }] },
+    ]
+    expect(matchingCommands(entries, 'bash')).toEqual([{ command: 'all' }, { command: 'bash-only' }])
+  })
+})
+
+describe('loadHooks malformed config shapes', () => {
+  it('ignores an event whose matchers are not an array', () => {
+    const dir = tempDir('hooks-cfg-')
+    const file = join(dir, 'settings.json')
+    writeFileSync(file, JSON.stringify({ hooks: { PreToolUse: { matcher: 'Bash' }, PostToolUse: [{ hooks: [{ command: 'ok' }] }] } }))
+    const config = loadHooks([file])
+    expect(config.PreToolUse).toBeUndefined()
+    expect(config.PostToolUse).toEqual([{ hooks: [{ command: 'ok' }] }])
+  })
+
+  it('yields an empty config for a settings file with no hooks key', () => {
+    const dir = tempDir('hooks-cfg-')
+    const file = join(dir, 'settings.json')
+    writeFileSync(file, JSON.stringify({ permissions: { allow: [] } }))
+    expect(loadHooks([file])).toEqual({})
+  })
+
+  it('keeps separate events separate while merging across files', () => {
+    const dir = tempDir('hooks-cfg-')
+    const a = join(dir, 'a.json')
+    const b = join(dir, 'b.json')
+    writeFileSync(a, JSON.stringify({ hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'p1' }] }] } }))
+    writeFileSync(b, JSON.stringify({ hooks: { PostToolUse: [{ matcher: 'Bash', hooks: [{ command: 'q1' }] }] } }))
+    expect(loadHooks([a, b])).toEqual({
+      PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'p1' }] }],
+      PostToolUse: [{ matcher: 'Bash', hooks: [{ command: 'q1' }] }],
+    })
+  })
+})
+
+describe('hooks extension registration', () => {
+  it('subscribes to the three lifecycle events it bridges', () => {
+    expect(setupExtension().registered).toEqual(['session_start', 'tool_call', 'tool_execution_end'])
+  })
+})
+
+describe('hooks extension session_start', () => {
+  const homeConfig = {
+    SessionStart: [{ matcher: 'startup', hooks: [{ command: 'home-session' }] }],
+    PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'home-pre' }] }],
+  }
+
+  it('runs SessionStart hooks matching the session source with the source in the payload', async () => {
+    writeSettings(hoisted.home, 'settings.json', homeConfig)
+    await setupExtension().sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    expect(commandsRun()).toEqual(['home-session'])
+    expect(JSON.parse(recordFor('home-session').stdin)).toEqual({ hook_event_name: 'SessionStart', source: 'startup' })
+  })
+
+  it('does not run SessionStart hooks whose matcher misses the session source', async () => {
+    writeSettings(hoisted.home, 'settings.json', homeConfig)
+    await setupExtension().sessionStart('resume', { cwd: tempDir('hooks-proj-') })
+    expect(commandsRun()).toEqual([])
+  })
+
+  it.each(['reload', 'fork'])('skips SessionStart hooks on a %s but still loads the config', async (reason) => {
+    writeSettings(hoisted.home, 'settings.json', { ...homeConfig, SessionStart: [{ matcher: reason, hooks: [{ command: 'home-session' }] }] })
+    const ext = setupExtension()
+    await ext.sessionStart(reason, { cwd: tempDir('hooks-proj-') })
+    expect(commandsRun()).toEqual([])
+    await ext.toolCall('bash', {})
+    expect(commandsRun()).toEqual(['home-pre'])
+  })
+
+  it('loads project settings after user settings when the project is trusted', async () => {
+    const project = tempDir('hooks-proj-')
+    writeSettings(hoisted.home, 'settings.json', homeConfig)
+    writeSettings(project, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'project-pre' }] }] })
+    writeSettings(project, 'settings.local.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'local-pre' }] }] })
+
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: project, isProjectTrusted: () => true })
+    await ext.toolCall('bash', {})
+    expect(commandsRun()).toEqual(['home-session', 'home-pre', 'project-pre', 'local-pre'])
+  })
+
+  it('ignores project settings when the project is untrusted', async () => {
+    const project = tempDir('hooks-proj-')
+    writeSettings(hoisted.home, 'settings.json', homeConfig)
+    writeSettings(project, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'project-pre' }] }] })
+
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: project, isProjectTrusted: () => false })
+    await ext.toolCall('bash', {})
+    expect(commandsRun()).toEqual(['home-session', 'home-pre'])
+  })
+
+  it('treats a host without isProjectTrusted as untrusted', async () => {
+    const project = tempDir('hooks-proj-')
+    writeSettings(hoisted.home, 'settings.json', homeConfig)
+    writeSettings(project, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'project-pre' }] }] })
+
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: project })
+    await ext.toolCall('bash', {})
+    expect(commandsRun()).toEqual(['home-session', 'home-pre'])
+  })
+
+  it('replaces the previous config rather than accumulating on a second session_start', async () => {
+    writeSettings(hoisted.home, 'settings.json', homeConfig)
+    const ext = setupExtension()
+    const project = tempDir('hooks-proj-')
+    await ext.sessionStart('startup', { cwd: project })
+    await ext.sessionStart('startup', { cwd: project })
+    hoisted.calls.length = 0
+    await ext.toolCall('bash', {})
+    expect(commandsRun()).toEqual(['home-pre'])
+  })
+
+  it('runs every matching SessionStart hook concurrently', async () => {
+    writeSettings(hoisted.home, 'settings.json', {
+      SessionStart: [{ matcher: 'startup', hooks: [{ command: 'sess-a' }, { command: 'sess-b' }] }],
+    })
+    script('sess-a', { hang: true })
+    script('sess-b', { hang: true })
+
+    const pending = setupExtension().sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await Promise.resolve()
+    expect(commandsRun()).toEqual(['sess-a', 'sess-b'])
+    for (const child of hoisted.live) child.emit('close', 0)
+    await expect(pending).resolves.toBeUndefined()
+  })
+})
+
+describe('hooks extension tool_call', () => {
+  const withPreHook = async (behavior: Behavior) => {
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'guard' }] }] })
+    script('guard', behavior)
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('blocks the tool with the hook stderr as the reason when the hook exits 2', async () => {
+    const ext = await withPreHook({ stderr: ['force push is not allowed'], code: 2 })
+    expect(await ext.toolCall('bash', { command: 'git push -f' })).toEqual({ block: true, reason: 'force push is not allowed' })
+  })
+
+  it('blocks the tool with the deny reason from hookSpecificOutput', async () => {
+    const ext = await withPreHook({ stdout: [JSON.stringify({ hookSpecificOutput: { permissionDecision: 'deny', permissionDecisionReason: 'secrets file' } })], code: 0 })
+    expect(await ext.toolCall('bash', { command: 'cat .env' })).toEqual({ block: true, reason: 'secrets file' })
+  })
+
+  it('returns undefined so the tool proceeds when the hook allows it', async () => {
+    const ext = await withPreHook({ code: 0 })
+    expect(await ext.toolCall('bash', { command: 'ls' })).toBeUndefined()
+  })
+
+  it('forwards the tool name and input to the hook payload', async () => {
+    const ext = await withPreHook({ code: 0 })
+    await ext.toolCall('bash', { command: 'ls -la' })
+    expect(JSON.parse(recordFor('guard').stdin)).toEqual({ hook_event_name: 'PreToolUse', tool_name: 'bash', tool_input: { command: 'ls -la' } })
+  })
+
+  it('runs no hook and allows the tool before any session_start has loaded a config', async () => {
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'guard' }] }] })
+    expect(await setupExtension().toolCall('bash', {})).toBeUndefined()
+    expect(commandsRun()).toEqual([])
+  })
+})
+
+describe('hooks extension tool_execution_end', () => {
+  const withPostHooks = async (hooks: Array<{ command: string }>) => {
+    writeSettings(hoisted.home, 'settings.json', { PostToolUse: [{ matcher: 'Bash', hooks }] })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('runs PostToolUse hooks with the tool name in the payload', async () => {
+    const ext = await withPostHooks([{ command: 'post' }])
+    await ext.toolEnd('bash')
+    expect(commandsRun()).toEqual(['post'])
+    expect(JSON.parse(recordFor('post').stdin)).toEqual({ hook_event_name: 'PostToolUse', tool_name: 'bash' })
+  })
+
+  it('skips PostToolUse hooks when the tool execution failed', async () => {
+    const ext = await withPostHooks([{ command: 'post' }])
+    await ext.toolEnd('bash', true)
+    expect(commandsRun()).toEqual([])
+  })
+
+  it('skips PostToolUse hooks whose matcher misses the tool', async () => {
+    const ext = await withPostHooks([{ command: 'post' }])
+    await ext.toolEnd('edit')
+    expect(commandsRun()).toEqual([])
+  })
+
+  it('does not block on a PostToolUse hook that exits 2', async () => {
+    const ext = await withPostHooks([{ command: 'post' }])
+    script('post', { stderr: ['angry'], code: 2 })
+    await expect(ext.toolEnd('bash')).resolves.toBeUndefined()
+  })
+
+  it('starts every matching PostToolUse hook before waiting on any of them', async () => {
+    const ext = await withPostHooks([{ command: 'post-a' }, { command: 'post-b' }])
+    script('post-a', { hang: true })
+    script('post-b', { hang: true })
+
+    const pending = ext.toolEnd('bash')
+    await Promise.resolve()
+    expect(commandsRun()).toEqual(['post-a', 'post-b'])
+    for (const child of hoisted.live) child.emit('close', 0)
+    await expect(pending).resolves.toBeUndefined()
+  })
+})

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -149,6 +149,7 @@ const writeServers = (file: string, servers: Record<string, unknown>): void => {
 const setup = async (opts: { user?: Record<string, unknown>; project?: Record<string, unknown> } = {}): Promise<Harness> => {
   const home = mkdtempSync(join(tmpdir(), 'mcp-home-'))
   const cwd = mkdtempSync(join(tmpdir(), 'mcp-proj-'))
+  tempDirs.push(home, cwd)
   hoisted.home = home
   if (opts.user) writeServers(join(home, '.claude.json'), opts.user)
   if (opts.project) writeServers(join(cwd, '.mcp.json'), opts.project)
@@ -218,6 +219,12 @@ const setEnv = (key: string, value: string): void => {
   savedEnv[key] = process.env[key]
   process.env[key] = value
 }
+const unsetEnv = (key: string): void => {
+  savedEnv[key] = process.env[key]
+  delete process.env[key]
+}
+
+const tempDirs: string[] = []
 
 beforeEach(() => {
   hoisted.transports.length = 0
@@ -228,6 +235,9 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks()
   vi.useRealTimers()
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
   for (const [key, value] of Object.entries(savedEnv)) {
     if (value === undefined) delete process.env[key]
     else process.env[key] = value
@@ -286,6 +296,7 @@ describe('mcp startup config scoping', () => {
   it('loadConfig merges the user home and project files with project winning', () => {
     const home = mkdtempSync(join(tmpdir(), 'mcp-home-'))
     const cwd = mkdtempSync(join(tmpdir(), 'mcp-proj-'))
+    tempDirs.push(home, cwd)
     hoisted.home = home
     writeServers(join(home, '.claude.json'), { shared: { command: 'from-user' }, only: { command: 'user-only' } })
     writeServers(join(cwd, '.mcp.json'), { shared: { command: 'from-project' } })
@@ -401,7 +412,7 @@ describe('mcp transport selection', () => {
   })
 
   it('omits Authorization when bearerTokenEnv names an unset variable', async () => {
-    delete process.env.MCP_TEST_ABSENT
+    unsetEnv('MCP_TEST_ABSENT')
     withTools([{ name: 'go' }])
     await setup({ user: { remote: { url: 'https://example.com/mcp', bearerTokenEnv: 'MCP_TEST_ABSENT' } } })
 

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -1,0 +1,767 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Exercises the extension body of mcp.ts (transport selection, tool registration,
+ * failure reporting, /mcp, lifecycle hooks) with the MCP SDK stubbed out.
+ * No test starts a server, spawns a process, or opens a socket: the transport
+ * classes are replaced by inert recorders and `os.homedir()` points at a temp dir
+ * so the developer's real ~/.claude.json is never read.
+ */
+
+interface TransportRecord {
+  kind: 'stdio' | 'http' | 'sse'
+  options: Record<string, unknown>
+  url?: URL
+}
+
+interface ToolDef {
+  name: string
+  description?: string
+  inputSchema?: unknown
+}
+
+interface ClientRecord {
+  info: { name: string; version: string }
+  transport?: TransportRecord
+}
+
+interface ListPage {
+  tools: ToolDef[]
+  nextCursor?: string
+}
+
+interface CallResult {
+  content?: unknown[]
+  structuredContent?: unknown
+  isError?: boolean
+}
+
+const hoisted = vi.hoisted(() => {
+  const state = {
+    home: '',
+    transports: [] as TransportRecord[],
+    clients: [] as ClientRecord[],
+    control: {} as {
+      connect: (transport: TransportRecord, client: ClientRecord) => Promise<void>
+      listTools: (args: { cursor?: string }, client: ClientRecord) => Promise<ListPage>
+      callTool: (args: { name: string; arguments: unknown }, client: ClientRecord) => Promise<CallResult>
+      close: (client: ClientRecord) => Promise<void>
+    },
+  }
+  return state
+})
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: () => hoisted.home }
+})
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class FakeClient implements ClientRecord {
+    transport?: TransportRecord
+    constructor(public info: { name: string; version: string }) {
+      hoisted.clients.push(this)
+    }
+    async connect(transport: TransportRecord): Promise<void> {
+      this.transport = transport
+      await hoisted.control.connect(transport, this)
+    }
+    listTools(args: { cursor?: string }): Promise<ListPage> {
+      return hoisted.control.listTools(args, this)
+    }
+    callTool(args: { name: string; arguments: unknown }): Promise<CallResult> {
+      return hoisted.control.callTool(args, this)
+    }
+    close(): Promise<void> {
+      return hoisted.control.close(this)
+    }
+  },
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: class implements TransportRecord {
+    kind = 'stdio' as const
+    constructor(public options: Record<string, unknown>) {
+      hoisted.transports.push(this)
+    }
+  },
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class implements TransportRecord {
+    kind = 'http' as const
+    constructor(
+      public url: URL,
+      public options: Record<string, unknown>,
+    ) {
+      hoisted.transports.push(this)
+    }
+  },
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: class implements TransportRecord {
+    kind = 'sse' as const
+    constructor(
+      public url: URL,
+      public options: Record<string, unknown>,
+    ) {
+      hoisted.transports.push(this)
+    }
+  },
+}))
+
+const mcpExtension = (await import('../extensions/mcp.ts')).default
+const { loadConfig } = await import('../extensions/mcp.ts')
+
+interface RegisteredTool {
+  name: string
+  label: string
+  description: string
+  parameters: unknown
+  execute: (id: string, params: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text?: string }>; details: { error?: string } }>
+}
+
+type Notification = { message: string; level: string }
+
+interface Harness {
+  tools: RegisteredTool[]
+  notifications: Notification[]
+  warnings: string[]
+  home: string
+  cwd: string
+  sessionStart: (trusted?: boolean | undefined) => Promise<void>
+  shutdown: () => Promise<void>
+  mcpCommand: () => Promise<void>
+  toolNames: () => string[]
+}
+
+const writeServers = (file: string, servers: Record<string, unknown>): void => {
+  mkdirSync(join(file, '..'), { recursive: true })
+  writeFileSync(file, JSON.stringify({ mcpServers: servers }))
+}
+
+/** Boots a fresh extension instance against temp-dir user/project config. */
+const setup = async (opts: { user?: Record<string, unknown>; project?: Record<string, unknown> } = {}): Promise<Harness> => {
+  const home = mkdtempSync(join(tmpdir(), 'mcp-home-'))
+  const cwd = mkdtempSync(join(tmpdir(), 'mcp-proj-'))
+  hoisted.home = home
+  if (opts.user) writeServers(join(home, '.claude.json'), opts.user)
+  if (opts.project) writeServers(join(cwd, '.mcp.json'), opts.project)
+
+  const tools: RegisteredTool[] = []
+  const notifications: Notification[] = []
+  const warnings: string[] = []
+  const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<void>>()
+  const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>()
+
+  vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+    warnings.push(args.join(' '))
+  })
+
+  const makeCtx = (trusted?: boolean): unknown => ({
+    cwd,
+    ui: { notify: (message: string, level: string) => notifications.push({ message, level }) },
+    isProjectTrusted: trusted === undefined ? undefined : () => trusted,
+  })
+
+  await mcpExtension({
+    on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<void>) => handlers.set(name, fn),
+    registerCommand: (name: string, opts2: { handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, opts2),
+    registerTool: (tool: RegisteredTool) => tools.push(tool),
+  } as never)
+
+  return {
+    tools,
+    notifications,
+    warnings,
+    home,
+    cwd,
+    sessionStart: async (trusted?: boolean) => {
+      await handlers.get('session_start')?.({ reason: 'startup' }, makeCtx(trusted))
+    },
+    shutdown: async () => {
+      await handlers.get('session_shutdown')?.({}, makeCtx(true))
+    },
+    mcpCommand: async () => {
+      await commands.get('mcp')?.handler('', makeCtx(true))
+    },
+    toolNames: () => tools.map((t) => t.name),
+  }
+}
+
+/** The /mcp handler notifies one multi-line blob; split it back into per-server lines. */
+const statusLinesOf = async (harness: Harness): Promise<string[]> => {
+  const before = harness.notifications.length
+  await harness.mcpCommand()
+  const emitted = harness.notifications[before]
+  return emitted.message.split('\n')
+}
+
+const withTools = (tools: ToolDef[]): void => {
+  hoisted.control.listTools = async () => ({ tools })
+}
+
+const defaultControl = (): typeof hoisted.control => ({
+  connect: async () => {},
+  listTools: async () => ({ tools: [] }),
+  callTool: async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+  close: async () => {},
+})
+
+const savedEnv: Record<string, string | undefined> = {}
+const setEnv = (key: string, value: string): void => {
+  savedEnv[key] = process.env[key]
+  process.env[key] = value
+}
+
+beforeEach(() => {
+  hoisted.transports.length = 0
+  hoisted.clients.length = 0
+  hoisted.control = defaultControl()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+    delete savedEnv[key]
+  }
+})
+
+describe('mcp startup config scoping', () => {
+  it('connects user config at startup without waiting for a session', async () => {
+    withTools([{ name: 'query' }])
+    const harness = await setup({ user: { db: { command: 'db-server' } } })
+
+    expect(harness.toolNames()).toEqual(['db_query'])
+    expect(hoisted.transports).toHaveLength(1)
+  })
+
+  it('does not connect project config until the project is trusted', async () => {
+    withTools([{ name: 'query' }])
+    const harness = await setup({ project: { risky: { command: 'arbitrary-command' } } })
+
+    await harness.sessionStart(false)
+
+    expect(hoisted.transports).toEqual([])
+    expect(harness.toolNames()).toEqual([])
+  })
+
+  it('does not connect project config when the host exposes no trust check', async () => {
+    withTools([{ name: 'query' }])
+    const harness = await setup({ project: { risky: { command: 'arbitrary-command' } } })
+
+    await harness.sessionStart(undefined)
+
+    expect(hoisted.transports).toEqual([])
+  })
+
+  it('connects project config once the project is trusted', async () => {
+    withTools([{ name: 'query' }])
+    const harness = await setup({ project: { proj: { command: 'proj-server' } } })
+
+    await harness.sessionStart(true)
+
+    expect(harness.toolNames()).toEqual(['proj_query'])
+  })
+
+  it('connects project config only once across repeated sessions', async () => {
+    withTools([{ name: 'query' }])
+    const harness = await setup({ project: { proj: { command: 'proj-server' } } })
+
+    await harness.sessionStart(true)
+    await harness.sessionStart(true)
+
+    expect(harness.toolNames()).toEqual(['proj_query'])
+    expect(hoisted.transports).toHaveLength(1)
+  })
+
+  it('loadConfig merges the user home and project files with project winning', () => {
+    const home = mkdtempSync(join(tmpdir(), 'mcp-home-'))
+    const cwd = mkdtempSync(join(tmpdir(), 'mcp-proj-'))
+    hoisted.home = home
+    writeServers(join(home, '.claude.json'), { shared: { command: 'from-user' }, only: { command: 'user-only' } })
+    writeServers(join(cwd, '.mcp.json'), { shared: { command: 'from-project' } })
+
+    const merged = loadConfig(cwd)
+
+    expect(Object.keys(merged).sort()).toEqual(['only', 'shared'])
+    expect((merged.shared as { command: string }).command).toBe('from-project')
+  })
+})
+
+describe('mcp transport selection', () => {
+  it('builds a stdio transport from command, args and cwd', async () => {
+    withTools([{ name: 'go' }])
+    await setup({ user: { local: { command: 'node', args: ['server.js'], cwd: '/srv/app' } } })
+
+    const transport = hoisted.transports[0]
+    expect(transport.kind).toBe('stdio')
+    expect(transport.options.command).toBe('node')
+    expect(transport.options.args).toEqual(['server.js'])
+    expect(transport.options.cwd).toBe('/srv/app')
+    expect(transport.options.stderr).toBe('ignore')
+  })
+
+  it('expands a leading ~ in cwd to the home directory', async () => {
+    withTools([{ name: 'go' }])
+    const harness = await setup({ user: { local: { command: 'node', cwd: '~/projects' } } })
+
+    expect(hoisted.transports[0].options.cwd).toBe(`${harness.home}/projects`)
+  })
+
+  it('does not expand a tilde that is not a home-directory prefix', async () => {
+    withTools([{ name: 'go' }])
+    await setup({ user: { local: { command: 'node', cwd: '~backup/data' } } })
+
+    expect(hoisted.transports[0].options.cwd).toBe('~backup/data')
+  })
+
+  it('defaults args to an empty list when omitted', async () => {
+    withTools([{ name: 'go' }])
+    await setup({ user: { local: { command: 'node' } } })
+
+    expect(hoisted.transports[0].options.args).toEqual([])
+  })
+
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: the title documents the ${VAR} syntax interpolateEnv parses
+  it('interpolates ${VAR} into the stdio environment on top of the inherited process env', async () => {
+    setEnv('MCP_TEST_SECRET', 'sekret')
+    withTools([{ name: 'go' }])
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: the literal ${} syntax is exactly what the config interpolation resolves
+    await setup({ user: { local: { command: 'node', env: { API_KEY: 'k-${MCP_TEST_SECRET}', PLAIN: 'literal' } } } })
+
+    const env = hoisted.transports[0].options.env as Record<string, string>
+    expect(env.API_KEY).toBe('k-sekret')
+    expect(env.PLAIN).toBe('literal')
+    expect(env.MCP_TEST_SECRET).toBe('sekret')
+  })
+
+  it('treats a config carrying both command and url as stdio', async () => {
+    withTools([{ name: 'go' }])
+    await setup({ user: { both: { command: 'node', url: 'https://example.com/mcp' } } })
+
+    expect(hoisted.transports[0].kind).toBe('stdio')
+  })
+
+  it('builds a streamable HTTP transport for a url config', async () => {
+    withTools([{ name: 'go' }])
+    await setup({ user: { remote: { url: 'https://example.com/mcp' } } })
+
+    const transport = hoisted.transports[0]
+    expect(transport.kind).toBe('http')
+    expect(transport.url?.href).toBe('https://example.com/mcp')
+    expect((transport.options.requestInit as { headers: Record<string, string> }).headers).toEqual({})
+  })
+
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: the title documents the ${VAR} syntax interpolateEnv parses
+  it('interpolates ${VAR} into the url and the headers', async () => {
+    setEnv('MCP_TEST_HOST', 'api.example.com')
+    setEnv('MCP_TEST_TENANT', 'acme')
+    withTools([{ name: 'go' }])
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: the literal ${} syntax is exactly what the config interpolation resolves
+    await setup({ user: { remote: { url: 'https://${MCP_TEST_HOST}/mcp', headers: { 'X-Tenant': '${MCP_TEST_TENANT}' } } } })
+
+    const transport = hoisted.transports[0]
+    expect(transport.url?.href).toBe('https://api.example.com/mcp')
+    expect((transport.options.requestInit as { headers: Record<string, string> }).headers['X-Tenant']).toBe('acme')
+  })
+
+  it('sends a literal bearerToken as an Authorization header', async () => {
+    withTools([{ name: 'go' }])
+    await setup({ user: { remote: { url: 'https://example.com/mcp', bearerToken: 'tok-123' } } })
+
+    const headers = (hoisted.transports[0].options.requestInit as { headers: Record<string, string> }).headers
+    expect(headers.Authorization).toBe('Bearer tok-123')
+  })
+
+  it('reads the bearer token from the environment variable named by bearerTokenEnv', async () => {
+    setEnv('MCP_TEST_BEARER', 'env-tok')
+    withTools([{ name: 'go' }])
+    await setup({ user: { remote: { url: 'https://example.com/mcp', bearerTokenEnv: 'MCP_TEST_BEARER' } } })
+
+    const headers = (hoisted.transports[0].options.requestInit as { headers: Record<string, string> }).headers
+    expect(headers.Authorization).toBe('Bearer env-tok')
+  })
+
+  it('prefers an explicit bearerToken over bearerTokenEnv', async () => {
+    setEnv('MCP_TEST_BEARER', 'env-tok')
+    withTools([{ name: 'go' }])
+    await setup({ user: { remote: { url: 'https://example.com/mcp', bearerToken: 'literal-tok', bearerTokenEnv: 'MCP_TEST_BEARER' } } })
+
+    const headers = (hoisted.transports[0].options.requestInit as { headers: Record<string, string> }).headers
+    expect(headers.Authorization).toBe('Bearer literal-tok')
+  })
+
+  it('omits Authorization when bearerTokenEnv names an unset variable', async () => {
+    delete process.env.MCP_TEST_ABSENT
+    withTools([{ name: 'go' }])
+    await setup({ user: { remote: { url: 'https://example.com/mcp', bearerTokenEnv: 'MCP_TEST_ABSENT' } } })
+
+    const headers = (hoisted.transports[0].options.requestInit as { headers: Record<string, string> }).headers
+    expect(headers).toEqual({})
+  })
+
+  it('falls back to SSE when the streamable transport fails to connect', async () => {
+    hoisted.control.connect = async (transport) => {
+      if (transport.kind === 'http') throw new Error('404 Not Found')
+    }
+    withTools([{ name: 'go' }])
+    const harness = await setup({ user: { remote: { url: 'https://example.com/mcp', bearerToken: 'tok' } } })
+
+    expect(hoisted.transports.map((t) => t.kind)).toEqual(['http', 'sse'])
+    const sse = hoisted.transports[1]
+    expect(sse.url?.href).toBe('https://example.com/mcp')
+    expect((sse.options.requestInit as { headers: Record<string, string> }).headers.Authorization).toBe('Bearer tok')
+    expect(harness.toolNames()).toEqual(['remote_go'])
+  })
+
+  it('does not retry over SSE when the streamable transport reports Unauthorized', async () => {
+    hoisted.control.connect = async (transport) => {
+      if (transport.kind === 'http') throw new Error('Unauthorized')
+    }
+    const harness = await setup({ user: { remote: { url: 'https://example.com/mcp' } } })
+
+    expect(hoisted.transports.map((t) => t.kind)).toEqual(['http'])
+    expect(await statusLinesOf(harness)).toEqual(['remote: failed: Unauthorized (0 tools)'])
+  })
+
+  it('reports a malformed url as a failure without constructing any transport', async () => {
+    const harness = await setup({ user: { remote: { url: 'not a url' } } })
+
+    expect(hoisted.transports).toEqual([])
+    const [line] = await statusLinesOf(harness)
+    expect(line.startsWith('remote: failed: ')).toBe(true)
+    expect(line.endsWith(' (0 tools)')).toBe(true)
+  })
+})
+
+describe('mcp tool registration', () => {
+  it('namespaces the tool under the server and replaces dashes with underscores', async () => {
+    withTools([{ name: 'search-issues' }])
+    const harness = await setup({ user: { 'sonar-qube': { command: 'sonar' } } })
+
+    expect(harness.toolNames()).toEqual(['sonar_qube_search_issues'])
+  })
+
+  it('labels the tool with the undecorated server and tool names', async () => {
+    withTools([{ name: 'search-issues', description: 'Find issues' }])
+    const harness = await setup({ user: { 'sonar-qube': { command: 'sonar' } } })
+
+    expect(harness.tools[0].label).toBe('sonar-qube: search-issues')
+    expect(harness.tools[0].description).toBe('Find issues')
+  })
+
+  it('synthesizes a description when the server supplies none', async () => {
+    withTools([{ name: 'query' }])
+    const harness = await setup({ user: { db: { command: 'db' } } })
+
+    expect(harness.tools[0].description).toBe('MCP tool query from db')
+  })
+
+  it('exposes the normalized input schema as the tool parameters', async () => {
+    withTools([{ name: 'query', inputSchema: { $schema: 'https://json-schema.org/draft/2020-12/schema', additionalProperties: false, type: 'object', properties: { sql: { type: 'string' } }, required: ['sql'] } }])
+    const harness = await setup({ user: { db: { command: 'db' } } })
+
+    expect(JSON.parse(JSON.stringify(harness.tools[0].parameters))).toEqual({ type: 'object', properties: { sql: { type: 'string' } }, required: ['sql'] })
+  })
+
+  it('substitutes an empty object schema when the server declares no input schema', async () => {
+    withTools([{ name: 'ping' }])
+    const harness = await setup({ user: { db: { command: 'db' } } })
+
+    expect(JSON.parse(JSON.stringify(harness.tools[0].parameters))).toEqual({ type: 'object', properties: {} })
+  })
+
+  it('registers every page of a paginated tool list', async () => {
+    hoisted.control.listTools = async ({ cursor }) => {
+      if (!cursor) return { tools: [{ name: 'one' }], nextCursor: 'page-2' }
+      if (cursor === 'page-2') return { tools: [{ name: 'two' }], nextCursor: 'page-3' }
+      return { tools: [{ name: 'three' }] }
+    }
+    const harness = await setup({ user: { db: { command: 'db' } } })
+
+    expect(harness.toolNames()).toEqual(['db_one', 'db_two', 'db_three'])
+    expect(await statusLinesOf(harness)).toEqual(['db: connected (3 tools)'])
+  })
+
+  it('skips a tool whose namespaced name collides with an already registered one', async () => {
+    hoisted.control.listTools = async (_args, client) => {
+      const command = client.transport?.options.command
+      return command === 'first' ? { tools: [{ name: 'x' }] } : { tools: [{ name: 'qube_x' }, { name: 'other' }] }
+    }
+    const harness = await setup({ user: { 'sonar-qube': { command: 'first' }, sonar: { command: 'second' } } })
+
+    expect(harness.toolNames()).toEqual(['sonar_qube_x', 'sonar_other'])
+    expect(harness.warnings).toEqual(['pi-code-mcp: skipping colliding tool name sonar_qube_x'])
+    expect(await statusLinesOf(harness)).toEqual(['sonar-qube: connected (1 tools)', 'sonar: connected (1 tools)'])
+  })
+
+  it('registers nothing and reports zero tools for a server that exposes none', async () => {
+    withTools([])
+    const harness = await setup({ user: { empty: { command: 'empty' } } })
+
+    expect(harness.toolNames()).toEqual([])
+    expect(await statusLinesOf(harness)).toEqual(['empty: connected (0 tools)'])
+  })
+})
+
+describe('mcp tool execution', () => {
+  const registerOne = async (inputSchema?: unknown): Promise<Harness> => {
+    withTools([{ name: 'search-issues', inputSchema }])
+    return setup({ user: { 'sonar-qube': { command: 'sonar' } } })
+  }
+
+  it('forwards the undecorated tool name and the caller arguments to the server', async () => {
+    const calls: Array<{ name: string; arguments: unknown }> = []
+    hoisted.control.callTool = async (args) => {
+      calls.push(args)
+      return { content: [{ type: 'text', text: 'done' }] }
+    }
+    const harness = await registerOne()
+
+    await harness.tools[0].execute('call-1', { severity: 'BLOCKER' })
+
+    expect(calls).toEqual([{ name: 'search-issues', arguments: { severity: 'BLOCKER' } }])
+  })
+
+  it('returns the mapped content and no error detail on success', async () => {
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'two issues' }] })
+    const harness = await registerOne()
+
+    const result = await harness.tools[0].execute('call-1', {})
+
+    expect(result.content).toEqual([{ type: 'text', text: 'two issues' }])
+    expect(result.details).toEqual({})
+  })
+
+  it('falls back to the structured content when the server returns no blocks', async () => {
+    hoisted.control.callTool = async () => ({ content: [], structuredContent: { total: 2 } })
+    const harness = await registerOne()
+
+    const result = await harness.tools[0].execute('call-1', {})
+
+    expect(result.content).toEqual([{ type: 'text', text: '{\n  "total": 2\n}' }])
+  })
+
+  it('passes an unrecognized content block through as its JSON serialization', async () => {
+    hoisted.control.callTool = async () => ({ content: [{ type: 'audio', data: 'AAA', mimeType: 'audio/wav' }, { type: 'image' }, { type: 'resource' }] })
+    const harness = await registerOne()
+
+    const result = await harness.tools[0].execute('call-1', {})
+
+    expect(result.content).toEqual([
+      { type: 'text', text: '{"type":"audio","data":"AAA","mimeType":"audio/wav"}' },
+      { type: 'text', text: '{"type":"image"}' },
+      { type: 'text', text: '{"type":"resource"}' },
+    ])
+  })
+
+  it('flags a server-reported error and appends the expected input schema', async () => {
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'bad argument' }], isError: true })
+    const harness = await registerOne({ type: 'object', properties: { severity: { type: 'string' } }, additionalProperties: true })
+
+    const result = await harness.tools[0].execute('call-1', {})
+
+    expect(result.details.error).toBe('tool_error')
+    expect(result.content).toEqual([
+      { type: 'text', text: 'bad argument' },
+      { type: 'text', text: 'Tool reported an error. Expected input schema: {"type":"object","properties":{"severity":{"type":"string"}}}' },
+    ])
+  })
+
+  it('propagates a call timeout as a rejection naming the namespaced tool', async () => {
+    hoisted.control.callTool = () => new Promise<CallResult>(() => {})
+    const harness = await registerOne()
+    vi.useFakeTimers()
+
+    const pending = harness.tools[0].execute('call-1', {})
+    const assertion = expect(pending).rejects.toThrow('sonar_qube_search_issues timed out after 120000ms')
+    await vi.advanceTimersByTimeAsync(120_000)
+    await assertion
+  })
+})
+
+describe('mcp failure reporting', () => {
+  it('records the error message of a server that fails to connect', async () => {
+    hoisted.control.connect = async () => {
+      throw new Error('spawn ENOENT')
+    }
+    const harness = await setup({ user: { broken: { command: 'missing-binary' } } })
+
+    expect(await statusLinesOf(harness)).toEqual(['broken: failed: spawn ENOENT (0 tools)'])
+    expect(harness.toolNames()).toEqual([])
+  })
+
+  it('stringifies a non-Error rejection', async () => {
+    hoisted.control.connect = async () => {
+      throw 'plain string failure'
+    }
+    const harness = await setup({ user: { broken: { command: 'x' } } })
+
+    expect(await statusLinesOf(harness)).toEqual(['broken: failed: plain string failure (0 tools)'])
+  })
+
+  it('times out a connect that never settles after the connect budget', async () => {
+    hoisted.control.connect = () => new Promise<void>(() => {})
+    vi.useFakeTimers()
+
+    const booting = setup({ user: { hung: { command: 'sleep' } } })
+    await vi.advanceTimersByTimeAsync(10_000)
+    const harness = await booting
+
+    expect(await statusLinesOf(harness)).toEqual(['hung: failed: connect hung timed out after 10000ms (0 tools)'])
+  })
+
+  it('times out a tool listing that never settles', async () => {
+    hoisted.control.listTools = () => new Promise<ListPage>(() => {})
+    vi.useFakeTimers()
+
+    const booting = setup({ user: { slow: { command: 'x' } } })
+    await vi.advanceTimersByTimeAsync(10_000)
+    const harness = await booting
+
+    expect(await statusLinesOf(harness)).toEqual(['slow: failed: list tools slow timed out after 10000ms (0 tools)'])
+  })
+
+  it('keeps connecting the remaining servers after one fails', async () => {
+    hoisted.control.connect = async (transport) => {
+      if (transport.options.command === 'bad') throw new Error('nope')
+    }
+    withTools([{ name: 'go' }])
+    const harness = await setup({ user: { broken: { command: 'bad' }, healthy: { command: 'good' } } })
+
+    expect(harness.toolNames()).toEqual(['healthy_go'])
+    expect(await statusLinesOf(harness)).toEqual(['broken: failed: nope (0 tools)', 'healthy: connected (1 tools)'])
+  })
+})
+
+describe('mcp /mcp command', () => {
+  it('explains where to configure servers when none are known', async () => {
+    const harness = await setup()
+
+    await harness.mcpCommand()
+
+    expect(harness.notifications).toEqual([{ message: 'No MCP servers configured. Add them to .mcp.json, .pi/mcp.json, ~/.claude.json, or ~/.pi/agent/mcp.json', level: 'info' }])
+  })
+
+  it('lists one line per server with its state and tool count', async () => {
+    hoisted.control.connect = async (transport) => {
+      if (transport.options.command === 'bad') throw new Error('nope')
+    }
+    hoisted.control.listTools = async () => ({ tools: [{ name: 'a' }, { name: 'b' }] })
+    const harness = await setup({ user: { good: { command: 'ok' }, broken: { command: 'bad' } } })
+
+    await harness.mcpCommand()
+
+    expect(harness.notifications).toEqual([{ message: 'good: connected (2 tools)\nbroken: failed: nope (0 tools)', level: 'info' }])
+  })
+})
+
+describe('mcp session_start notification', () => {
+  it('stays silent when no servers are configured', async () => {
+    const harness = await setup()
+
+    await harness.sessionStart(true)
+
+    expect(harness.notifications).toEqual([])
+  })
+
+  it('totals the tools across connected servers at info level', async () => {
+    hoisted.control.listTools = async (_args, client) => (client.transport?.options.command === 'one' ? { tools: [{ name: 'a' }, { name: 'b' }] } : { tools: [{ name: 'c' }] })
+    const harness = await setup({ user: { first: { command: 'one' }, second: { command: 'two' } } })
+
+    await harness.sessionStart(true)
+
+    expect(harness.notifications).toEqual([{ message: 'MCP: 3 tools from 2 servers', level: 'info' }])
+  })
+
+  it('warns and counts the failures when a server did not connect', async () => {
+    hoisted.control.connect = async (transport) => {
+      if (transport.options.command === 'bad') throw new Error('nope')
+    }
+    withTools([{ name: 'a' }])
+    const harness = await setup({ user: { good: { command: 'ok' }, broken: { command: 'bad' } } })
+
+    await harness.sessionStart(true)
+
+    expect(harness.notifications).toEqual([{ message: 'MCP: 1 tools from 1 servers, 1 failed', level: 'warning' }])
+  })
+
+  it('counts servers connected from the trusted project config in the same notification', async () => {
+    withTools([{ name: 'a' }])
+    const harness = await setup({ user: { fromUser: { command: 'u' } }, project: { fromProject: { command: 'p' } } })
+
+    await harness.sessionStart(true)
+
+    expect(harness.notifications).toEqual([{ message: 'MCP: 2 tools from 2 servers', level: 'info' }])
+  })
+})
+
+describe('mcp session_shutdown', () => {
+  it('closes every connected client', async () => {
+    const closed: string[] = []
+    hoisted.control.close = async (client) => {
+      closed.push(String(client.transport?.options.command))
+    }
+    withTools([{ name: 'a' }])
+    const harness = await setup({ user: { first: { command: 'one' }, second: { command: 'two' } } })
+
+    await harness.shutdown()
+
+    expect(closed.sort()).toEqual(['one', 'two'])
+  })
+
+  it('does not close a client that never connected', async () => {
+    const closed: string[] = []
+    hoisted.control.connect = async (transport) => {
+      if (transport.options.command === 'bad') throw new Error('nope')
+    }
+    hoisted.control.close = async (client) => {
+      closed.push(String(client.transport?.options.command))
+    }
+    withTools([{ name: 'a' }])
+    const harness = await setup({ user: { broken: { command: 'bad' }, healthy: { command: 'good' } } })
+
+    await harness.shutdown()
+
+    expect(closed).toEqual(['good'])
+  })
+
+  it('still shuts down when a client close rejects', async () => {
+    const closed: string[] = []
+    hoisted.control.close = async (client) => {
+      if (client.transport?.options.command === 'one') throw new Error('already gone')
+      closed.push('two')
+    }
+    withTools([{ name: 'a' }])
+    const harness = await setup({ user: { first: { command: 'one' }, second: { command: 'two' } } })
+
+    await expect(harness.shutdown()).resolves.toBeUndefined()
+    expect(closed).toEqual(['two'])
+  })
+
+  it('gives up on a hung close after the shutdown budget instead of stalling exit', async () => {
+    const closed: string[] = []
+    hoisted.control.close = async (client) => {
+      if (client.transport?.options.command === 'hang') return new Promise<void>(() => {})
+      closed.push('quick')
+    }
+    withTools([{ name: 'a' }])
+    const harness = await setup({ user: { hung: { command: 'hang' }, quick: { command: 'quick' } } })
+    vi.useFakeTimers()
+
+    const shutting = harness.shutdown()
+    await vi.advanceTimersByTimeAsync(3000)
+
+    await expect(shutting).resolves.toBeUndefined()
+    expect(closed).toEqual(['quick'])
+  })
+})

--- a/tests/memory-actions.test.ts
+++ b/tests/memory-actions.test.ts
@@ -1,0 +1,68 @@
+import { existsSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import memoryExtension, { memoryDir } from '../extensions/memory.ts'
+
+type Handler = (event: unknown, ctx: unknown) => Promise<unknown>
+type Tool = { execute: (id: string, params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }> }
+
+// os.homedir() honors $HOME on POSIX, so point memory's store at a throwaway home.
+describe('memory tool actions', () => {
+  const origHome = process.env.HOME
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME
+    else process.env.HOME = origHome
+  })
+
+  function setup() {
+    process.env.HOME = mkdtempSync(join(tmpdir(), 'mem-home-'))
+    const cwd = mkdtempSync(join(tmpdir(), 'mem-proj-'))
+    const handlers = new Map<string, Handler>()
+    let tool: Tool | undefined
+    memoryExtension({
+      on: (name: string, fn: Handler) => handlers.set(name, fn),
+      registerTool: (t: Tool) => {
+        tool = t
+      },
+    } as never)
+    if (!tool) throw new Error('memory tool not registered')
+    return { handlers, tool, cwd, dir: memoryDir(cwd) }
+  }
+
+  const start = async (handlers: Map<string, Handler>, cwd: string) => handlers.get('session_start')?.({}, { cwd, ui: { notify: () => {} } })
+
+  it('saves, reads, lists, and deletes a memory', async () => {
+    const { handlers, tool, cwd, dir } = setup()
+    await start(handlers, cwd)
+
+    const saved = await tool.execute('1', { action: 'save', name: 'Build Cmd', description: 'how to build', content: 'run npm build' })
+    expect(saved.content[0].text).toContain('Saved memory build-cmd')
+    expect(existsSync(join(dir, 'build-cmd.md'))).toBe(true)
+
+    expect((await tool.execute('2', { action: 'read', name: 'build-cmd' })).content[0].text).toBe('run npm build')
+    expect((await tool.execute('3', { action: 'list' })).content[0].text).toContain('build-cmd')
+
+    expect((await tool.execute('4', { action: 'delete', name: 'build-cmd' })).content[0].text).toContain('Deleted')
+    expect(existsSync(join(dir, 'build-cmd.md'))).toBe(false)
+  })
+
+  it('validates required fields and reports missing reads', async () => {
+    const { handlers, tool, cwd } = setup()
+    await start(handlers, cwd)
+    expect((await tool.execute('1', { action: 'save', name: 'x' })).content[0].text).toContain('requires')
+    expect((await tool.execute('2', { action: 'read', name: 'nope' })).content[0].text).toContain('No memory named nope')
+    expect((await tool.execute('3', { action: 'list' })).content[0].text).toContain('No memories')
+  })
+
+  it('injects the saved memory index into the system prompt', async () => {
+    const { handlers, tool, cwd } = setup()
+    await start(handlers, cwd)
+    await tool.execute('1', { action: 'save', name: 'style', description: 'code style', content: 'tabs' })
+    const result = (await handlers.get('before_agent_start')?.({ systemPrompt: 'BASE' }, {})) as { systemPrompt: string }
+    expect(result.systemPrompt).toContain('## Memory')
+    expect(result.systemPrompt).toContain('style')
+  })
+})

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import notifyExtension from '../extensions/notify.ts'
+
+type Handler = (event: unknown, ctx: unknown) => Promise<void>
+
+function drive(): { agentEnd: () => Promise<void> } {
+  const handlers = new Map<string, Handler>()
+  notifyExtension({ on: (name: string, fn: Handler) => handlers.set(name, fn) } as never)
+  return { agentEnd: () => handlers.get('agent_end')?.({}, {}) ?? Promise.resolve() }
+}
+
+describe('notify', () => {
+  const env = { WT_SESSION: process.env.WT_SESSION, KITTY_WINDOW_ID: process.env.KITTY_WINDOW_ID }
+  afterEach(() => {
+    vi.restoreAllMocks()
+    for (const [k, v] of Object.entries(env)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  it('emits an OSC 777 notification by default on agent_end', async () => {
+    const writes: string[] = []
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(String(chunk))
+      return true
+    })
+    process.env.WT_SESSION = undefined
+    process.env.KITTY_WINDOW_ID = undefined
+    delete process.env.WT_SESSION
+    delete process.env.KITTY_WINDOW_ID
+
+    await drive().agentEnd()
+    const out = writes.join('')
+    expect(out).toContain('Ready for input')
+    expect(out).toContain('\x1b]777')
+  })
+
+  it('emits an OSC 99 notification under kitty', async () => {
+    const writes: string[] = []
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(String(chunk))
+      return true
+    })
+    delete process.env.WT_SESSION
+    process.env.KITTY_WINDOW_ID = '1'
+
+    await drive().agentEnd()
+    expect(writes.join('')).toContain('\x1b]99')
+  })
+
+  it('takes the Windows path without crashing when WT_SESSION is set', async () => {
+    // powershell.exe spawn fails on non-Windows, but the callback swallows the error.
+    process.env.WT_SESSION = 'x'
+    await expect(drive().agentEnd()).resolves.toBeUndefined()
+  })
+})

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -1,0 +1,381 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import planModeExtension from '../extensions/plan-mode/index.ts'
+import type { TodoItem } from '../extensions/plan-mode/utils.ts'
+
+type Handler = (event: never, ctx: never) => Promise<unknown>
+type SentMessage = { customType?: string; content: string; display?: boolean }
+type ToolResult = { content: Array<{ type: string; text: string }>; terminate?: boolean }
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+  strikethrough: (text: string) => text,
+}
+
+const assistant = (text: string) => ({ role: 'assistant', content: [{ type: 'text', text }] })
+
+/** Fresh extension instance: the extension closes over mutable plan state per registration. */
+function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
+  const handlers = new Map<string, Handler>()
+  const commands = new Map<string, (args: string, ctx: unknown) => Promise<void>>()
+  const tools = new Map<string, (id: string, params: Record<string, unknown>) => Promise<ToolResult>>()
+  const shortcuts: Array<(ctx: unknown) => Promise<void>> = []
+  const sent: SentMessage[] = []
+  const userMessages: string[] = []
+  const appended: Array<{ type: string; data: unknown }> = []
+  let activeTools = options.activeTools ?? ['read', 'bash', 'grep', 'find', 'ls', 'question', 'plan_mode_complete', 'edit', 'write']
+
+  const pi = {
+    registerFlag: () => {},
+    getFlag: () => options.flag,
+    getActiveTools: () => activeTools,
+    setActiveTools: (next: string[]) => {
+      activeTools = next
+    },
+    registerCommand: (name: string, spec: { handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, spec.handler),
+    registerTool: (tool: { name: string; execute: (id: string, params: Record<string, unknown>) => Promise<ToolResult> }) => tools.set(tool.name, tool.execute),
+    registerShortcut: (_key: unknown, spec: { handler: (ctx: unknown) => Promise<void> }) => shortcuts.push(spec.handler),
+    on: (name: string, fn: Handler) => handlers.set(name, fn),
+    sendMessage: (message: SentMessage) => sent.push(message),
+    sendUserMessage: (text: string) => userMessages.push(text),
+    appendEntry: (type: string, data: unknown) => appended.push({ type, data }),
+  }
+
+  planModeExtension(pi as never)
+
+  const status: Array<string | undefined> = []
+  const widgets: Array<string[] | undefined> = []
+  const notices: string[] = []
+  const ctx = {
+    hasUI: true,
+    ui: {
+      theme,
+      setStatus: (_key: string, text?: string) => status.push(text),
+      setWidget: (_key: string, lines?: string[]) => widgets.push(lines),
+      notify: (text: string) => notices.push(text),
+      select: async (_q: string, choices: string[]) => choices[0],
+      editor: async () => '',
+    },
+    sessionManager: { getEntries: () => [] as unknown[] },
+  }
+
+  const emit = (name: string, event: unknown = {}, context: unknown = ctx) => handlers.get(name)?.(event as never, context as never)
+
+  return {
+    ctx,
+    emit,
+    status,
+    widgets,
+    notices,
+    sent,
+    userMessages,
+    appended,
+    shortcuts,
+    getActiveTools: () => activeTools,
+    runCommand: (name: string, args = '', context: unknown = ctx) => commands.get(name)?.(args, context),
+    callTool: (name: string, params: Record<string, unknown>) => tools.get(name)?.('call-1', params) as Promise<ToolResult>,
+  }
+}
+
+describe('plan mode toggle', () => {
+  it('restricts active tools to the read-only set when enabled', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    expect(s.getActiveTools()).toEqual(['read', 'bash', 'grep', 'find', 'ls', 'question', 'plan_mode_complete'])
+    expect(s.notices[0]).toContain('Plan mode enabled')
+  })
+
+  it('only enables tools the session already had', async () => {
+    const s = setup({ activeTools: ['read', 'edit'] })
+    await s.runCommand('plan')
+    expect(s.getActiveTools()).toEqual(['read'])
+  })
+
+  it('restores the full tool set when disabled again', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    await s.runCommand('plan')
+    expect(s.getActiveTools()).toContain('edit')
+    expect(s.getActiveTools()).toContain('write')
+    expect(s.notices[1]).toContain('Full access restored')
+  })
+
+  it('shows a plan badge in the status line while enabled and clears it when off', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    expect(s.status.at(-1)).toContain('plan')
+    await s.runCommand('plan')
+    expect(s.status.at(-1)).toBeUndefined()
+  })
+
+  it('toggles from the keyboard shortcut too', async () => {
+    const s = setup()
+    await s.shortcuts[0](s.ctx)
+    expect(s.getActiveTools()).not.toContain('write')
+  })
+})
+
+describe('bash allowlist enforcement', () => {
+  it('blocks a destructive command while in plan mode', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    const result = (await s.emit('tool_call', { toolName: 'bash', input: { command: 'rm -rf build' } })) as { block: boolean; reason: string }
+    expect(result.block).toBe(true)
+    expect(result.reason).toContain('rm -rf build')
+  })
+
+  it('allows an allowlisted read-only command', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    expect(await s.emit('tool_call', { toolName: 'bash', input: { command: 'ls -la' } })).toBeUndefined()
+  })
+
+  it('ignores bash entirely when plan mode is off', async () => {
+    const s = setup()
+    expect(await s.emit('tool_call', { toolName: 'bash', input: { command: 'rm -rf build' } })).toBeUndefined()
+  })
+
+  it('never blocks non-bash tools', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    expect(await s.emit('tool_call', { toolName: 'read', input: { command: 'rm -rf build' } })).toBeUndefined()
+  })
+})
+
+describe('plan_mode_complete tool', () => {
+  it('is a no-op when plan mode is not active', async () => {
+    const s = setup()
+    const result = await s.callTool('plan_mode_complete', { plan: '1. Read the config loader' })
+    expect(result.content[0].text).toContain('tool ignored')
+    expect(result.terminate).toBeUndefined()
+  })
+
+  it('parses the submitted plan into persisted todos and terminates the turn', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    const result = await s.callTool('plan_mode_complete', { plan: '1. Read the config loader\n2. Add the new field' })
+
+    expect(result.terminate).toBe(true)
+    const persisted = s.appended.at(-1)?.data as { todos: TodoItem[] }
+    expect(persisted.todos.map((t) => t.step)).toEqual([1, 2])
+  })
+})
+
+describe('/plan-todos command', () => {
+  it('tells the user to create a plan first when there are no todos', async () => {
+    const s = setup()
+    await s.runCommand('plan-todos')
+    expect(s.notices[0]).toContain('No todos')
+  })
+
+  it('lists each step with a completion mark', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    await s.callTool('plan_mode_complete', { plan: '1. Read the config loader\n2. Add the new field' })
+    await s.runCommand('plan-todos')
+    expect(s.notices.at(-1)).toContain('1. ○ Config loader')
+    expect(s.notices.at(-1)).toContain('2. ○ New field')
+  })
+})
+
+describe('injected context', () => {
+  it('injects the plan-mode brief while in plan mode', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    const result = (await s.emit('before_agent_start')) as { message: SentMessage }
+    expect(result.message.customType).toBe('plan-mode-context')
+    expect(result.message.content).toContain('[PLAN MODE ACTIVE]')
+    expect(result.message.display).toBe(false)
+  })
+
+  it('injects only the remaining steps while executing', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    await s.callTool('plan_mode_complete', { plan: '1. Read the config loader\n2. Add the new field' })
+    await s.emit('agent_end', { messages: [] })
+    await s.emit('turn_end', { message: assistant('done with the first [DONE:1]') })
+
+    const result = (await s.emit('before_agent_start')) as { message: SentMessage }
+    expect(result.message.customType).toBe('plan-execution-context')
+    expect(result.message.content).toContain('2. New field')
+    expect(result.message.content).not.toContain('1. Config loader')
+  })
+
+  it('injects nothing when idle', async () => {
+    const s = setup()
+    expect(await s.emit('before_agent_start')).toBeUndefined()
+  })
+})
+
+describe('stale plan context filtering', () => {
+  const messages = [
+    { role: 'user', customType: 'plan-mode-context', content: 'brief' },
+    { role: 'user', content: 'x [PLAN MODE ACTIVE] y' },
+    { role: 'user', content: [{ type: 'text', text: '[PLAN MODE ACTIVE]' }] },
+    { role: 'user', content: 'a real question' },
+    { role: 'assistant', content: [{ type: 'text', text: 'an answer' }] },
+  ]
+
+  it('strips plan-mode scaffolding once plan mode is off', async () => {
+    const s = setup()
+    const result = (await s.emit('context', { messages })) as { messages: Array<{ content: unknown }> }
+    expect(result.messages).toHaveLength(2)
+    expect(result.messages[0].content).toBe('a real question')
+  })
+
+  it('leaves the context untouched while plan mode is on', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    expect(await s.emit('context', { messages })).toBeUndefined()
+  })
+})
+
+describe('execution progress tracking', () => {
+  let s: ReturnType<typeof setup>
+
+  beforeEach(async () => {
+    s = setup()
+    await s.runCommand('plan')
+    await s.callTool('plan_mode_complete', { plan: '1. Read the config loader\n2. Add the new field' })
+    await s.emit('agent_end', { messages: [] })
+  })
+
+  it('enters execution mode and asks the agent to start on step one', () => {
+    const execute = s.sent.find((m) => m.customType === 'plan-mode-execute')
+    expect(execute?.content).toBe('Execute the plan. Start with: Config loader')
+    expect(s.getActiveTools()).toContain('write')
+  })
+
+  it('counts completed steps in the status line as [DONE:n] markers arrive', async () => {
+    await s.emit('turn_end', { message: assistant('finished [DONE:1]') })
+    expect(s.status.at(-1)).toContain('1/2')
+  })
+
+  it('renders the todo widget with the remaining step unticked', async () => {
+    await s.emit('turn_end', { message: assistant('finished [DONE:1]') })
+    expect(s.widgets.at(-1)).toEqual(['☑ Config loader', '☐ New field'])
+  })
+
+  it('ignores turn_end when the message is not from the assistant', async () => {
+    await s.emit('turn_end', { message: { role: 'user', content: '[DONE:1]' } })
+    expect(s.status.at(-1)).not.toContain('1/2')
+  })
+
+  it('announces completion and clears state once every step is done', async () => {
+    await s.emit('turn_end', { message: assistant('[DONE:1] [DONE:2]') })
+    await s.emit('agent_end', { messages: [] })
+
+    expect(s.sent.at(-1)?.content).toContain('**Plan Complete!**')
+    expect(s.widgets.at(-1)).toBeUndefined()
+    expect(s.appended.at(-1)?.data as { todos: TodoItem[]; executing: boolean }).toMatchObject({ executing: false })
+  })
+
+  it('stays in execution mode while steps remain', async () => {
+    await s.emit('turn_end', { message: assistant('[DONE:1]') })
+    await s.emit('agent_end', { messages: [] })
+    expect(s.sent.some((m) => m.content.includes('Plan Complete'))).toBe(false)
+  })
+})
+
+describe('plan review prompt', () => {
+  it('falls back to extracting a plan from the assistant prose', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    await s.emit('agent_end', { messages: [assistant('Plan:\n1. Read the config loader\n2. Add the new field')] })
+
+    const list = s.sent.find((m) => m.customType === 'plan-todo-list')
+    expect(list?.content).toContain('**Plan Steps (2):**')
+    expect(s.sent.find((m) => m.customType === 'plan-mode-execute')).toBeDefined()
+  })
+
+  it('stays in plan mode when the user picks "Stay in plan mode"', async () => {
+    const s = setup()
+    s.ctx.ui.select = async (_q: string, choices: string[]) => choices[1]
+    await s.runCommand('plan')
+    await s.emit('agent_end', { messages: [assistant('Plan:\n1. Read the config loader')] })
+
+    expect(s.sent.find((m) => m.customType === 'plan-mode-execute')).toBeUndefined()
+    expect(s.getActiveTools()).not.toContain('write')
+  })
+
+  it('sends the refinement back as a user message', async () => {
+    const s = setup()
+    s.ctx.ui.select = async (_q: string, choices: string[]) => choices[2]
+    s.ctx.ui.editor = async () => '  focus on the parser  '
+    await s.runCommand('plan')
+    await s.emit('agent_end', { messages: [assistant('Plan:\n1. Read the config loader')] })
+
+    expect(s.userMessages).toEqual(['focus on the parser'])
+  })
+
+  it('ignores an empty refinement', async () => {
+    const s = setup()
+    s.ctx.ui.select = async (_q: string, choices: string[]) => choices[2]
+    s.ctx.ui.editor = async () => '   '
+    await s.runCommand('plan')
+    await s.emit('agent_end', { messages: [assistant('Plan:\n1. Read the config loader')] })
+
+    expect(s.userMessages).toEqual([])
+  })
+
+  it('executes without step tracking when no plan could be extracted', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    await s.emit('agent_end', { messages: [assistant('I looked around but wrote no numbered plan.')] })
+
+    expect(s.sent.find((m) => m.customType === 'plan-todo-list')).toBeUndefined()
+    expect(s.sent.find((m) => m.customType === 'plan-mode-execute')?.content).toBe('Execute the plan you just created.')
+  })
+
+  it('does not prompt when there is no UI', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    await s.emit('agent_end', { messages: [assistant('Plan:\n1. Read the config loader')] }, { ...s.ctx, hasUI: false })
+    expect(s.sent).toEqual([])
+  })
+})
+
+describe('session restore', () => {
+  const restoreCtx = (s: ReturnType<typeof setup>, entries: unknown[]) => ({ ...s.ctx, sessionManager: { getEntries: () => entries } })
+
+  it('enables plan mode from the --plan flag', async () => {
+    const s = setup({ flag: true })
+    await s.emit('session_start', {}, restoreCtx(s, []))
+    expect(s.getActiveTools()).not.toContain('write')
+    expect(s.status.at(-1)).toContain('plan')
+  })
+
+  it('restores persisted plan mode state', async () => {
+    const s = setup()
+    const entries = [{ type: 'custom', customType: 'plan-mode', data: { enabled: true, todos: [], executing: false } }]
+    await s.emit('session_start', {}, restoreCtx(s, entries))
+    expect(s.getActiveTools()).not.toContain('write')
+  })
+
+  it('rebuilds completion state from [DONE:n] markers after the last execute marker', async () => {
+    const s = setup()
+    const todos: TodoItem[] = [
+      { step: 1, text: 'Config loader', completed: false },
+      { step: 2, text: 'New field', completed: false },
+    ]
+    const entries = [
+      { type: 'message', customType: 'plan-mode-execute', message: assistant('start') },
+      { type: 'message', message: assistant('did the first [DONE:1]') },
+      { type: 'custom', customType: 'plan-mode', data: { enabled: false, todos, executing: true } },
+    ]
+    await s.emit('session_start', {}, restoreCtx(s, entries))
+    expect(s.widgets.at(-1)).toEqual(['☑ Config loader', '☐ New field'])
+  })
+
+  it('ignores [DONE:n] markers from a previous plan run', async () => {
+    const s = setup()
+    const todos: TodoItem[] = [{ step: 1, text: 'Config loader', completed: false }]
+    const entries = [
+      { type: 'message', message: assistant('stale marker [DONE:1]') },
+      { type: 'message', customType: 'plan-mode-execute', message: assistant('start') },
+      { type: 'custom', customType: 'plan-mode', data: { enabled: false, todos, executing: true } },
+    ]
+    await s.emit('session_start', {}, restoreCtx(s, entries))
+    expect(s.widgets.at(-1)).toEqual(['☐ Config loader'])
+  })
+})

--- a/tests/question.test.ts
+++ b/tests/question.test.ts
@@ -1,0 +1,298 @@
+import type { Text } from '@earendil-works/pi-tui'
+import { describe, expect, it } from 'vitest'
+
+import questionExtension from '../extensions/question.ts'
+
+interface Option {
+  label: string
+  description?: string
+}
+interface Details {
+  question: string
+  options: string[]
+  answer: string | null
+  wasCustom?: boolean
+}
+type ToolResult = { content: Array<{ type: string; text?: string }>; details?: Details }
+
+/** The subset of the pi-tui component contract that ui.custom hands back to the host. */
+interface Overlay {
+  render: (width: number) => string[]
+  invalidate: () => void
+  handleInput: (data: string) => void
+}
+type CustomFactory = (tui: unknown, theme: unknown, keybindings: unknown, done: (result: unknown) => void) => Overlay
+
+interface QuestionTool {
+  name: string
+  execute: (id: string, params: { question: string; options: Option[] }, signal: unknown, onUpdate: unknown, ctx: unknown) => Promise<ToolResult>
+  renderCall: (args: Record<string, unknown>, theme: unknown, context?: unknown) => Text
+  renderResult: (result: ToolResult, options: unknown, theme: unknown, context?: unknown) => Text
+}
+
+/** Identity theme so every assertion can be made against plain, un-styled strings. */
+const theme = { fg: (_color: string, s: string) => s, bold: (s: string) => s }
+
+/** Editor only reaches for requestRender and terminal.rows. */
+const fakeTui = () => ({ requestRender: () => {}, terminal: { rows: 24 } })
+
+/** Raw terminal byte sequences, as the host feeds them to handleInput. */
+const RAW = { up: '\x1b[A', down: '\x1b[B', enter: '\r', escape: '\x1b' }
+
+const setup = (): QuestionTool => {
+  let tool: QuestionTool | undefined
+  questionExtension({
+    registerTool: (t: QuestionTool) => {
+      if (t.name === 'question') tool = t
+    },
+  } as never)
+  if (!tool) throw new Error('question tool was not registered')
+  return tool
+}
+
+/** Text is built padding-free here, so a wide render is the flat list of lines it was given. */
+const lines = (text: Text): string[] => text.render(200).map((line) => line.trimEnd())
+
+const OPTIONS: Option[] = [{ label: 'Alpha', description: 'first one' }, { label: 'Beta' }]
+
+/** Resolve ui.custom immediately, without ever building the overlay. */
+const uiCtx = (resolved: unknown) => ({ hasUI: true, ui: { custom: async () => resolved } })
+
+/** Start execute, capture the live overlay, and hand back the still-pending result. */
+const openOverlay = (tool: QuestionTool, options: Option[] = OPTIONS) => {
+  let overlay: Overlay | undefined
+  const ctx = {
+    hasUI: true,
+    ui: {
+      custom: (factory: CustomFactory) =>
+        new Promise((resolve) => {
+          overlay = factory(fakeTui(), theme, {}, resolve)
+        }),
+    },
+  }
+  const result = tool.execute('call-1', { question: 'Pick one', options }, undefined, undefined, ctx)
+  if (!overlay) throw new Error('ui.custom factory was never invoked')
+  return { overlay, result }
+}
+
+describe('question execute', () => {
+  it('refuses to ask when no UI is available', async () => {
+    const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS }, undefined, undefined, { hasUI: false })
+    expect(result.content).toEqual([{ type: 'text', text: 'Error: UI not available (running in non-interactive mode)' }])
+    expect(result.details).toEqual({ question: 'Pick one', options: ['Alpha', 'Beta'], answer: null })
+  })
+
+  it('refuses an empty option list without opening the overlay', async () => {
+    const ctx = {
+      hasUI: true,
+      ui: {
+        custom: () => {
+          throw new Error('ui.custom must not be called for an empty option list')
+        },
+      },
+    }
+    const result = await setup().execute('call-1', { question: 'Pick one', options: [] }, undefined, undefined, ctx)
+    expect(result.content).toEqual([{ type: 'text', text: 'Error: No options provided' }])
+    expect(result.details).toEqual({ question: 'Pick one', options: [], answer: null })
+  })
+
+  it('reports a cancelled overlay with a null answer', async () => {
+    const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS }, undefined, undefined, uiCtx(null))
+    expect(result.content).toEqual([{ type: 'text', text: 'User cancelled the selection' }])
+    expect(result.details).toEqual({ question: 'Pick one', options: ['Alpha', 'Beta'], answer: null })
+  })
+
+  it('reports a picked option with the index the overlay resolved', async () => {
+    const picked = { answer: 'Beta', wasCustom: false, index: 2 }
+    const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS }, undefined, undefined, uiCtx(picked))
+    expect(result.content).toEqual([{ type: 'text', text: 'User selected: 2. Beta' }])
+    expect(result.details).toEqual({ question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'Beta', wasCustom: false })
+  })
+
+  it('reports a typed answer as custom', async () => {
+    const typed = { answer: 'something else', wasCustom: true }
+    const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS }, undefined, undefined, uiCtx(typed))
+    expect(result.content).toEqual([{ type: 'text', text: 'User wrote: something else' }])
+    expect(result.details).toEqual({ question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'something else', wasCustom: true })
+  })
+})
+
+describe('question renderCall', () => {
+  it('numbers the options and appends the free-text entry', () => {
+    const rendered = setup().renderCall({ question: 'Pick one', options: OPTIONS }, theme)
+    expect(lines(rendered)).toEqual(['question Pick one', '  Options: 1. Alpha, 2. Beta, 3. Type something.'])
+  })
+
+  it('omits the option line when the option list is empty', () => {
+    expect(lines(setup().renderCall({ question: 'Pick one', options: [] }, theme))).toEqual(['question Pick one'])
+  })
+
+  it('omits the option line when options is not an array', () => {
+    expect(lines(setup().renderCall({ question: 'Pick one' }, theme))).toEqual(['question Pick one'])
+  })
+})
+
+describe('question renderResult', () => {
+  it('falls back to the raw content text when details are missing', () => {
+    const result = { content: [{ type: 'text', text: 'Error: No options provided' }] }
+    expect(lines(setup().renderResult(result, undefined, theme))).toEqual(['Error: No options provided'])
+  })
+
+  it('renders nothing when details are missing and the content is not text', () => {
+    expect(lines(setup().renderResult({ content: [{ type: 'image' }] }, undefined, theme))).toEqual([])
+  })
+
+  it('renders a null answer as cancelled', () => {
+    const result = { content: [], details: { question: 'Pick one', options: ['Alpha'], answer: null } }
+    expect(lines(setup().renderResult(result, undefined, theme))).toEqual(['Cancelled'])
+  })
+
+  it('marks a custom answer as written', () => {
+    const result = { content: [], details: { question: 'Pick one', options: ['Alpha'], answer: 'my own', wasCustom: true } }
+    expect(lines(setup().renderResult(result, undefined, theme))).toEqual(['✓ (wrote) my own'])
+  })
+
+  it('numbers the first option as 1', () => {
+    const result = { content: [], details: { question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'Alpha', wasCustom: false } }
+    expect(lines(setup().renderResult(result, undefined, theme))).toEqual(['✓ 1. Alpha'])
+  })
+
+  it('numbers a later option by its position in the list', () => {
+    const result = { content: [], details: { question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'Beta', wasCustom: false } }
+    expect(lines(setup().renderResult(result, undefined, theme))).toEqual(['✓ 2. Beta'])
+  })
+
+  it('drops the number when the answer is not one of the options', () => {
+    const result = { content: [], details: { question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'Gamma', wasCustom: false } }
+    expect(lines(setup().renderResult(result, undefined, theme))).toEqual(['✓ Gamma'])
+  })
+})
+
+describe('question overlay', () => {
+  it('renders the question, the numbered options with descriptions, and the navigation hint', () => {
+    const { overlay } = openOverlay(setup())
+    const out = overlay.render(60)
+    expect(out[0]).toBe('─'.repeat(60))
+    expect(out[1]).toBe(' Pick one')
+    expect(out).toContain('> 1. Alpha')
+    expect(out).toContain('     first one')
+    expect(out).toContain('  2. Beta')
+    expect(out).toContain('  3. Type something.')
+    expect(out).toContain(' ↑↓ navigate • Enter to select • Esc to cancel')
+  })
+
+  it('moves the cursor to the next option on down', () => {
+    const { overlay } = openOverlay(setup())
+    overlay.handleInput(RAW.down)
+    const out = overlay.render(60)
+    expect(out).toContain('  1. Alpha')
+    expect(out).toContain('> 2. Beta')
+  })
+
+  it('keeps the cursor on the first option when up is pressed at the top', () => {
+    const { overlay } = openOverlay(setup())
+    overlay.handleInput(RAW.up)
+    expect(overlay.render(60)).toContain('> 1. Alpha')
+  })
+
+  it('keeps the cursor on the free-text option when down is pressed at the bottom', () => {
+    const { overlay } = openOverlay(setup())
+    for (let i = 0; i < 4; i++) overlay.handleInput(RAW.down)
+    expect(overlay.render(60)).toContain('> 3. Type something.')
+  })
+
+  it('discards its cached lines when the host invalidates', () => {
+    const { overlay } = openOverlay(setup())
+    const wide = overlay.render(60)
+    // Cached output is reused verbatim, so the new width only takes effect after invalidate.
+    expect(overlay.render(20)).toEqual(wide)
+
+    overlay.invalidate()
+    expect(overlay.render(20)[0]).toBe('─'.repeat(20))
+  })
+
+  it('resolves the first option as selection number 1 on enter', async () => {
+    const { overlay, result } = openOverlay(setup())
+    overlay.handleInput(RAW.enter)
+    expect(await result).toEqual({
+      content: [{ type: 'text', text: 'User selected: 1. Alpha' }],
+      details: { question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'Alpha', wasCustom: false },
+    })
+  })
+
+  it('resolves the option under the cursor with its 1-based number on enter', async () => {
+    const { overlay, result } = openOverlay(setup())
+    overlay.handleInput(RAW.down)
+    overlay.handleInput(RAW.enter)
+    expect(await result).toEqual({
+      content: [{ type: 'text', text: 'User selected: 2. Beta' }],
+      details: { question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'Beta', wasCustom: false },
+    })
+  })
+
+  it('cancels on escape from the option list', async () => {
+    const { overlay, result } = openOverlay(setup())
+    overlay.handleInput(RAW.escape)
+    expect(await result).toEqual({
+      content: [{ type: 'text', text: 'User cancelled the selection' }],
+      details: { question: 'Pick one', options: ['Alpha', 'Beta'], answer: null },
+    })
+  })
+
+  it('shows the editor and its own hint after entering the free-text option', () => {
+    const { overlay } = openOverlay(setup())
+    for (let i = 0; i < 2; i++) overlay.handleInput(RAW.down)
+    overlay.handleInput(RAW.enter)
+    const out = overlay.render(60)
+    expect(out).toContain('> 3. Type something. ✎')
+    expect(out).toContain(' Your answer:')
+    expect(out).toContain(' Enter to submit • Esc to go back')
+  })
+
+  it('echoes typed characters into the editor', () => {
+    const { overlay } = openOverlay(setup())
+    for (let i = 0; i < 2; i++) overlay.handleInput(RAW.down)
+    overlay.handleInput(RAW.enter)
+    overlay.handleInput('h')
+    overlay.handleInput('i')
+    expect(overlay.render(60).some((line) => line.includes('hi'))).toBe(true)
+  })
+
+  it('resolves a typed answer as custom when the editor submits', async () => {
+    const { overlay, result } = openOverlay(setup())
+    for (let i = 0; i < 2; i++) overlay.handleInput(RAW.down)
+    overlay.handleInput(RAW.enter)
+    overlay.handleInput('h')
+    overlay.handleInput('i')
+    overlay.handleInput(RAW.enter)
+    expect(await result).toEqual({
+      content: [{ type: 'text', text: 'User wrote: hi' }],
+      details: { question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'hi', wasCustom: true },
+    })
+  })
+
+  it('returns to the option list and discards the draft on escape from the editor', () => {
+    const { overlay } = openOverlay(setup())
+    for (let i = 0; i < 2; i++) overlay.handleInput(RAW.down)
+    overlay.handleInput(RAW.enter)
+    overlay.handleInput('x')
+    overlay.handleInput(RAW.escape)
+
+    const out = overlay.render(60)
+    expect(out).toContain('> 3. Type something.')
+    expect(out).toContain(' ↑↓ navigate • Enter to select • Esc to cancel')
+    expect(out.some((line) => line.includes('x'))).toBe(false)
+  })
+
+  it('stays open on a blank submission instead of answering', async () => {
+    const { overlay, result } = openOverlay(setup())
+    for (let i = 0; i < 2; i++) overlay.handleInput(RAW.down)
+    overlay.handleInput(RAW.enter)
+    overlay.handleInput(' ')
+    overlay.handleInput(RAW.enter)
+    expect(overlay.render(60)).toContain(' ↑↓ navigate • Enter to select • Esc to cancel')
+
+    overlay.handleInput(RAW.escape)
+    expect((await result).content).toEqual([{ type: 'text', text: 'User cancelled the selection' }])
+  })
+})

--- a/tests/question.test.ts
+++ b/tests/question.test.ts
@@ -201,14 +201,22 @@ describe('question overlay', () => {
     expect(overlay.render(60)).toContain('> 3. Type something.')
   })
 
-  it('discards its cached lines when the host invalidates', () => {
+  it('re-lays out when the width changes', () => {
     const { overlay } = openOverlay(setup())
-    const wide = overlay.render(60)
-    // Cached output is reused verbatim, so the new width only takes effect after invalidate.
-    expect(overlay.render(20)).toEqual(wide)
-
-    overlay.invalidate()
+    expect(overlay.render(60)[0]).toBe('─'.repeat(60))
+    // A terminal resize only calls requestRender, never invalidate, so the
+    // cache must be keyed on width or the overlay paints at the stale one.
     expect(overlay.render(20)[0]).toBe('─'.repeat(20))
+  })
+
+  it('reuses its cached lines at an unchanged width until the host invalidates', () => {
+    const { overlay } = openOverlay(setup())
+    const first = overlay.render(60)
+    expect(overlay.render(60)).toEqual(first)
+
+    overlay.handleInput(RAW.down)
+    overlay.invalidate()
+    expect(overlay.render(60)).not.toEqual(first)
   })
 
   it('resolves the first option as selection number 1 on enter', async () => {

--- a/tests/status-line.test.ts
+++ b/tests/status-line.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import statusLine from '../extensions/status-line.ts'
+
+const theme = { fg: (_color: string, text: string) => text }
+
+function setup() {
+  const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<void>>()
+  statusLine({ on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<void>) => handlers.set(name, fn) } as never)
+  const status: string[] = []
+  const makeCtx = (branch: unknown[] = []) => ({
+    ui: { theme, setStatus: (_key: string, text: string) => status.push(text) },
+    sessionManager: { getBranch: () => branch },
+  })
+  return { handlers, status, makeCtx }
+}
+
+describe('status-line', () => {
+  it('shows "ready" with no turns or cost at session start', async () => {
+    const { handlers, status, makeCtx } = setup()
+    await handlers.get('session_start')?.({}, makeCtx())
+    expect(status.at(-1)).toContain('ready')
+  })
+
+  it('shows the turn counter during a turn and on turn end', async () => {
+    const { handlers, status, makeCtx } = setup()
+    await handlers.get('turn_start')?.({}, makeCtx())
+    expect(status.at(-1)).toContain('turn 1...')
+    await handlers.get('turn_end')?.({}, makeCtx())
+    expect(status.at(-1)).toContain('turn 1')
+  })
+
+  it('sums session cost from branch usage and formats it to cents', async () => {
+    const { handlers, status, makeCtx } = setup()
+    const branch = [
+      { type: 'message', message: { usage: { cost: { total: 0.5 } } } },
+      { type: 'message', message: { usage: { cost: { total: 0.25 } } } },
+    ]
+    await handlers.get('turn_end')?.({}, makeCtx(branch))
+    expect(status.at(-1)).toContain('$0.75')
+  })
+
+  it('uses four decimals for sub-cent costs', async () => {
+    const { handlers, status, makeCtx } = setup()
+    await handlers.get('turn_end')?.({}, makeCtx([{ type: 'message', message: { usage: { cost: { total: 0.0012 } } } }]))
+    expect(status.at(-1)).toContain('$0.0012')
+  })
+
+  it('keeps the running turn count after agent_end', async () => {
+    const { handlers, status, makeCtx } = setup()
+    await handlers.get('turn_start')?.({}, makeCtx())
+    await handlers.get('agent_end')?.({}, makeCtx())
+    expect(status.at(-1)).toContain('turn 1')
+  })
+})

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -1,0 +1,505 @@
+import type { EventEmitter } from 'node:events'
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { discoverAgents, formatAgentList } from '../extensions/subagent/agents.ts'
+
+/**
+ * Covers extensions/subagent/agents.ts and extensions/subagent/background.ts.
+ *
+ * No test touches the developer's real home directory: `os.homedir()` is mocked
+ * to a temp dir and PI_CODING_AGENT_DIR pins `getAgentDir()` inside that same
+ * temp dir. No test spawns a real process: `node:child_process` is replaced by a
+ * recorder handing back EventEmitter-based fake children.
+ *
+ * background.ts keeps a module-level `runs` Map with no exported reset, so every
+ * test that touches the registry calls `loadBackground()`, which does
+ * `vi.resetModules()` + a dynamic import to get a module instance with an empty
+ * Map. `formatStatus` is preferred over `backgroundStatusText` wherever the
+ * registry is not the thing under test.
+ */
+
+const fakeHome = vi.hoisted(() => ({ path: '' }))
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: () => fakeHome.path }
+})
+
+type FakeChild = EventEmitter & { stdout: EventEmitter }
+
+interface SpawnCall {
+  command: string
+  args: string[]
+  options: unknown
+}
+
+const spawned = vi.hoisted(() => ({ calls: [] as SpawnCall[], children: [] as FakeChild[] }))
+
+vi.mock('node:child_process', async () => {
+  const { EventEmitter: Emitter } = await import('node:events')
+  return {
+    spawn: (command: string, args: string[], options: unknown) => {
+      const child = Object.assign(new Emitter(), { stdout: new Emitter() }) as FakeChild
+      spawned.calls.push({ command, args, options })
+      spawned.children.push(child)
+      return child
+    },
+  }
+})
+
+// ---------------------------------------------------------------------------
+// agents.ts
+// ---------------------------------------------------------------------------
+
+const AGENT_DIR_ENV = 'PI_CODING_AGENT_DIR'
+
+const agentMd = (fields: Record<string, string>, body = 'body text'): string => {
+  const yaml = Object.entries(fields)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join('\n')
+  return `---\n${yaml}\n---\n${body}`
+}
+
+const names = (agents: Array<{ name: string }>): string[] => agents.map((a) => a.name).sort()
+
+describe('discoverAgents', () => {
+  let root: string
+  let home: string
+  let cwd: string
+  let piUserDir: string
+  let claudeUserDir: string
+  let piProjectDir: string
+  let claudeProjectDir: string
+  let previousEnv: string | undefined
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'subagent-cov-'))
+    home = join(root, 'home')
+    const projectRoot = join(root, 'project')
+    cwd = join(projectRoot, 'src', 'nested')
+    piUserDir = join(home, '.pi', 'agent', 'agents')
+    claudeUserDir = join(home, '.claude', 'agents')
+    piProjectDir = join(projectRoot, '.pi', 'agents')
+    claudeProjectDir = join(projectRoot, '.claude', 'agents')
+    mkdirSync(cwd, { recursive: true })
+
+    fakeHome.path = home
+    previousEnv = process.env[AGENT_DIR_ENV]
+    process.env[AGENT_DIR_ENV] = join(home, '.pi', 'agent')
+  })
+
+  afterEach(() => {
+    if (previousEnv === undefined) delete process.env[AGENT_DIR_ENV]
+    else process.env[AGENT_DIR_ENV] = previousEnv
+  })
+
+  const writeAgent = (dir: string, file: string, fields: Record<string, string>, body?: string): string => {
+    mkdirSync(dir, { recursive: true })
+    const filePath = join(dir, file)
+    writeFileSync(filePath, agentMd(fields, body))
+    return filePath
+  }
+
+  it('loads a user agent from ~/.pi/agent/agents with source and file path', () => {
+    const filePath = writeAgent(piUserDir, 'scout.md', { name: 'scout', description: 'finds things' }, 'Scout prompt')
+
+    const { agents } = discoverAgents(cwd, 'user')
+
+    expect(agents).toEqual([
+      {
+        name: 'scout',
+        description: 'finds things',
+        tools: undefined,
+        model: undefined,
+        systemPrompt: 'Scout prompt',
+        source: 'user',
+        filePath,
+      },
+    ])
+  })
+
+  it('loads a user agent from ~/.claude/agents', () => {
+    writeAgent(claudeUserDir, 'legacy.md', { name: 'legacy', description: 'from claude dir' })
+
+    expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['legacy'])
+  })
+
+  it('excludes project agents when scope is user', () => {
+    writeAgent(piUserDir, 'u.md', { name: 'u-agent', description: 'user one' })
+    writeAgent(piProjectDir, 'p.md', { name: 'p-agent', description: 'project one' })
+
+    expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['u-agent'])
+  })
+
+  it('excludes user agents when scope is project', () => {
+    writeAgent(piUserDir, 'u.md', { name: 'u-agent', description: 'user one' })
+    writeAgent(piProjectDir, 'p.md', { name: 'p-agent', description: 'project one' })
+
+    expect(names(discoverAgents(cwd, 'project').agents)).toEqual(['p-agent'])
+  })
+
+  it('merges user and project agents when scope is both', () => {
+    writeAgent(piUserDir, 'u.md', { name: 'u-agent', description: 'user one' })
+    writeAgent(claudeProjectDir, 'p.md', { name: 'p-agent', description: 'project one' })
+
+    expect(names(discoverAgents(cwd, 'both').agents)).toEqual(['p-agent', 'u-agent'])
+  })
+
+  it('lets a project agent win over a user agent of the same name when scope is both', () => {
+    writeAgent(piUserDir, 'dup.md', { name: 'dup', description: 'user copy' }, 'USER')
+    writeAgent(piProjectDir, 'dup.md', { name: 'dup', description: 'project copy' }, 'PROJECT')
+
+    const { agents } = discoverAgents(cwd, 'both')
+
+    expect(agents).toHaveLength(1)
+    expect(agents[0].source).toBe('project')
+    expect(agents[0].systemPrompt).toBe('PROJECT')
+  })
+
+  it('lets ~/.pi/agent/agents win over ~/.claude/agents on a name conflict', () => {
+    writeAgent(claudeUserDir, 'dup.md', { name: 'dup', description: 'claude copy' }, 'CLAUDE')
+    writeAgent(piUserDir, 'dup.md', { name: 'dup', description: 'pi copy' }, 'PI')
+
+    const { agents } = discoverAgents(cwd, 'user')
+
+    expect(agents).toHaveLength(1)
+    expect(agents[0].description).toBe('pi copy')
+    expect(agents[0].systemPrompt).toBe('PI')
+  })
+
+  it('returns no agents and a null projectAgentsDir when no agent directory exists', () => {
+    expect(discoverAgents(cwd, 'both')).toEqual({ agents: [], projectAgentsDir: null })
+  })
+
+  it('reports the nearest ancestor .pi/agents as projectAgentsDir', () => {
+    mkdirSync(piProjectDir, { recursive: true })
+
+    expect(discoverAgents(cwd, 'both').projectAgentsDir).toBe(piProjectDir)
+  })
+
+  it('reports projectAgentsDir as null when only .claude/agents exists in the project', () => {
+    writeAgent(claudeProjectDir, 'p.md', { name: 'p-agent', description: 'project one' })
+
+    const { agents, projectAgentsDir } = discoverAgents(cwd, 'project')
+
+    expect(names(agents)).toEqual(['p-agent'])
+    expect(projectAgentsDir).toBeNull()
+  })
+
+  it('skips a markdown file whose frontmatter has no name', () => {
+    writeAgent(piUserDir, 'ok.md', { name: 'ok', description: 'valid' })
+    writeAgent(piUserDir, 'nameless.md', { description: 'no name here' })
+
+    expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['ok'])
+  })
+
+  it('skips a markdown file whose frontmatter has no description', () => {
+    writeAgent(piUserDir, 'ok.md', { name: 'ok', description: 'valid' })
+    writeAgent(piUserDir, 'undescribed.md', { name: 'undescribed' })
+
+    expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['ok'])
+  })
+
+  it('skips a markdown file with no frontmatter block', () => {
+    writeAgent(piUserDir, 'ok.md', { name: 'ok', description: 'valid' })
+    writeFileSync(join(piUserDir, 'plain.md'), 'just a heading\n\nand prose')
+
+    expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['ok'])
+  })
+
+  it('ignores files that are not markdown even when they contain valid frontmatter', () => {
+    writeAgent(piUserDir, 'ok.md', { name: 'ok', description: 'valid' })
+    writeFileSync(join(piUserDir, 'decoy.txt'), agentMd({ name: 'decoy', description: 'wrong extension' }))
+
+    expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['ok'])
+  })
+
+  it('ignores a directory whose name ends in .md', () => {
+    writeAgent(piUserDir, 'ok.md', { name: 'ok', description: 'valid' })
+    mkdirSync(join(piUserDir, 'bundle.md'))
+
+    expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['ok'])
+  })
+
+  it('skips a markdown entry whose contents cannot be read', () => {
+    writeAgent(piUserDir, 'ok.md', { name: 'ok', description: 'valid' })
+    symlinkSync(join(piUserDir, 'missing-target.md'), join(piUserDir, 'broken.md'))
+
+    expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['ok'])
+  })
+
+  it('skips an agent path that exists but is not a readable directory', () => {
+    writeAgent(piUserDir, 'ok.md', { name: 'ok', description: 'valid' })
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    writeFileSync(claudeUserDir, 'not a directory')
+
+    expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['ok'])
+  })
+
+  it('maps Claude tool names to pi tool names and lowercases unmapped ones', () => {
+    writeAgent(piUserDir, 'tooled.md', { name: 'tooled', description: 'has tools', tools: 'Read, Glob, Bash, WebFetch' })
+
+    expect(discoverAgents(cwd, 'user').agents[0].tools).toEqual(['read', 'find', 'bash', 'webfetch'])
+  })
+
+  it('leaves tools undefined when the tools field lists nothing usable', () => {
+    writeAgent(piUserDir, 'empty-tools.md', { name: 'empty-tools', description: 'no tools', tools: '",,"' })
+
+    expect(discoverAgents(cwd, 'user').agents[0].tools).toBeUndefined()
+  })
+
+  it('carries the model field through from frontmatter', () => {
+    writeAgent(piUserDir, 'modelled.md', { name: 'modelled', description: 'pinned model', model: 'opus' })
+
+    expect(discoverAgents(cwd, 'user').agents[0].model).toBe('opus')
+  })
+})
+
+describe('formatAgentList', () => {
+  const agent = (name: string, source: 'user' | 'project', description: string) => ({
+    name,
+    description,
+    systemPrompt: '',
+    source,
+    filePath: `/tmp/${name}.md`,
+  })
+
+  it('reports none with no remainder for an empty list', () => {
+    expect(formatAgentList([], 5)).toEqual({ text: 'none', remaining: 0 })
+  })
+
+  it('renders every agent as "name (source): description" joined by semicolons', () => {
+    const result = formatAgentList([agent('alpha', 'user', 'does alpha'), agent('beta', 'project', 'does beta')], 5)
+
+    expect(result).toEqual({ text: 'alpha (user): does alpha; beta (project): does beta', remaining: 0 })
+  })
+
+  it('truncates at maxItems and reports the remaining count', () => {
+    const list = [agent('a', 'user', 'first'), agent('b', 'user', 'second'), agent('c', 'user', 'third')]
+
+    expect(formatAgentList(list, 2)).toEqual({ text: 'a (user): first; b (user): second', remaining: 1 })
+  })
+
+  it('lists nothing and counts every agent as remaining when maxItems is zero', () => {
+    expect(formatAgentList([agent('a', 'user', 'first')], 0)).toEqual({ text: '', remaining: 1 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// background.ts
+// ---------------------------------------------------------------------------
+
+const messageEnd = (role: string, ...texts: string[]): string => JSON.stringify({ type: 'message_end', message: { role, content: texts.map((text) => ({ type: 'text', text })) } })
+
+const loadBackground = async (): Promise<typeof import('../extensions/subagent/background.ts')> => {
+  vi.resetModules()
+  spawned.calls.length = 0
+  spawned.children.length = 0
+  return await import('../extensions/subagent/background.ts')
+}
+
+describe('parseFinalOutputFromJsonl', () => {
+  it('keeps the last text part when one assistant message has several', async () => {
+    const { parseFinalOutputFromJsonl } = await loadBackground()
+
+    expect(parseFinalOutputFromJsonl(messageEnd('assistant', 'draft', 'polished'))).toEqual({ text: 'polished', turns: 1 })
+  })
+
+  it('counts an assistant turn even when the message carries no content', async () => {
+    const { parseFinalOutputFromJsonl } = await loadBackground()
+    const jsonl = [JSON.stringify({ type: 'message_end', message: { role: 'assistant' } }), messageEnd('assistant', 'answer')].join('\n')
+
+    expect(parseFinalOutputFromJsonl(jsonl)).toEqual({ text: 'answer', turns: 2 })
+  })
+
+  it('ignores events that are not message_end', async () => {
+    const { parseFinalOutputFromJsonl } = await loadBackground()
+    const jsonl = [JSON.stringify({ type: 'message_start', message: { role: 'assistant', content: [{ type: 'text', text: 'ignored' }] } }), messageEnd('assistant', 'kept')].join('\n')
+
+    expect(parseFinalOutputFromJsonl(jsonl)).toEqual({ text: 'kept', turns: 1 })
+  })
+
+  it('skips blank and unparseable lines instead of failing', async () => {
+    const { parseFinalOutputFromJsonl } = await loadBackground()
+    const jsonl = ['', '   ', '{not json', messageEnd('assistant', 'survived'), ''].join('\n')
+
+    expect(parseFinalOutputFromJsonl(jsonl)).toEqual({ text: 'survived', turns: 1 })
+  })
+
+  it('ignores non-text content parts', async () => {
+    const { parseFinalOutputFromJsonl } = await loadBackground()
+    const jsonl = JSON.stringify({
+      type: 'message_end',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'spoken' }, { type: 'tool_use' }] },
+    })
+
+    expect(parseFinalOutputFromJsonl(jsonl)).toEqual({ text: 'spoken', turns: 1 })
+  })
+})
+
+describe('formatStatus', () => {
+  it('renders a finished run with exit code and turn count', async () => {
+    const { formatStatus } = await loadBackground()
+    const run = { id: 'bg-abcd1234', agent: 'scout', task: 'survey the repo', state: 'done' as const, exitCode: 0, turns: 4 }
+
+    expect(formatStatus([run])).toBe('bg-abcd1234 scout: done (exit 0, 4 turns) - survey the repo')
+  })
+
+  it('renders a missing exit code as a question mark', async () => {
+    const { formatStatus } = await loadBackground()
+    const run = { id: 'bg-abcd1234', agent: 'scout', task: 'survey', state: 'failed' as const, turns: 2 }
+
+    expect(formatStatus([run])).toBe('bg-abcd1234 scout: failed (exit ?, 2 turns) - survey')
+  })
+
+  it('omits exit code and turns for a running run', async () => {
+    const { formatStatus } = await loadBackground()
+    const run = { id: 'bg-abcd1234', agent: 'scout', task: 'survey', state: 'running' as const, exitCode: 0, turns: 7 }
+
+    expect(formatStatus([run])).toBe('bg-abcd1234 scout: running - survey')
+  })
+
+  it('truncates the task at 60 characters', async () => {
+    const { formatStatus } = await loadBackground()
+    const task = 'x'.repeat(65)
+    const run = { id: 'bg-abcd1234', agent: 'scout', task, state: 'running' as const, turns: 0 }
+
+    expect(formatStatus([run])).toBe(`bg-abcd1234 scout: running - ${'x'.repeat(60)}`)
+  })
+
+  it('separates multiple runs with newlines', async () => {
+    const { formatStatus } = await loadBackground()
+    const runs = [
+      { id: 'bg-1', agent: 'a', task: 'one', state: 'running' as const, turns: 0 },
+      { id: 'bg-2', agent: 'b', task: 'two', state: 'failed' as const, exitCode: 2, turns: 1 },
+    ]
+
+    expect(formatStatus(runs)).toBe('bg-1 a: running - one\nbg-2 b: failed (exit 2, 1 turns) - two')
+  })
+
+  it('reports the empty registry with a sentence', async () => {
+    const { formatStatus } = await loadBackground()
+
+    expect(formatStatus([])).toBe('No background runs in this session.')
+  })
+})
+
+describe('startBackgroundRun', () => {
+  const invocation = { command: 'pi', args: ['--mode', 'json'], cwd: '/work/dir' }
+
+  it('returns a bg- prefixed id built from a uuid prefix', async () => {
+    const { startBackgroundRun } = await loadBackground()
+
+    const id = startBackgroundRun('scout', 'survey', invocation, () => {})
+
+    expect(id).toMatch(/^bg-[0-9a-f]{8}$/)
+  })
+
+  it('gives concurrent runs distinct ids', async () => {
+    const { startBackgroundRun } = await loadBackground()
+
+    const first = startBackgroundRun('scout', 'one', invocation, () => {})
+    const second = startBackgroundRun('scout', 'two', invocation, () => {})
+
+    expect(first).not.toBe(second)
+  })
+
+  it('spawns the invocation without a shell and with stdout piped', async () => {
+    const { startBackgroundRun } = await loadBackground()
+
+    startBackgroundRun('scout', 'survey', invocation, () => {})
+
+    expect(spawned.calls).toEqual([
+      {
+        command: 'pi',
+        args: ['--mode', 'json'],
+        options: { cwd: '/work/dir', shell: false, stdio: ['ignore', 'pipe', 'ignore'] },
+      },
+    ])
+  })
+
+  it('registers the run as running before the child exits', async () => {
+    const { startBackgroundRun, backgroundStatusText } = await loadBackground()
+
+    const id = startBackgroundRun('scout', 'survey the repo', invocation, () => {})
+
+    expect(backgroundStatusText()).toBe(`${id} scout: running - survey the repo`)
+  })
+
+  it('marks the run done and reports parsed output when the child exits zero', async () => {
+    const { startBackgroundRun } = await loadBackground()
+    const completed: Array<Record<string, unknown>> = []
+
+    const id = startBackgroundRun('scout', 'survey', invocation, (run) => completed.push({ ...run }))
+    const child = spawned.children[0]
+    child.stdout.emit('data', Buffer.from(`${messageEnd('assistant', 'all done')}\n`))
+    child.emit('close', 0)
+
+    expect(completed).toEqual([{ id, agent: 'scout', task: 'survey', state: 'done', exitCode: 0, output: 'all done', turns: 1 }])
+  })
+
+  it('concatenates stdout chunks before parsing', async () => {
+    const { startBackgroundRun } = await loadBackground()
+    const completed: Array<Record<string, unknown>> = []
+    const line = messageEnd('assistant', 'split across chunks')
+
+    startBackgroundRun('scout', 'survey', invocation, (run) => completed.push({ ...run }))
+    const child = spawned.children[0]
+    child.stdout.emit('data', Buffer.from(line.slice(0, 20)))
+    child.stdout.emit('data', Buffer.from(line.slice(20)))
+    child.emit('close', 0)
+
+    expect(completed[0].output).toBe('split across chunks')
+    expect(completed[0].turns).toBe(1)
+  })
+
+  it('marks the run failed and keeps the exit code when the child exits non-zero', async () => {
+    const { startBackgroundRun } = await loadBackground()
+    const completed: Array<Record<string, unknown>> = []
+
+    startBackgroundRun('scout', 'survey', invocation, (run) => completed.push({ ...run }))
+    const child = spawned.children[0]
+    child.emit('close', 3)
+
+    expect(completed[0].state).toBe('failed')
+    expect(completed[0].exitCode).toBe(3)
+  })
+
+  it('treats a null exit code as a failure recorded as exit 0', async () => {
+    const { startBackgroundRun } = await loadBackground()
+    const completed: Array<Record<string, unknown>> = []
+
+    startBackgroundRun('scout', 'survey', invocation, (run) => completed.push({ ...run }))
+    const child = spawned.children[0]
+    child.emit('close', null)
+
+    expect(completed[0].state).toBe('failed')
+    expect(completed[0].exitCode).toBe(0)
+  })
+
+  it('marks the run failed with exit 1 and no output when the child errors', async () => {
+    const { startBackgroundRun } = await loadBackground()
+    const completed: Array<Record<string, unknown>> = []
+
+    const id = startBackgroundRun('scout', 'survey', invocation, (run) => completed.push({ ...run }))
+    const child = spawned.children[0]
+    child.emit('error', new Error('ENOENT'))
+
+    expect(completed).toEqual([{ id, agent: 'scout', task: 'survey', state: 'failed', exitCode: 1, turns: 0 }])
+  })
+
+  it('reflects the finished state in the session status text', async () => {
+    const { startBackgroundRun, backgroundStatusText } = await loadBackground()
+
+    const id = startBackgroundRun('scout', 'survey', invocation, () => {})
+    const child = spawned.children[0]
+    child.stdout.emit('data', Buffer.from(`${messageEnd('assistant', 'ok')}\n`))
+    child.emit('close', 0)
+
+    expect(backgroundStatusText()).toBe(`${id} scout: done (exit 0, 1 turns) - survey`)
+  })
+})

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -1,0 +1,873 @@
+import { EventEmitter } from 'node:events'
+import * as fs from 'node:fs'
+import type { AgentToolResult } from '@earendil-works/pi-agent-core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import subagentExtension from '../extensions/subagent/index.ts'
+
+const spawnMock = vi.hoisted(() => vi.fn())
+const discoverAgentsMock = vi.hoisted(() => vi.fn())
+const startBackgroundRunMock = vi.hoisted(() => vi.fn((_agent: string, _task: string, _invocation: { command: string; args: string[]; cwd: string }, _onComplete: (run: unknown) => void): string => 'bg-deadbeef'))
+const backgroundStatusTextMock = vi.hoisted(() => vi.fn(() => 'No background runs in this session.'))
+
+vi.mock('node:child_process', async (importOriginal) => ({ ...(await importOriginal<object>()), spawn: spawnMock }))
+vi.mock('../extensions/subagent/agents.js', () => ({ discoverAgents: discoverAgentsMock }))
+vi.mock('../extensions/subagent/background.js', () => ({
+  backgroundStatusText: backgroundStatusTextMock,
+  startBackgroundRun: startBackgroundRunMock,
+}))
+
+// ---------------------------------------------------------------------------
+// Fake child process. No test in this file may start a real process: `spawn` is
+// mocked module-wide and every child is this in-memory EventEmitter.
+// ---------------------------------------------------------------------------
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  kill = vi.fn()
+}
+
+/** What the fake child does once the implementation has attached its listeners. */
+interface Script {
+  /** Raw stdout chunks, emitted in order. Chunk boundaries need not align with lines. */
+  stdout?: string[]
+  stderr?: string[]
+  /** Exit code handed to the 'close' event. */
+  exitCode?: number | null
+  /** Emit 'error' instead of 'close'. */
+  fail?: boolean
+  /** Milliseconds to wait before driving the child, for ordering across parallel spawns. */
+  delay?: number
+}
+
+interface SpawnCall {
+  command: string
+  args: string[]
+  options: { cwd?: string; shell?: boolean }
+  /** Content of the --append-system-prompt file as it existed at spawn time, if any. */
+  promptFile: { path: string; content: string } | null
+}
+
+let spawnCalls: SpawnCall[] = []
+let spawnedChildren: FakeChild[] = []
+let scripts: Map<string, Script>
+
+/** Registers what the child spawned for `task` should do. */
+const script = (task: string, s: Script) => scripts.set(`Task: ${task}`, s)
+
+const drive = (child: FakeChild, s: Script) => {
+  for (const chunk of s.stdout ?? []) child.stdout.emit('data', Buffer.from(chunk))
+  for (const chunk of s.stderr ?? []) child.stderr.emit('data', Buffer.from(chunk))
+  if (s.fail) child.emit('error', new Error('spawn ENOENT'))
+  else child.emit('close', s.exitCode === undefined ? 0 : s.exitCode)
+}
+
+/** The pi arguments the implementation builds, isolated from the runtime-dependent prefix. */
+const piArgs = (call: SpawnCall): string[] => call.args.slice(call.args.indexOf('--mode'))
+
+// ---------------------------------------------------------------------------
+// JSONL event builders: the wire format runSingleAgent parses off stdout.
+// ---------------------------------------------------------------------------
+
+interface UsageWire {
+  input?: number
+  output?: number
+  cacheRead?: number
+  cacheWrite?: number
+  cost?: { total: number }
+  totalTokens?: number
+}
+
+const assistantMessage = (over: { text?: string; usage?: UsageWire; model?: string; stopReason?: string; errorMessage?: string } = {}) => ({
+  role: 'assistant',
+  content: over.text === undefined ? [] : [{ type: 'text', text: over.text }],
+  usage: over.usage,
+  model: over.model,
+  stopReason: over.stopReason,
+  errorMessage: over.errorMessage,
+})
+
+const line = (event: unknown) => `${JSON.stringify(event)}\n`
+const messageEnd = (message: unknown) => line({ type: 'message_end', message })
+const say = (text: string) => messageEnd(assistantMessage({ text }))
+
+// ---------------------------------------------------------------------------
+// Tool + context harness
+// ---------------------------------------------------------------------------
+
+type ToolResult = AgentToolResult<{ mode: string; agentScope: string; projectAgentsDir: string | null; results: ResultShape[] }> & { isError?: boolean }
+
+interface ResultShape {
+  agent: string
+  agentSource: string
+  task: string
+  exitCode: number
+  messages: unknown[]
+  stderr: string
+  usage: { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number; contextTokens: number; turns: number }
+  model?: string
+  stopReason?: string
+  errorMessage?: string
+  step?: number
+}
+
+type Execute = (id: string, params: Record<string, unknown>, signal?: AbortSignal, onUpdate?: (partial: ToolResult) => void, ctx?: unknown) => Promise<ToolResult>
+
+const sendMessageMock = vi.fn()
+
+const getExecute = (): Execute => {
+  let execute: Execute | undefined
+  subagentExtension({
+    registerTool: (t: { name: string; execute: Execute }) => {
+      if (t.name === 'subagent') execute = t.execute
+    },
+    sendMessage: sendMessageMock,
+  } as never)
+  if (!execute) throw new Error('subagent tool was not registered')
+  return execute
+}
+
+const agentConfig = (over: Partial<{ name: string; systemPrompt: string; source: string; model: string; tools: string[] }> = {}) => ({
+  name: 'scout',
+  description: 'a scout',
+  systemPrompt: '',
+  source: 'user',
+  filePath: '/agents/scout.md',
+  ...over,
+})
+
+const trustedCtx = { cwd: '/repo', hasUI: false, isProjectTrusted: () => true, ui: { confirm: vi.fn(async () => true) } }
+
+const text = (result: ToolResult): string => {
+  const first = result.content[0]
+  if (first?.type !== 'text') throw new Error(`expected a text content part, got ${first?.type}`)
+  return first.text
+}
+
+const results = (result: ToolResult): ResultShape[] => {
+  if (!result.details) throw new Error('expected details on the tool result')
+  return result.details.results
+}
+
+let execute: Execute
+
+beforeEach(() => {
+  spawnCalls = []
+  spawnedChildren = []
+  scripts = new Map()
+  spawnMock.mockReset()
+  spawnMock.mockImplementation((command: string, args: string[], options: { cwd?: string }) => {
+    const promptIndex = args.indexOf('--append-system-prompt')
+    const promptPath = promptIndex === -1 ? null : args[promptIndex + 1]
+    spawnCalls.push({
+      command,
+      args,
+      options,
+      promptFile: promptPath ? { path: promptPath, content: fs.readFileSync(promptPath, 'utf-8') } : null,
+    })
+    const child = new FakeChild()
+    spawnedChildren.push(child)
+    const s = scripts.get(args[args.length - 1]) ?? {}
+    setTimeout(() => drive(child, s), s.delay ?? 0)
+    return child
+  })
+  startBackgroundRunMock.mockClear()
+  startBackgroundRunMock.mockReturnValue('bg-deadbeef')
+  backgroundStatusTextMock.mockClear()
+  sendMessageMock.mockClear()
+  trustedCtx.ui.confirm.mockClear()
+  discoverAgentsMock.mockReturnValue({ agents: [agentConfig()], projectAgentsDir: null })
+  execute = getExecute()
+})
+
+// ---------------------------------------------------------------------------
+
+describe('execute dispatch', () => {
+  it('returns the background status listing and runs nothing when status is set', async () => {
+    backgroundStatusTextMock.mockReturnValue('bg-1 scout: running - audit')
+    const result = await execute('c1', { status: true, agent: 'scout', task: 'ignored' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('bg-1 scout: running - audit')
+    expect(result.details).toMatchObject({ mode: 'single', agentScope: 'user', projectAgentsDir: null, results: [] })
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a call with no mode and names every discovered agent with its source', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig(), agentConfig({ name: 'repo', source: 'project' })], projectAgentsDir: '/repo/.pi/agents' })
+
+    const result = await execute('c1', {}, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Invalid parameters. Provide exactly one mode.\nAvailable agents: scout (user), repo (project)')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a call that supplies two modes at once', async () => {
+    const params = { chain: [{ agent: 'scout', task: 'a' }], tasks: [{ agent: 'scout', task: 'b' }] }
+    const result = await execute('c1', params, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Invalid parameters. Provide exactly one mode.\nAvailable agents: scout (user)')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('reports none as the available list when discovery found no agents', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [], projectAgentsDir: null })
+    const result = await execute('c1', { agent: 'scout' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Invalid parameters. Provide exactly one mode.\nAvailable agents: none')
+  })
+
+  it('passes the requested agent scope to discovery and echoes it back in the details', async () => {
+    const result = await execute('c1', { status: true, agentScope: 'both' }, undefined, undefined, trustedCtx)
+
+    expect(discoverAgentsMock).toHaveBeenCalledWith('/repo', 'both')
+    expect(result.details).toMatchObject({ agentScope: 'both' })
+  })
+})
+
+describe('project agent gate', () => {
+  const projectAgents = { agents: [agentConfig({ name: 'repo', source: 'project' })], projectAgentsDir: '/repo/.pi/agents' }
+
+  it('refuses an untrusted project agent when there is no UI', async () => {
+    discoverAgentsMock.mockReturnValue(projectAgents)
+    const ctx = { ...trustedCtx, hasUI: false, isProjectTrusted: () => false }
+
+    const result = await execute('c1', { agent: 'repo', task: 't' }, undefined, undefined, ctx)
+
+    expect(text(result)).toBe('Project-local agents (repo) require a trusted project; refusing in non-interactive mode.')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('treats a context without isProjectTrusted as untrusted', async () => {
+    discoverAgentsMock.mockReturnValue(projectAgents)
+    const ctx = { cwd: '/repo', hasUI: false, ui: { confirm: vi.fn() } }
+
+    const result = await execute('c1', { agent: 'repo', task: 't' }, undefined, undefined, ctx)
+
+    expect(text(result)).toBe('Project-local agents (repo) require a trusted project; refusing in non-interactive mode.')
+    expect(ctx.ui.confirm).not.toHaveBeenCalled()
+  })
+
+  it('labels the refusal with the chain mode and every requested project agent', async () => {
+    discoverAgentsMock.mockReturnValue({
+      agents: [agentConfig({ name: 'repo', source: 'project' }), agentConfig({ name: 'lint', source: 'project' })],
+      projectAgentsDir: '/repo/.pi/agents',
+    })
+    const ctx = { ...trustedCtx, isProjectTrusted: () => false }
+
+    const result = await execute(
+      'c1',
+      {
+        chain: [
+          { agent: 'repo', task: 'a' },
+          { agent: 'lint', task: 'b' },
+        ],
+      },
+      undefined,
+      undefined,
+      ctx,
+    )
+
+    expect(text(result)).toBe('Project-local agents (repo, lint) require a trusted project; refusing in non-interactive mode.')
+    expect(result.details).toMatchObject({ mode: 'chain', results: [] })
+  })
+
+  it('asks the user before running an untrusted project agent interactively', async () => {
+    discoverAgentsMock.mockReturnValue(projectAgents)
+    const confirm = vi.fn(async () => true)
+    const ctx = { ...trustedCtx, hasUI: true, isProjectTrusted: () => false, ui: { confirm } }
+    script('t', { stdout: [say('done')] })
+
+    const result = await execute('c1', { agent: 'repo', task: 't' }, undefined, undefined, ctx)
+
+    expect(confirm).toHaveBeenCalledWith('Run project-local agents?', 'Agents: repo\nSource: /repo/.pi/agents\n\nProject agents are repo-controlled. Only continue for trusted repositories.')
+    expect(text(result)).toBe('done')
+  })
+
+  it('reports an unknown project agents directory in the confirmation prompt', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ name: 'repo', source: 'project' })], projectAgentsDir: null })
+    const confirm = vi.fn(async () => false)
+    const ctx = { ...trustedCtx, hasUI: true, isProjectTrusted: () => false, ui: { confirm } }
+
+    await execute('c1', { agent: 'repo', task: 't' }, undefined, undefined, ctx)
+
+    expect(confirm).toHaveBeenCalledWith('Run project-local agents?', 'Agents: repo\nSource: (unknown)\n\nProject agents are repo-controlled. Only continue for trusted repositories.')
+  })
+
+  it('cancels without spawning when the user declines the confirmation', async () => {
+    discoverAgentsMock.mockReturnValue(projectAgents)
+    const ctx = { ...trustedCtx, hasUI: true, isProjectTrusted: () => false, ui: { confirm: vi.fn(async () => false) } }
+
+    const result = await execute('c1', { tasks: [{ agent: 'repo', task: 't' }] }, undefined, undefined, ctx)
+
+    expect(text(result)).toBe('Canceled: project-local agents not approved.')
+    expect(result.details).toMatchObject({ mode: 'parallel', results: [] })
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('runs a user-scoped agent without consulting the UI', async () => {
+    const confirm = vi.fn(async () => true)
+    const ctx = { ...trustedCtx, hasUI: true, isProjectTrusted: () => false, ui: { confirm } }
+    script('t', { stdout: [say('ok')] })
+
+    const result = await execute('c1', { agent: 'scout', task: 't' }, undefined, undefined, ctx)
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(text(result)).toBe('ok')
+  })
+})
+
+describe('background mode', () => {
+  it('refuses a background run that is not single mode', async () => {
+    const result = await execute('c1', { background: true, chain: [{ agent: 'scout', task: 't' }] }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('background: true requires single mode (agent + task).')
+    expect(startBackgroundRunMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a background run for an agent that does not exist', async () => {
+    const result = await execute('c1', { background: true, agent: 'ghost', task: 't' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Unknown agent: "ghost". Available agents: "scout".')
+    expect(startBackgroundRunMock).not.toHaveBeenCalled()
+  })
+
+  it('starts the run with the agent invocation and reports the returned run id', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ model: 'sonnet', tools: ['read', 'bash'] })], projectAgentsDir: null })
+    startBackgroundRunMock.mockReturnValue('bg-1a2b3c4d')
+
+    const result = await execute('c1', { background: true, agent: 'scout', task: 'audit', cwd: '/other' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Started background run bg-1a2b3c4d (scout). A notification will arrive on completion; check progress with {status: true}.')
+    expect(startBackgroundRunMock.mock.calls[0][0]).toBe('scout')
+    expect(startBackgroundRunMock.mock.calls[0][1]).toBe('audit')
+    const invocation = startBackgroundRunMock.mock.calls[0][2]
+    expect(invocation.args.slice(invocation.args.indexOf('--mode'))).toEqual(['--mode', 'json', '-p', '--no-session', '--model', 'sonnet', '--tools', 'read,bash', 'Task: audit'])
+    expect(invocation.cwd).toBe('/other')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('defaults the background working directory to the context cwd', async () => {
+    await execute('c1', { background: true, agent: 'scout', task: 'audit' }, undefined, undefined, trustedCtx)
+
+    expect(startBackgroundRunMock.mock.calls[0][2].cwd).toBe('/repo')
+  })
+
+  it('deletes the temporary system prompt file once the background run completes', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ systemPrompt: 'You audit.' })], projectAgentsDir: null })
+
+    await execute('c1', { background: true, agent: 'scout', task: 'audit' }, undefined, undefined, trustedCtx)
+
+    const invocation = startBackgroundRunMock.mock.calls[0][2]
+    const promptPath = invocation.args[invocation.args.indexOf('--append-system-prompt') + 1]
+    expect(fs.readFileSync(promptPath, 'utf-8')).toBe('You audit.')
+
+    const onComplete = startBackgroundRunMock.mock.calls[0][3]
+    onComplete({ id: 'bg-1a2b3c4d', agent: 'scout', state: 'done', turns: 3, output: 'all clear' })
+
+    expect(fs.existsSync(promptPath)).toBe(false)
+  })
+
+  it('notifies the parent agent with the run outcome when the background run completes', async () => {
+    await execute('c1', { background: true, agent: 'scout', task: 'audit' }, undefined, undefined, trustedCtx)
+    const onComplete = startBackgroundRunMock.mock.calls[0][3]
+
+    onComplete({ id: 'bg-1a2b3c4d', agent: 'scout', state: 'done', turns: 3, output: 'all clear' })
+
+    expect(sendMessageMock).toHaveBeenCalledWith({ customType: 'subagent-background', content: 'Background subagent run bg-1a2b3c4d (scout) done after 3 turns.\n\nall clear', display: true }, { triggerTurn: true })
+  })
+
+  it('substitutes a no-output marker when the background run produced nothing', async () => {
+    await execute('c1', { background: true, agent: 'scout', task: 'audit' }, undefined, undefined, trustedCtx)
+    const onComplete = startBackgroundRunMock.mock.calls[0][3]
+
+    onComplete({ id: 'bg-9', agent: 'scout', state: 'failed', turns: 0, output: '' })
+
+    expect(sendMessageMock.mock.calls[0][0].content).toBe('Background subagent run bg-9 (scout) failed after 0 turns.\n\n(no output)')
+  })
+})
+
+describe('runSingleAgent process handling', () => {
+  it('reports an unknown agent without spawning anything', async () => {
+    const result = await execute('c1', { agent: 'ghost', task: 'find it' }, undefined, undefined, trustedCtx)
+
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(result.isError).toBe(true)
+    expect(text(result)).toBe('Agent failed: Unknown agent: "ghost". Available agents: "scout".')
+    expect(results(result)[0]).toMatchObject({ agent: 'ghost', agentSource: 'unknown', task: 'find it', exitCode: 1, messages: [], step: undefined })
+  })
+
+  it('builds the pi arguments from the agent model, tools and task', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ model: 'opus', tools: ['read', 'grep'] })], projectAgentsDir: null })
+    script('inspect', { stdout: [say('ok')] })
+
+    await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(piArgs(spawnCalls[0])).toEqual(['--mode', 'json', '-p', '--no-session', '--model', 'opus', '--tools', 'read,grep', 'Task: inspect'])
+    expect(spawnCalls[0].options.shell).toBe(false)
+  })
+
+  it('omits the model and tools flags when the agent declares neither', async () => {
+    script('inspect', { stdout: [say('ok')] })
+
+    await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(piArgs(spawnCalls[0])).toEqual(['--mode', 'json', '-p', '--no-session', 'Task: inspect'])
+  })
+
+  it('writes the agent system prompt to a temp file, passes it, and removes it afterwards', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ name: 'my agent/1', systemPrompt: 'Be terse.' })], projectAgentsDir: null })
+    script('inspect', { stdout: [say('ok')] })
+
+    await execute('c1', { agent: 'my agent/1', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    const call = spawnCalls[0]
+    expect(piArgs(call).slice(0, 5)).toEqual(['--mode', 'json', '-p', '--no-session', '--append-system-prompt'])
+    expect(call.promptFile?.content).toBe('Be terse.')
+    // Unsafe characters in the agent name are replaced before it reaches the filesystem.
+    expect(call.promptFile?.path.endsWith('/prompt-my_agent_1.md')).toBe(true)
+    expect(fs.existsSync(call.promptFile?.path as string)).toBe(false)
+  })
+
+  it('runs the child in the caller-supplied working directory, falling back to the context cwd', async () => {
+    script('a', { stdout: [say('x')] })
+    script('b', { stdout: [say('y')] })
+
+    await execute('c1', { agent: 'scout', task: 'a', cwd: '/elsewhere' }, undefined, undefined, trustedCtx)
+    await execute('c2', { agent: 'scout', task: 'b' }, undefined, undefined, trustedCtx)
+
+    expect(spawnCalls[0].options.cwd).toBe('/elsewhere')
+    expect(spawnCalls[1].options.cwd).toBe('/repo')
+  })
+
+  it('parses a JSONL event that arrives split across two stdout chunks', async () => {
+    const whole = say('reassembled')
+    script('inspect', { stdout: [whole.slice(0, 20), whole.slice(20)] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('reassembled')
+    expect(results(result)[0].messages).toHaveLength(1)
+  })
+
+  it('parses a final JSONL event that never received a trailing newline', async () => {
+    script('inspect', { stdout: [say('flushed').trimEnd()] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('flushed')
+  })
+
+  it('skips malformed and blank JSONL lines without losing the surrounding events', async () => {
+    script('inspect', { stdout: [`${say('first')}not json at all\n\n   \n${say('second')}`] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('second')
+    expect(results(result)[0].messages).toHaveLength(2)
+  })
+
+  it('ignores JSONL events of unrelated types', async () => {
+    script('inspect', { stdout: [line({ type: 'message_start', message: assistantMessage({ text: 'ignored' }) }), line({ type: 'message_end' }), say('kept')] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('kept')
+    expect(results(result)[0].messages).toHaveLength(1)
+  })
+
+  it('records tool result messages without counting them as turns', async () => {
+    script('inspect', { stdout: [say('done'), line({ type: 'tool_result_end', message: { role: 'toolResult', content: [] } })] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(results(result)[0].messages).toHaveLength(2)
+    expect(results(result)[0].usage.turns).toBe(1)
+  })
+
+  it('sums usage across assistant turns but takes the latest context size', async () => {
+    script('inspect', {
+      stdout: [messageEnd(assistantMessage({ text: 'one', usage: { input: 10, output: 2, cacheRead: 100, cacheWrite: 0, cost: { total: 0.5 }, totalTokens: 200 } })), messageEnd(assistantMessage({ text: 'two', usage: { input: 5, output: 3, cacheRead: 0, cacheWrite: 7, cost: { total: 0.25 }, totalTokens: 300 } }))],
+    })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(results(result)[0].usage).toEqual({ input: 15, output: 5, cacheRead: 100, cacheWrite: 7, cost: 0.75, contextTokens: 300, turns: 2 })
+  })
+
+  it('counts an assistant turn that carries no usage block at all', async () => {
+    script('inspect', { stdout: [say('one'), say('two')] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(results(result)[0].usage).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 2 })
+  })
+
+  it('adopts the model reported by the child when the agent config declares none', async () => {
+    script('inspect', { stdout: [messageEnd(assistantMessage({ text: 'a', model: 'first-model' })), messageEnd(assistantMessage({ text: 'b', model: 'second-model' }))] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(results(result)[0].model).toBe('first-model')
+  })
+
+  it('keeps the configured model over the one the child reports', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ model: 'opus' })], projectAgentsDir: null })
+    script('inspect', { stdout: [messageEnd(assistantMessage({ text: 'a', model: 'reported' }))] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(results(result)[0].model).toBe('opus')
+  })
+
+  it('collects stderr chunks onto the result', async () => {
+    script('inspect', { stdout: [say('ok')], stderr: ['warn: ', 'deprecated flag'] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(results(result)[0].stderr).toBe('warn: deprecated flag')
+  })
+
+  it('treats a spawn error as exit code 1', async () => {
+    script('inspect', { fail: true })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(results(result)[0].exitCode).toBe(1)
+    expect(text(result)).toBe('Agent failed: (no output)')
+  })
+
+  it('maps a null exit code to zero', async () => {
+    script('inspect', { stdout: [say('ok')], exitCode: null })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(results(result)[0].exitCode).toBe(0)
+    expect(text(result)).toBe('ok')
+  })
+
+  it('streams a running placeholder before any assistant text arrives', async () => {
+    const updates: string[] = []
+    script('inspect', { stdout: [messageEnd(assistantMessage({})), say('final')] })
+
+    await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, (partial) => updates.push(text(partial)), trustedCtx)
+
+    expect(updates).toEqual(['(running...)', 'final'])
+  })
+
+  it('terminates the child and rejects when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    script('inspect', { stdout: [say('too late')] })
+
+    await expect(execute('c1', { agent: 'scout', task: 'inspect' }, controller.signal, undefined, trustedCtx)).rejects.toThrow('Subagent was aborted')
+    expect(spawnedChildren[0].kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('terminates the child when the signal aborts mid-run', async () => {
+    const controller = new AbortController()
+    script('inspect', { stdout: [say('too late')], delay: 20 })
+
+    const pending = execute('c1', { agent: 'scout', task: 'inspect' }, controller.signal, undefined, trustedCtx)
+    controller.abort()
+
+    await expect(pending).rejects.toThrow('Subagent was aborted')
+    expect(spawnedChildren[0].kill).toHaveBeenCalledWith('SIGTERM')
+  })
+})
+
+describe('single mode', () => {
+  it('returns the final assistant text on success', async () => {
+    script('inspect', { stdout: [say('first answer'), say('final answer')] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('final answer')
+    expect(result.isError).toBeUndefined()
+    expect(results(result)[0]).toMatchObject({ agent: 'scout', agentSource: 'user', task: 'inspect', exitCode: 0 })
+  })
+
+  it('reports no output when the child exits cleanly with no assistant text', async () => {
+    script('inspect', {})
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('(no output)')
+    expect(result.isError).toBeUndefined()
+  })
+
+  it('names the stop reason in the failure text when one is reported', async () => {
+    script('inspect', { stdout: [messageEnd(assistantMessage({ text: 'partial', stopReason: 'error', errorMessage: 'model overloaded' }))] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Agent error: model overloaded')
+    expect(result.isError).toBe(true)
+  })
+
+  it('fails an aborted run even though the child exited cleanly', async () => {
+    script('inspect', { stdout: [messageEnd(assistantMessage({ text: 'partial work', stopReason: 'aborted' }))] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Agent aborted: partial work')
+    expect(result.isError).toBe(true)
+  })
+
+  it('succeeds on a benign stop reason', async () => {
+    script('inspect', { stdout: [messageEnd(assistantMessage({ text: 'all done', stopReason: 'stop' }))] })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('all done')
+    expect(result.isError).toBeUndefined()
+  })
+
+  it('prefers the reported error message over stderr and the final output', async () => {
+    script('inspect', { stdout: [messageEnd(assistantMessage({ text: 'some output', errorMessage: 'rate limited' }))], stderr: ['stderr noise'], exitCode: 2 })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Agent failed: rate limited')
+  })
+
+  it('falls back to stderr when no error message was reported', async () => {
+    script('inspect', { stdout: [say('some output')], stderr: ['crashed hard'], exitCode: 2 })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Agent failed: crashed hard')
+  })
+
+  it('falls back to the final assistant output when stderr is empty', async () => {
+    script('inspect', { stdout: [say('what the agent said')], exitCode: 3 })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Agent failed: what the agent said')
+  })
+
+  it('falls back to a no-output marker when nothing at all was produced', async () => {
+    script('inspect', { exitCode: 7 })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Agent failed: (no output)')
+  })
+})
+
+describe('chain mode', () => {
+  const twoStep = {
+    chain: [
+      { agent: 'scout', task: 'find the bug' },
+      { agent: 'scout', task: 'fix: {previous}' },
+    ],
+  }
+
+  it('feeds each step output into the next step {previous} placeholder', async () => {
+    script('find the bug', { stdout: [say('null deref in parser')] })
+    script('fix: null deref in parser', { stdout: [say('patched')] })
+
+    const result = await execute('c1', twoStep, undefined, undefined, trustedCtx)
+
+    expect(piArgs(spawnCalls[0]).at(-1)).toBe('Task: find the bug')
+    expect(piArgs(spawnCalls[1]).at(-1)).toBe('Task: fix: null deref in parser')
+    expect(text(result)).toBe('patched')
+    expect(results(result).map((r) => r.step)).toEqual([1, 2])
+  })
+
+  it('substitutes every occurrence of the placeholder', async () => {
+    const chain = [
+      { agent: 'scout', task: 'a' },
+      { agent: 'scout', task: '{previous} and {previous}' },
+    ]
+    script('a', { stdout: [say('X')] })
+    script('X and X', { stdout: [say('done')] })
+
+    const result = await execute('c1', { chain }, undefined, undefined, trustedCtx)
+
+    expect(piArgs(spawnCalls[1]).at(-1)).toBe('Task: X and X')
+    expect(text(result)).toBe('done')
+  })
+
+  it('substitutes an empty string for the placeholder in the first step', async () => {
+    script('summarize ', { stdout: [say('nothing to summarize')] })
+
+    const result = await execute('c1', { chain: [{ agent: 'scout', task: 'summarize {previous}' }] }, undefined, undefined, trustedCtx)
+
+    expect(piArgs(spawnCalls[0]).at(-1)).toBe('Task: summarize ')
+    expect(text(result)).toBe('nothing to summarize')
+  })
+
+  it('reports no output when the last step produced none', async () => {
+    script('a', { stdout: [say('X')] })
+    script('b', {})
+
+    const result = await execute(
+      'c1',
+      {
+        chain: [
+          { agent: 'scout', task: 'a' },
+          { agent: 'scout', task: 'b' },
+        ],
+      },
+      undefined,
+      undefined,
+      trustedCtx,
+    )
+
+    expect(text(result)).toBe('(no output)')
+  })
+
+  it('stops at the failing step and never spawns the rest of the chain', async () => {
+    script('find the bug', { stderr: ['scout crashed'], exitCode: 4 })
+
+    const result = await execute('c1', twoStep, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Chain stopped at step 1 (scout): scout crashed')
+    expect(result.isError).toBe(true)
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    expect(results(result)).toHaveLength(1)
+  })
+
+  it('stops at a later step and keeps the earlier results', async () => {
+    script('find the bug', { stdout: [say('the bug')] })
+    script('fix: the bug', { stdout: [messageEnd(assistantMessage({ text: 'gave up', stopReason: 'error' }))] })
+
+    const result = await execute('c1', twoStep, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Chain stopped at step 2 (scout): gave up')
+    expect(results(result).map((r) => r.step)).toEqual([1, 2])
+  })
+
+  it('stops on an aborted step reported with a clean exit code', async () => {
+    script('find the bug', { stdout: [messageEnd(assistantMessage({ stopReason: 'aborted', errorMessage: 'user interrupted' }))] })
+
+    const result = await execute('c1', twoStep, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Chain stopped at step 1 (scout): user interrupted')
+  })
+
+  it('stops with a no-output marker when the failing step said nothing', async () => {
+    script('find the bug', { exitCode: 1 })
+
+    const result = await execute('c1', twoStep, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Chain stopped at step 1 (scout): (no output)')
+  })
+
+  it('stops the chain on an unknown agent without spawning', async () => {
+    const chain = [
+      { agent: 'ghost', task: 'a' },
+      { agent: 'scout', task: 'b' },
+    ]
+
+    const result = await execute('c1', { chain }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Chain stopped at step 1 (ghost): Unknown agent: "ghost". Available agents: "scout".')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('streams each step alongside the results already completed', async () => {
+    script('find the bug', { stdout: [say('the bug')] })
+    script('fix: the bug', { stdout: [say('patched')] })
+    const updates: { text: string; agents: string[]; steps: (number | undefined)[] }[] = []
+
+    await execute('c1', twoStep, undefined, (partial) => updates.push({ text: text(partial), agents: results(partial).map((r) => r.agent), steps: results(partial).map((r) => r.step) }), trustedCtx)
+
+    expect(updates.map((u) => u.text)).toEqual(['the bug', 'patched'])
+    expect(updates.map((u) => u.steps)).toEqual([[1], [1, 2]])
+    expect(updates[1].agents).toEqual(['scout', 'scout'])
+  })
+})
+
+describe('parallel mode', () => {
+  const tasksOf = (...names: string[]) => names.map((task) => ({ agent: 'scout', task }))
+
+  it('refuses more than eight parallel tasks before spawning anything', async () => {
+    const tasks = Array.from({ length: 9 }, (_, i) => ({ agent: 'scout', task: `t${i}` }))
+
+    const result = await execute('c1', { tasks }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Too many parallel tasks (9). Max is 8.')
+    expect(result.details).toMatchObject({ mode: 'parallel', results: [] })
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts exactly eight parallel tasks', async () => {
+    const names = Array.from({ length: 8 }, (_, i) => `t${i}`)
+    for (const name of names) script(name, { stdout: [say(name)] })
+
+    const result = await execute('c1', { tasks: tasksOf(...names) }, undefined, undefined, trustedCtx)
+
+    expect(spawnMock).toHaveBeenCalledTimes(8)
+    expect(text(result).split('\n\n')[0]).toBe('Parallel: 8/8 succeeded')
+  })
+
+  it('summarizes each task with its completion state and output preview', async () => {
+    script('alpha', { stdout: [say('alpha output')] })
+    script('beta', { stdout: [say('beta output')], exitCode: 1 })
+
+    const result = await execute('c1', { tasks: tasksOf('alpha', 'beta') }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Parallel: 1/2 succeeded\n\n[scout] completed: alpha output\n\n[scout] failed: beta output')
+  })
+
+  it('truncates a task preview past 100 characters', async () => {
+    const long = 'z'.repeat(150)
+    const exact = 'y'.repeat(100)
+    script('alpha', { stdout: [say(long)] })
+    script('beta', { stdout: [say(exact)] })
+
+    const result = await execute('c1', { tasks: tasksOf('alpha', 'beta') }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe(`Parallel: 2/2 succeeded\n\n[scout] completed: ${'z'.repeat(100)}...\n\n[scout] completed: ${exact}`)
+  })
+
+  it('substitutes a no-output marker for a task that said nothing', async () => {
+    script('alpha', {})
+
+    const result = await execute('c1', { tasks: tasksOf('alpha') }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Parallel: 1/1 succeeded\n\n[scout] completed: (no output)')
+  })
+
+  it('reports an unknown agent as a failed task rather than aborting the batch', async () => {
+    script('alpha', { stdout: [say('fine')] })
+
+    const tasks = [{ agent: 'ghost', task: 'nope' }, ...tasksOf('alpha')]
+    const result = await execute('c1', { tasks }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Parallel: 1/2 succeeded\n\n[ghost] failed: (no output)\n\n[scout] completed: fine')
+    expect(results(result)[0]).toMatchObject({ agent: 'ghost', agentSource: 'unknown', exitCode: 1 })
+  })
+
+  it('marks not-yet-started tasks with a running placeholder in streamed updates', async () => {
+    script('alpha', { stdout: [say('alpha done')] })
+    script('beta', { stdout: [say('beta done')], delay: 30 })
+    const updates: { text: string; exitCodes: number[]; sources: string[] }[] = []
+
+    await execute('c1', { tasks: tasksOf('alpha', 'beta') }, undefined, (partial) => updates.push({ text: text(partial), exitCodes: results(partial).map((r) => r.exitCode), sources: results(partial).map((r) => r.agentSource) }), trustedCtx)
+
+    expect(updates[0]).toEqual({ text: 'Parallel: 1/2 done, 1 running...', exitCodes: [0, -1], sources: ['user', 'unknown'] })
+    expect(updates.at(-1)).toEqual({ text: 'Parallel: 2/2 done, 0 running...', exitCodes: [0, 0], sources: ['user', 'user'] })
+  })
+
+  it('keeps results aligned with the input task order', async () => {
+    script('alpha', { stdout: [say('A')], delay: 30 })
+    script('beta', { stdout: [say('B')] })
+
+    const result = await execute('c1', { tasks: tasksOf('alpha', 'beta') }, undefined, undefined, trustedCtx)
+
+    expect(results(result).map((r) => r.task)).toEqual(['alpha', 'beta'])
+    expect(text(result)).toBe('Parallel: 2/2 succeeded\n\n[scout] completed: A\n\n[scout] completed: B')
+  })
+
+  it('honours a per-task working directory', async () => {
+    script('alpha', { stdout: [say('A')] })
+
+    await execute('c1', { tasks: [{ agent: 'scout', task: 'alpha', cwd: '/pkg/a' }] }, undefined, undefined, trustedCtx)
+
+    expect(spawnCalls[0].options.cwd).toBe('/pkg/a')
+  })
+})

--- a/tests/subagent-render.test.ts
+++ b/tests/subagent-render.test.ts
@@ -2,7 +2,7 @@ import * as os from 'node:os'
 import type { AgentToolResult } from '@earendil-works/pi-agent-core'
 import type { Message } from '@earendil-works/pi-ai'
 import type { Theme } from '@earendil-works/pi-coding-agent'
-import type { Component, Container } from '@earendil-works/pi-tui'
+import { type Component, type Container, Markdown } from '@earendil-works/pi-tui'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import subagentExtension, { formatTokens, formatToolCall, formatUsageStats, getDisplayItems, getFinalOutput, mapWithConcurrencyLimit } from '../extensions/subagent/index.ts'
@@ -26,8 +26,12 @@ const str = (c: Component): string =>
     .render(200)
     .map((line) => line.trimEnd())
     .join('\n')
-const childStr = (c: Container, i: number): string => str(c.children[i])
-const shapeOf = (c: Container): string[] => c.children.map((child) => child.constructor.name)
+/**
+ * Visible content of a container in order. Markdown stands in as a marker because
+ * it cannot render without an initialized theme. Asserting content rather than the
+ * child class sequence keeps these tests from breaking on spacing-only changes.
+ */
+const visibleLines = (c: Container): string[] => c.children.flatMap((child) => (child instanceof Markdown ? ['<output>'] : str(child).split('\n'))).filter((line) => line !== '')
 
 type ToolShape = {
   name: string
@@ -378,22 +382,14 @@ describe('renderResult single mode', () => {
     })
     const container = renderResult(toolResult('single', [r]), { expanded: true }, theme) as Container
 
-    expect(shapeOf(container)).toEqual(['Text', 'Spacer', 'Text', 'Text', 'Spacer', 'Text', 'Text', 'Spacer', 'Markdown'])
-    expect(childStr(container, 0)).toBe('✓ scout (user)')
-    expect(childStr(container, 2)).toBe('─── Task ───')
-    expect(childStr(container, 3)).toBe('do it')
-    expect(childStr(container, 5)).toBe('─── Output ───')
-    expect(childStr(container, 6)).toBe('→ $ ls')
+    expect(visibleLines(container)).toEqual(['✓ scout (user)', '─── Task ───', 'do it', '─── Output ───', '→ $ ls', '<output>'])
   })
 
   it('marks an expanded failure with the stop reason and error message', () => {
     const r = makeResult({ agent: 'scout', agentSource: 'project', task: 't', exitCode: 1, stopReason: 'error', errorMessage: 'boom' })
     const container = renderResult(toolResult('single', [r]), { expanded: true }, theme) as Container
 
-    expect(shapeOf(container)).toEqual(['Text', 'Text', 'Spacer', 'Text', 'Text', 'Spacer', 'Text', 'Text'])
-    expect(childStr(container, 0)).toBe('✗ scout (project) [error]')
-    expect(childStr(container, 1)).toBe('Error: boom')
-    expect(childStr(container, 7)).toBe('(no output)')
+    expect(visibleLines(container)).toEqual(['✗ scout (project) [error]', 'Error: boom', '─── Task ───', 't', '─── Output ───', '(no output)'])
   })
 
   it('treats an aborted stop reason as a failure even with exit code 0', () => {
@@ -405,8 +401,7 @@ describe('renderResult single mode', () => {
     const r = makeResult({ agent: 'scout', usage: { ...noUsage, turns: 2, input: 1500 }, model: 'sonnet' })
     const container = renderResult(toolResult('single', [r]), { expanded: true }, theme) as Container
 
-    expect(shapeOf(container).slice(-2)).toEqual(['Spacer', 'Text'])
-    expect(childStr(container, container.children.length - 1)).toBe('2 turns ↑1.5k sonnet')
+    expect(visibleLines(container).at(-1)).toBe('2 turns ↑1.5k sonnet')
   })
 
   it('clips each text item to three lines when collapsed', () => {
@@ -457,14 +452,7 @@ describe('renderResult chain mode', () => {
   it('builds an expanded container with a per-step block and an aggregate total', () => {
     const container = renderResult(toolResult('chain', steps), { expanded: true }, theme) as Container
 
-    expect(shapeOf(container)).toEqual(['Text', 'Spacer', 'Text', 'Text', 'Text', 'Spacer', 'Markdown', 'Text', 'Spacer', 'Text', 'Text', 'Spacer', 'Text'])
-    expect(childStr(container, 0)).toBe('✓ chain 2/2 steps')
-    expect(childStr(container, 2)).toBe('─── Step 1: alpha ✓')
-    expect(childStr(container, 3)).toBe('Task: first task')
-    expect(childStr(container, 4)).toBe('→ $ ls')
-    expect(childStr(container, 7)).toBe('1 turn ↑500')
-    expect(childStr(container, 9)).toBe('─── Step 2: beta ✓')
-    expect(childStr(container, 12)).toBe('Total: 1 turn ↑500')
+    expect(visibleLines(container)).toEqual(['✓ chain 2/2 steps', '─── Step 1: alpha ✓', 'Task: first task', '→ $ ls', '<output>', '1 turn ↑500', '─── Step 2: beta ✓', 'Task: second task', 'Total: 1 turn ↑500'])
   })
 })
 
@@ -491,13 +479,7 @@ describe('renderResult parallel mode', () => {
     const results = [makeResult({ agent: 'a', task: 'T', messages: [assistant(toolCallPart('bash', { command: 'ls' }), textPart('hello'))], usage: { ...noUsage, turns: 1, input: 100 } })]
     const container = renderResult(toolResult('parallel', results), { expanded: true }, theme) as Container
 
-    expect(shapeOf(container)).toEqual(['Text', 'Spacer', 'Text', 'Text', 'Text', 'Spacer', 'Markdown', 'Text', 'Spacer', 'Text'])
-    expect(childStr(container, 0)).toBe('✓ parallel 1/1 tasks')
-    expect(childStr(container, 2)).toBe('─── a ✓')
-    expect(childStr(container, 3)).toBe('Task: T')
-    expect(childStr(container, 4)).toBe('→ $ ls')
-    expect(childStr(container, 7)).toBe('1 turn ↑100')
-    expect(childStr(container, 9)).toBe('Total: 1 turn ↑100')
+    expect(visibleLines(container)).toEqual(['✓ parallel 1/1 tasks', '─── a ✓', 'Task: T', '→ $ ls', '<output>', '1 turn ↑100', 'Total: 1 turn ↑100'])
   })
 })
 

--- a/tests/subagent-render.test.ts
+++ b/tests/subagent-render.test.ts
@@ -1,0 +1,579 @@
+import * as os from 'node:os'
+import type { AgentToolResult } from '@earendil-works/pi-agent-core'
+import type { Message } from '@earendil-works/pi-ai'
+import type { Theme } from '@earendil-works/pi-coding-agent'
+import type { Component, Container } from '@earendil-works/pi-tui'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import subagentExtension, { formatTokens, formatToolCall, formatUsageStats, getDisplayItems, getFinalOutput, mapWithConcurrencyLimit } from '../extensions/subagent/index.ts'
+
+const discoverAgentsMock = vi.hoisted(() => vi.fn())
+const startBackgroundRunMock = vi.hoisted(() => vi.fn(() => 'bg-1'))
+
+vi.mock('../extensions/subagent/agents.js', () => ({ discoverAgents: discoverAgentsMock }))
+vi.mock('../extensions/subagent/background.js', () => ({
+  backgroundStatusText: () => 'BACKGROUND-STATUS',
+  startBackgroundRun: startBackgroundRunMock,
+}))
+
+/** Identity theme: renderers concatenate the returned strings verbatim, so output is plain text. */
+const theme = { fg: (_role: string, s: string) => s, bold: (s: string) => s } as unknown as Theme
+
+type Rendered = Component & { render: (width: number) => string[] }
+/** Wide enough that Text never word-wraps; render pads each line to the width, so strip that padding. */
+const str = (c: Component): string =>
+  (c as Rendered)
+    .render(200)
+    .map((line) => line.trimEnd())
+    .join('\n')
+const childStr = (c: Container, i: number): string => str(c.children[i])
+const shapeOf = (c: Container): string[] => c.children.map((child) => child.constructor.name)
+
+type ToolShape = {
+  name: string
+  execute: (id: string, params: Record<string, unknown>, signal?: unknown, onUpdate?: unknown, ctx?: unknown) => Promise<AgentToolResult<unknown>>
+  renderCall: (args: Record<string, unknown>, theme: Theme, context?: unknown) => Component
+  renderResult: (result: unknown, opts: { expanded: boolean }, theme: Theme, context?: unknown) => Component
+}
+
+const getTool = (): ToolShape => {
+  let tool: ToolShape | undefined
+  subagentExtension({
+    registerTool: (t: ToolShape) => {
+      if (t.name === 'subagent') tool = t
+    },
+  } as never)
+  if (!tool) throw new Error('subagent tool was not registered')
+  return tool
+}
+
+const assistant = (...content: unknown[]): Message => ({ role: 'assistant', content }) as unknown as Message
+const user = (text: string): Message => ({ role: 'user', content: [{ type: 'text', text }] }) as unknown as Message
+const textPart = (text: string) => ({ type: 'text', text })
+const toolCallPart = (name: string, args: Record<string, unknown>) => ({ type: 'toolCall', name, arguments: args })
+
+const noUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 }
+
+type ResultStub = {
+  agent: string
+  agentSource: 'user' | 'project' | 'unknown'
+  task: string
+  exitCode: number
+  messages: Message[]
+  stderr: string
+  usage: typeof noUsage
+  model?: string
+  stopReason?: string
+  errorMessage?: string
+  step?: number
+}
+
+const makeResult = (over: Partial<ResultStub> & { agent: string }): ResultStub => ({
+  agentSource: 'user',
+  task: 'task',
+  exitCode: 0,
+  messages: [],
+  stderr: '',
+  usage: { ...noUsage },
+  ...over,
+})
+
+const toolResult = (mode: 'single' | 'parallel' | 'chain', results: ResultStub[], text = 'fallback text') => ({
+  content: [{ type: 'text', text }],
+  details: { mode, agentScope: 'user', projectAgentsDir: null, results },
+})
+
+describe('formatTokens', () => {
+  // Spec: <1000 raw, <10000 one decimal k, <1000000 rounded k, else one decimal M.
+  it('renders sub-thousand counts verbatim', () => {
+    expect(formatTokens(0)).toBe('0')
+    expect(formatTokens(999)).toBe('999')
+  })
+
+  it('switches to one-decimal thousands at 1000', () => {
+    expect(formatTokens(1000)).toBe('1.0k')
+    expect(formatTokens(1500)).toBe('1.5k')
+    expect(formatTokens(9999)).toBe('10.0k')
+  })
+
+  it('switches to rounded thousands at 10000', () => {
+    expect(formatTokens(10000)).toBe('10k')
+    expect(formatTokens(999999)).toBe('1000k')
+  })
+
+  it('switches to one-decimal millions at 1000000', () => {
+    expect(formatTokens(1000000)).toBe('1.0M')
+    expect(formatTokens(2500000)).toBe('2.5M')
+  })
+})
+
+describe('formatUsageStats', () => {
+  it('returns an empty string when every field is zero and no model is given', () => {
+    expect(formatUsageStats({ ...noUsage })).toBe('')
+  })
+
+  it('omits zero-valued fields entirely', () => {
+    expect(formatUsageStats({ ...noUsage, output: 5 })).toBe('↓5')
+    expect(formatUsageStats({ ...noUsage, cost: 0, cacheRead: 2000 })).toBe('R2.0k')
+  })
+
+  it('appends the model even when all counters are zero', () => {
+    expect(formatUsageStats({ ...noUsage }, 'sonnet')).toBe('sonnet')
+  })
+
+  it('singularizes a one-turn run and pluralizes beyond that', () => {
+    expect(formatUsageStats({ ...noUsage, turns: 1 })).toBe('1 turn')
+    expect(formatUsageStats({ ...noUsage, turns: 2 })).toBe('2 turns')
+  })
+
+  it('orders the parts turns, input, output, cacheRead, cacheWrite, cost, context, model', () => {
+    const usage = { input: 1500, output: 200, cacheRead: 3000, cacheWrite: 4000, cost: 0.5, contextTokens: 50000, turns: 3 }
+    expect(formatUsageStats(usage, 'sonnet')).toBe('3 turns ↑1.5k ↓200 R3.0k W4.0k $0.5000 ctx:50k sonnet')
+  })
+})
+
+describe('getFinalOutput', () => {
+  it('returns the first text part of the last assistant message', () => {
+    const messages = [assistant(textPart('early')), user('ignored'), assistant(toolCallPart('bash', {}), textPart('first'), textPart('second'))]
+    expect(getFinalOutput(messages)).toBe('first')
+  })
+
+  it('falls back to an earlier assistant message when the last one has no text part', () => {
+    const messages = [assistant(textPart('early')), assistant(toolCallPart('bash', {}))]
+    expect(getFinalOutput(messages)).toBe('early')
+  })
+
+  it('returns an empty string when there is no assistant message', () => {
+    expect(getFinalOutput([user('hi')])).toBe('')
+    expect(getFinalOutput([])).toBe('')
+  })
+})
+
+describe('getDisplayItems', () => {
+  it('collects assistant text and tool calls in forward order', () => {
+    const messages = [assistant(textPart('one')), assistant(toolCallPart('read', { file_path: '/a' }), textPart('two'))]
+    expect(getDisplayItems(messages)).toEqual([
+      { type: 'text', text: 'one' },
+      { type: 'toolCall', name: 'read', args: { file_path: '/a' } },
+      { type: 'text', text: 'two' },
+    ])
+  })
+
+  it('drops non-assistant messages and thinking/toolResult parts', () => {
+    const messages = [user('question'), assistant({ type: 'thinking', thinking: 'hmm' }, { type: 'toolResult', output: 'x' }, textPart('kept'))]
+    expect(getDisplayItems(messages)).toEqual([{ type: 'text', text: 'kept' }])
+  })
+})
+
+describe('mapWithConcurrencyLimit', () => {
+  /** Runs fn over items while recording peak in-flight count; each item resolves after `delays[i]` ms. */
+  const instrument = (delays: number[]) => {
+    let active = 0
+    let peak = 0
+    const fn = vi.fn(async (item: number, index: number) => {
+      active++
+      peak = Math.max(peak, active)
+      await new Promise((resolve) => setTimeout(resolve, delays[index]))
+      active--
+      return item * 10
+    })
+    return { fn, peak: () => peak }
+  }
+
+  it('never calls fn for an empty input', async () => {
+    const fn = vi.fn(async (n: number) => n)
+    expect(await mapWithConcurrencyLimit([], 4, fn)).toEqual([])
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('keeps result order aligned with input order when completion order is reversed', async () => {
+    // Invariant: results[i] is always fn(items[i]), independent of who finishes first.
+    const completions: number[] = []
+    const results = await mapWithConcurrencyLimit([1, 2, 3, 4], 4, async (item, index) => {
+      await new Promise((resolve) => setTimeout(resolve, (4 - index) * 10))
+      completions.push(item)
+      return `r${item}`
+    })
+    expect(results).toEqual(['r1', 'r2', 'r3', 'r4'])
+    expect(completions).toEqual([4, 3, 2, 1])
+  })
+
+  it('never runs more items at once than the concurrency limit', async () => {
+    const { fn, peak } = instrument([30, 10, 20, 5, 15])
+    const results = await mapWithConcurrencyLimit([1, 2, 3, 4, 5], 2, fn)
+    expect(results).toEqual([10, 20, 30, 40, 50])
+    expect(peak()).toBe(2)
+    expect(fn).toHaveBeenCalledTimes(5)
+  })
+
+  it('caps the worker count at the number of items when concurrency exceeds it', async () => {
+    const { fn, peak } = instrument([20, 20, 20])
+    expect(await mapWithConcurrencyLimit([1, 2, 3], 10, fn)).toEqual([10, 20, 30])
+    expect(peak()).toBe(3)
+  })
+
+  it('clamps a non-positive concurrency to a single worker', async () => {
+    const zero = instrument([20, 10, 5])
+    expect(await mapWithConcurrencyLimit([1, 2, 3], 0, zero.fn)).toEqual([10, 20, 30])
+    expect(zero.peak()).toBe(1)
+
+    const negative = instrument([20, 10, 5])
+    expect(await mapWithConcurrencyLimit([1, 2, 3], -5, negative.fn)).toEqual([10, 20, 30])
+    expect(negative.peak()).toBe(1)
+  })
+
+  it('propagates the rejection reason from fn', async () => {
+    await expect(mapWithConcurrencyLimit([1], 1, async () => Promise.reject(new Error('worker blew up')))).rejects.toThrow('worker blew up')
+  })
+})
+
+describe('formatToolCall', () => {
+  const fg = ((_role: string, s: string) => s) as Theme['fg']
+  const home = os.homedir()
+
+  it('prefixes a bash command with a shell marker', () => {
+    expect(formatToolCall('bash', { command: 'ls -la' }, fg)).toBe('$ ls -la')
+  })
+
+  it('truncates a bash command past 60 characters', () => {
+    const command = 'x'.repeat(70)
+    expect(formatToolCall('bash', { command }, fg)).toBe(`$ ${'x'.repeat(60)}...`)
+    expect(formatToolCall('bash', { command: 'y'.repeat(60) }, fg)).toBe(`$ ${'y'.repeat(60)}`)
+  })
+
+  it('falls back to an ellipsis for a bash call with no command', () => {
+    expect(formatToolCall('bash', {}, fg)).toBe('$ ...')
+  })
+
+  it('abbreviates the home directory prefix in paths', () => {
+    expect(formatToolCall('read', { file_path: `${home}/src/a.ts` }, fg)).toBe('read ~/src/a.ts')
+    expect(formatToolCall('read', { file_path: '/etc/hosts' }, fg)).toBe('read /etc/hosts')
+  })
+
+  it('appends a line range to read only when offset or limit is present', () => {
+    expect(formatToolCall('read', { path: '/a.ts' }, fg)).toBe('read /a.ts')
+    expect(formatToolCall('read', { path: '/a.ts', offset: 5 }, fg)).toBe('read /a.ts:5')
+    expect(formatToolCall('read', { path: '/a.ts', offset: 5, limit: 10 }, fg)).toBe('read /a.ts:5-14')
+    expect(formatToolCall('read', { path: '/a.ts', limit: 10 }, fg)).toBe('read /a.ts:1-10')
+  })
+
+  it('adds a line count to write only for multi-line content', () => {
+    expect(formatToolCall('write', { file_path: '/a.ts', content: 'one line' }, fg)).toBe('write /a.ts')
+    expect(formatToolCall('write', { file_path: '/a.ts', content: 'a\nb\nc' }, fg)).toBe('write /a.ts (3 lines)')
+    expect(formatToolCall('write', {}, fg)).toBe('write ...')
+  })
+
+  it('renders edit, ls, find and grep with their path defaults', () => {
+    expect(formatToolCall('edit', { file_path: `${home}/a.ts` }, fg)).toBe('edit ~/a.ts')
+    expect(formatToolCall('ls', {}, fg)).toBe('ls .')
+    expect(formatToolCall('find', {}, fg)).toBe('find * in .')
+    expect(formatToolCall('find', { pattern: '*.ts', path: '/src' }, fg)).toBe('find *.ts in /src')
+    expect(formatToolCall('grep', { pattern: 'todo', path: '/src' }, fg)).toBe('grep /todo/ in /src')
+    expect(formatToolCall('grep', {}, fg)).toBe('grep // in .')
+  })
+
+  it('falls back to the tool name plus a 50-character JSON preview', () => {
+    expect(formatToolCall('mystery', { a: 1 }, fg)).toBe('mystery {"a":1}')
+    const long = { key: 'z'.repeat(80) }
+    const json = JSON.stringify(long)
+    expect(formatToolCall('mystery', long, fg)).toBe(`mystery ${json.slice(0, 50)}...`)
+  })
+})
+
+describe('renderCall', () => {
+  const renderCall = getTool().renderCall
+
+  it('renders chain mode with a numbered step list', () => {
+    const args = {
+      chain: [
+        { agent: 'scout', task: 'find the bug' },
+        { agent: 'fixer', task: 'fix it' },
+      ],
+    }
+    expect(str(renderCall(args, theme))).toBe(['subagent chain (2 steps) [user]', '  1. scout find the bug', '  2. fixer fix it'].join('\n'))
+  })
+
+  it('strips the {previous} placeholder from the chain preview', () => {
+    const args = { chain: [{ agent: 'fixer', task: '{previous} then summarize' }] }
+    expect(str(renderCall(args, theme))).toBe(['subagent chain (1 steps) [user]', '  1. fixer then summarize'].join('\n'))
+  })
+
+  it('truncates chain step previews past 40 characters', () => {
+    const task = 'a'.repeat(45)
+    const args = { chain: [{ agent: 'scout', task }] }
+    expect(str(renderCall(args, theme))).toBe(['subagent chain (1 steps) [user]', `  1. scout ${'a'.repeat(40)}...`].join('\n'))
+  })
+
+  it('shows only the first three chain steps and counts the rest', () => {
+    const chain = ['a', 'b', 'c', 'd', 'e'].map((agent) => ({ agent, task: 't' }))
+    expect(str(renderCall({ chain }, theme))).toBe(['subagent chain (5 steps) [user]', '  1. a t', '  2. b t', '  3. c t', '  ... +2 more'].join('\n'))
+  })
+
+  it('renders parallel mode with an unnumbered task list and the requested scope', () => {
+    const args = {
+      agentScope: 'both',
+      tasks: [
+        { agent: 'scout', task: 'look' },
+        { agent: 'fixer', task: 'patch' },
+      ],
+    }
+    expect(str(renderCall(args, theme))).toBe(['subagent parallel (2 tasks) [both]', '  scout look', '  fixer patch'].join('\n'))
+  })
+
+  it('shows only the first three parallel tasks and counts the rest', () => {
+    const tasks = ['a', 'b', 'c', 'd'].map((agent) => ({ agent, task: 't' }))
+    expect(str(renderCall({ tasks }, theme))).toBe(['subagent parallel (4 tasks) [user]', '  a t', '  b t', '  c t', '  ... +1 more'].join('\n'))
+  })
+
+  it('truncates parallel task previews past 40 characters', () => {
+    const task = 'b'.repeat(41)
+    expect(str(renderCall({ tasks: [{ agent: 'scout', task }] }, theme))).toBe(['subagent parallel (1 tasks) [user]', `  scout ${'b'.repeat(40)}...`].join('\n'))
+  })
+
+  it('renders single mode with the agent name and task on the second line', () => {
+    expect(str(renderCall({ agent: 'scout', task: 'find it' }, theme))).toBe(['subagent scout [user]', '  find it'].join('\n'))
+  })
+
+  it('truncates a single-mode task past 60 characters', () => {
+    const task = 'c'.repeat(61)
+    expect(str(renderCall({ agent: 'scout', task }, theme))).toBe(['subagent scout [user]', `  ${'c'.repeat(60)}...`].join('\n'))
+  })
+
+  it('falls back to ellipses when the agent or task is missing', () => {
+    expect(str(renderCall({}, theme))).toBe(['subagent ... [user]', '  ...'].join('\n'))
+  })
+})
+
+describe('renderResult fallbacks', () => {
+  const renderResult = getTool().renderResult
+
+  it('shows the content text when details are missing', () => {
+    const result = { content: [{ type: 'text', text: 'plain summary' }] }
+    expect(str(renderResult(result, { expanded: false }, theme))).toBe('plain summary')
+  })
+
+  it('shows the content text when the results array is empty', () => {
+    expect(str(renderResult(toolResult('single', [], 'nothing ran'), { expanded: true }, theme))).toBe('nothing ran')
+  })
+
+  it('reports no output when the content is not text', () => {
+    const result = { content: [{ type: 'image', data: 'x' }] }
+    expect(str(renderResult(result, { expanded: false }, theme))).toBe('(no output)')
+  })
+
+  it('falls through to the content text for a single mode carrying several results', () => {
+    const results = [makeResult({ agent: 'a' }), makeResult({ agent: 'b' })]
+    expect(str(renderResult(toolResult('single', results, 'aggregate'), { expanded: false }, theme))).toBe('aggregate')
+  })
+})
+
+describe('renderResult single mode', () => {
+  const renderResult = getTool().renderResult
+
+  it('builds an expanded container with task, tool calls and a markdown final output', () => {
+    const r = makeResult({
+      agent: 'scout',
+      task: 'do it',
+      messages: [assistant(toolCallPart('bash', { command: 'ls' }), textPart('result text'))],
+    })
+    const container = renderResult(toolResult('single', [r]), { expanded: true }, theme) as Container
+
+    expect(shapeOf(container)).toEqual(['Text', 'Spacer', 'Text', 'Text', 'Spacer', 'Text', 'Text', 'Spacer', 'Markdown'])
+    expect(childStr(container, 0)).toBe('✓ scout (user)')
+    expect(childStr(container, 2)).toBe('─── Task ───')
+    expect(childStr(container, 3)).toBe('do it')
+    expect(childStr(container, 5)).toBe('─── Output ───')
+    expect(childStr(container, 6)).toBe('→ $ ls')
+  })
+
+  it('marks an expanded failure with the stop reason and error message', () => {
+    const r = makeResult({ agent: 'scout', agentSource: 'project', task: 't', exitCode: 1, stopReason: 'error', errorMessage: 'boom' })
+    const container = renderResult(toolResult('single', [r]), { expanded: true }, theme) as Container
+
+    expect(shapeOf(container)).toEqual(['Text', 'Text', 'Spacer', 'Text', 'Text', 'Spacer', 'Text', 'Text'])
+    expect(childStr(container, 0)).toBe('✗ scout (project) [error]')
+    expect(childStr(container, 1)).toBe('Error: boom')
+    expect(childStr(container, 7)).toBe('(no output)')
+  })
+
+  it('treats an aborted stop reason as a failure even with exit code 0', () => {
+    const r = makeResult({ agent: 'scout', stopReason: 'aborted' })
+    expect(str(renderResult(toolResult('single', [r]), { expanded: false }, theme))).toBe('✗ scout (user) [aborted]\n(no output)')
+  })
+
+  it('appends usage stats to the expanded container when any counter is non-zero', () => {
+    const r = makeResult({ agent: 'scout', usage: { ...noUsage, turns: 2, input: 1500 }, model: 'sonnet' })
+    const container = renderResult(toolResult('single', [r]), { expanded: true }, theme) as Container
+
+    expect(shapeOf(container).slice(-2)).toEqual(['Spacer', 'Text'])
+    expect(childStr(container, container.children.length - 1)).toBe('2 turns ↑1.5k sonnet')
+  })
+
+  it('clips each text item to three lines when collapsed', () => {
+    const r = makeResult({ agent: 'scout', messages: [assistant(textPart('one\ntwo\nthree\nfour'))], usage: { ...noUsage, turns: 2, input: 1500 }, model: 'sonnet' })
+    expect(str(renderResult(toolResult('single', [r]), { expanded: false }, theme))).toBe(['✓ scout (user)', 'one', 'two', 'three', '2 turns ↑1.5k sonnet'].join('\n'))
+  })
+
+  it('keeps the last ten items when collapsed and counts the earlier ones', () => {
+    const messages = Array.from({ length: 12 }, (_, i) => assistant(textPart(`i${i}`)))
+    const r = makeResult({ agent: 'scout', messages })
+    const kept = Array.from({ length: 10 }, (_, i) => `i${i + 2}`)
+    expect(str(renderResult(toolResult('single', [r]), { expanded: false }, theme))).toBe(['✓ scout (user)', '... 2 earlier items', ...kept, '(Ctrl+O to expand)'].join('\n'))
+  })
+
+  it('omits the expand hint when the collapsed item count is not exceeded', () => {
+    const messages = Array.from({ length: 10 }, (_, i) => assistant(textPart(`i${i}`)))
+    const r = makeResult({ agent: 'scout', messages })
+    const kept = Array.from({ length: 10 }, (_, i) => `i${i}`)
+    expect(str(renderResult(toolResult('single', [r]), { expanded: false }, theme))).toBe(['✓ scout (user)', ...kept].join('\n'))
+  })
+
+  it('prefers the error message over the item list when collapsed', () => {
+    const r = makeResult({ agent: 'scout', exitCode: 2, errorMessage: 'boom', messages: [assistant(textPart('ignored'))] })
+    expect(str(renderResult(toolResult('single', [r]), { expanded: false }, theme))).toBe('✗ scout (user)\nError: boom')
+  })
+})
+
+describe('renderResult chain mode', () => {
+  const renderResult = getTool().renderResult
+
+  const steps = [makeResult({ agent: 'alpha', task: 'first task', step: 1, messages: [assistant(toolCallPart('bash', { command: 'ls' }), textPart('out1'))], usage: { ...noUsage, turns: 1, input: 500 } }), makeResult({ agent: 'beta', task: 'second task', step: 2 })]
+
+  it('summarizes the successful step count when collapsed', () => {
+    expect(str(renderResult(toolResult('chain', steps), { expanded: false }, theme))).toBe(['✓ chain 2/2 steps', '', '─── Step 1: alpha ✓', '→ $ ls', 'out1', '', '─── Step 2: beta ✓', '(no output)', '', 'Total: 1 turn ↑500', '(Ctrl+O to expand)'].join('\n'))
+  })
+
+  it('marks the chain as failed when any step has a non-zero exit code', () => {
+    const failed = [steps[0], makeResult({ agent: 'beta', step: 2, exitCode: 1 })]
+    expect(str(renderResult(toolResult('chain', failed), { expanded: false }, theme)).split('\n')[0]).toBe('✗ chain 1/2 steps')
+  })
+
+  it('keeps only the last five items per step when collapsed', () => {
+    const messages = Array.from({ length: 7 }, (_, i) => assistant(textPart(`i${i}`)))
+    const long = [makeResult({ agent: 'alpha', step: 1, messages })]
+    expect(str(renderResult(toolResult('chain', long), { expanded: false }, theme))).toBe(['✓ chain 1/1 steps', '', '─── Step 1: alpha ✓', '... 2 earlier items', 'i2', 'i3', 'i4', 'i5', 'i6', '(Ctrl+O to expand)'].join('\n'))
+  })
+
+  it('builds an expanded container with a per-step block and an aggregate total', () => {
+    const container = renderResult(toolResult('chain', steps), { expanded: true }, theme) as Container
+
+    expect(shapeOf(container)).toEqual(['Text', 'Spacer', 'Text', 'Text', 'Text', 'Spacer', 'Markdown', 'Text', 'Spacer', 'Text', 'Text', 'Spacer', 'Text'])
+    expect(childStr(container, 0)).toBe('✓ chain 2/2 steps')
+    expect(childStr(container, 2)).toBe('─── Step 1: alpha ✓')
+    expect(childStr(container, 3)).toBe('Task: first task')
+    expect(childStr(container, 4)).toBe('→ $ ls')
+    expect(childStr(container, 7)).toBe('1 turn ↑500')
+    expect(childStr(container, 9)).toBe('─── Step 2: beta ✓')
+    expect(childStr(container, 12)).toBe('Total: 1 turn ↑500')
+  })
+})
+
+describe('renderResult parallel mode', () => {
+  const renderResult = getTool().renderResult
+
+  it('renders a running indicator for tasks whose exit code is -1', () => {
+    const results = [makeResult({ agent: 'a', exitCode: -1 }), makeResult({ agent: 'b', messages: [assistant(textPart('done'))] }), makeResult({ agent: 'c', exitCode: 1 })]
+    // Still running, so the expanded flag is ignored and the compact view is used.
+    expect(str(renderResult(toolResult('parallel', results), { expanded: true }, theme))).toBe(['⏳ parallel 2/3 done, 1 running', '', '─── a ⏳', '(running...)', '', '─── b ✓', 'done', '', '─── c ✗', '(no output)'].join('\n'))
+  })
+
+  it('appends the expand hint and a total once nothing is running', () => {
+    const results = [makeResult({ agent: 'a', usage: { ...noUsage, turns: 1, input: 500 } }), makeResult({ agent: 'b', exitCode: 2 })]
+    expect(str(renderResult(toolResult('parallel', results), { expanded: false }, theme))).toBe(['◐ parallel 1/2 tasks', '', '─── a ✓', '(no output)', '', '─── b ✗', '(no output)', '', 'Total: 1 turn ↑500', '(Ctrl+O to expand)'].join('\n'))
+  })
+
+  it('uses the success icon when every task exited cleanly', () => {
+    const results = [makeResult({ agent: 'a' }), makeResult({ agent: 'b' })]
+    expect(str(renderResult(toolResult('parallel', results), { expanded: false }, theme)).split('\n')[0]).toBe('✓ parallel 2/2 tasks')
+  })
+
+  it('builds an expanded container per task with an aggregate total', () => {
+    const results = [makeResult({ agent: 'a', task: 'T', messages: [assistant(toolCallPart('bash', { command: 'ls' }), textPart('hello'))], usage: { ...noUsage, turns: 1, input: 100 } })]
+    const container = renderResult(toolResult('parallel', results), { expanded: true }, theme) as Container
+
+    expect(shapeOf(container)).toEqual(['Text', 'Spacer', 'Text', 'Text', 'Text', 'Spacer', 'Markdown', 'Text', 'Spacer', 'Text'])
+    expect(childStr(container, 0)).toBe('✓ parallel 1/1 tasks')
+    expect(childStr(container, 2)).toBe('─── a ✓')
+    expect(childStr(container, 3)).toBe('Task: T')
+    expect(childStr(container, 4)).toBe('→ $ ls')
+    expect(childStr(container, 7)).toBe('1 turn ↑100')
+    expect(childStr(container, 9)).toBe('Total: 1 turn ↑100')
+  })
+})
+
+describe('subagent execute guards', () => {
+  const ctx = { cwd: '/repo', hasUI: false, isProjectTrusted: () => true, ui: { confirm: async () => true } }
+  let execute: ToolShape['execute']
+
+  beforeEach(() => {
+    discoverAgentsMock.mockReturnValue({
+      agents: [{ name: 'scout', description: 'd', systemPrompt: '', source: 'user', filePath: '/a.md' }],
+      projectAgentsDir: null,
+    })
+    startBackgroundRunMock.mockClear()
+    execute = getTool().execute
+  })
+
+  it('short-circuits to the background status listing when status is set', async () => {
+    const result = await execute('c1', { status: true }, undefined, undefined, ctx)
+    expect(result.content).toEqual([{ type: 'text', text: 'BACKGROUND-STATUS' }])
+    expect(result.details).toMatchObject({ mode: 'single', results: [] })
+    expect(startBackgroundRunMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a call with no mode and lists the available agents', async () => {
+    const result = await execute('c1', {}, undefined, undefined, ctx)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Invalid parameters. Provide exactly one mode.\nAvailable agents: scout (user)' })
+  })
+
+  it('rejects a call combining two modes', async () => {
+    const params = { agent: 'scout', task: 't', tasks: [{ agent: 'scout', task: 'u' }] }
+    const result = await execute('c1', params, undefined, undefined, ctx)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Invalid parameters. Provide exactly one mode.\nAvailable agents: scout (user)' })
+  })
+
+  it('reports none when no agents were discovered', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [], projectAgentsDir: null })
+    const result = await execute('c1', {}, undefined, undefined, ctx)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Invalid parameters. Provide exactly one mode.\nAvailable agents: none' })
+  })
+
+  it('refuses more than eight parallel tasks before spawning anything', async () => {
+    const tasks = Array.from({ length: 9 }, () => ({ agent: 'scout', task: 't' }))
+    const result = await execute('c1', { tasks }, undefined, undefined, ctx)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Too many parallel tasks (9). Max is 8.' })
+    expect(result.details).toMatchObject({ mode: 'parallel', results: [] })
+  })
+
+  it('rejects background mode without a single-mode agent and task', async () => {
+    const result = await execute('c1', { background: true, tasks: [{ agent: 'scout', task: 't' }] }, undefined, undefined, ctx)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'background: true requires single mode (agent + task).' })
+    expect(startBackgroundRunMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a background run for an unknown agent', async () => {
+    const result = await execute('c1', { background: true, agent: 'ghost', task: 't' }, undefined, undefined, ctx)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Unknown agent: "ghost". Available agents: "scout".' })
+    expect(startBackgroundRunMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses untrusted project agents in headless mode', async () => {
+    discoverAgentsMock.mockReturnValue({
+      agents: [{ name: 'repo', description: 'd', systemPrompt: '', source: 'project', filePath: '/p.md' }],
+      projectAgentsDir: '/repo/.pi/agents',
+    })
+    const headless = { ...ctx, isProjectTrusted: () => false }
+    const result = await execute('c1', { agent: 'repo', task: 't' }, undefined, undefined, headless)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Project-local agents (repo) require a trusted project; refusing in non-interactive mode.' })
+  })
+
+  it('cancels when the user declines the project agent confirmation', async () => {
+    discoverAgentsMock.mockReturnValue({
+      agents: [{ name: 'repo', description: 'd', systemPrompt: '', source: 'project', filePath: '/p.md' }],
+      projectAgentsDir: '/repo/.pi/agents',
+    })
+    const interactive = { ...ctx, hasUI: true, isProjectTrusted: () => false, ui: { confirm: async () => false } }
+    const result = await execute('c1', { agent: 'repo', task: 't' }, undefined, undefined, interactive)
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Canceled: project-local agents not approved.' })
+  })
+})

--- a/tests/todo-more.test.ts
+++ b/tests/todo-more.test.ts
@@ -1,0 +1,687 @@
+import { describe, expect, it } from 'vitest'
+
+import todoExtension, { layoutOverlay, type Todo } from '../extensions/todo.ts'
+
+type Content = Array<{ type: string; text?: string }>
+type ToolResult = { content: Content; details?: { action: string; todos: Todo[]; nextId: number; error?: string } }
+type Handler = (event: unknown, ctx: unknown) => Promise<unknown>
+
+interface Component {
+  render: (width: number) => string[]
+  invalidate?: () => void
+  handleInput?: (data: string) => void
+}
+type WidgetFactory = (tui: unknown, theme: unknown) => Component
+
+/** Theme stub that returns its input unchanged, so assertions pin plain text. */
+const theme = { fg: (_role: string, s: string) => s, bold: (s: string) => s } as never
+
+/** truncateToWidth wraps the ellipsis in SGR codes; strip them to compare text. */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: an SGR sequence starts with a literal ESC
+const plain = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '')
+/** Text#render right-pads every line to the requested width. */
+const trimmed = (lines: string[]): string[] => lines.map((l) => l.trimEnd())
+
+interface FakeUI {
+  ui: Record<string, unknown>
+  widgetCalls: Array<{ key: string; content: WidgetFactory | undefined }>
+  renderRequests: () => number
+  notices: Array<{ message: string; type?: string }>
+  customFactories: Array<(tui: unknown, th: unknown, kb: unknown, done: (r: unknown) => void) => Component>
+  /** Build the component from the most recent setWidget factory. */
+  widget: () => Component
+}
+
+const fakeUI = (): FakeUI => {
+  const widgetCalls: FakeUI['widgetCalls'] = []
+  const notices: FakeUI['notices'] = []
+  const customFactories: FakeUI['customFactories'] = []
+  let renders = 0
+  const tui = {
+    requestRender: () => {
+      renders++
+    },
+  }
+  return {
+    widgetCalls,
+    notices,
+    customFactories,
+    renderRequests: () => renders,
+    widget: () => {
+      const last = widgetCalls.at(-1)?.content
+      if (!last) throw new Error('no widget factory registered')
+      return last(tui, theme)
+    },
+    ui: {
+      setWidget: (key: string, content: WidgetFactory | undefined) => widgetCalls.push({ key, content }),
+      notify: (message: string, type?: string) => notices.push({ message, type }),
+      custom: async (factory: FakeUI['customFactories'][number]) => {
+        customFactories.push(factory)
+        return undefined
+      },
+    },
+  }
+}
+
+interface Harness {
+  call: (params: Record<string, unknown>) => Promise<ToolResult>
+  fire: (name: string, event: unknown, ctx: unknown) => Promise<unknown>
+  renderCall: (args: Record<string, unknown>) => string[]
+  renderResult: (result: ToolResult, expanded: boolean) => string[]
+  commandNames: string[]
+  runCommand: (name: string, ctx: unknown) => Promise<void>
+}
+
+/** Fresh extension instance so module-level todo state is isolated per test. */
+const setup = (): Harness => {
+  const handlers = new Map<string, Handler>()
+  const commands = new Map<string, { description: string; handler: (args: string, ctx: unknown) => Promise<void> }>()
+  let tool: Record<string, (...a: never[]) => unknown> | undefined
+
+  todoExtension({
+    on: (name: string, fn: Handler) => handlers.set(name, fn),
+    registerCommand: (name: string, config: { description: string; handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, config),
+    registerTool: (t: Record<string, unknown>) => {
+      if (t.name === 'todo') tool = t as Record<string, (...a: never[]) => unknown>
+    },
+  } as never)
+  if (!tool) throw new Error('todo tool was not registered')
+  const t = tool
+
+  return {
+    call: (params) => (t.execute as never as (id: string, p: unknown) => Promise<ToolResult>)('call-1', params),
+    fire: async (name, event, ctx) => {
+      const handler = handlers.get(name)
+      if (!handler) throw new Error(`no handler for ${name}`)
+      return handler(event, ctx)
+    },
+    renderCall: (args) => trimmed((t.renderCall as never as (a: unknown, th: unknown, c: unknown) => Component)(args, theme, {}).render(200)),
+    renderResult: (result, expanded) => trimmed((t.renderResult as never as (r: unknown, o: unknown, th: unknown, c: unknown) => Component)(result, { expanded }, theme, {}).render(200)),
+    commandNames: [...commands.keys()],
+    runCommand: async (name, ctx) => {
+      const config = commands.get(name)
+      if (!config) throw new Error(`no command ${name}`)
+      await config.handler('', ctx)
+    },
+  }
+}
+
+const pending = (id: number, text: string): Todo => ({ id, text, status: 'pending' })
+const completed = (id: number, text: string): Todo => ({ id, text, status: 'completed' })
+
+/** A session entry shaped like a persisted todo tool result. */
+const resultEntry = (todos: unknown[], nextId: number) => ({
+  type: 'message',
+  message: { role: 'toolResult', toolName: 'todo', details: { action: 'add', todos, nextId } },
+})
+
+const branchCtx = (entries: unknown[], ui: FakeUI, hasUI = true) => ({
+  hasUI,
+  ui: ui.ui,
+  sessionManager: { getBranch: () => entries },
+})
+
+describe('layoutOverlay boundaries', () => {
+  it('returns an empty layout for an empty list at a zero budget', () => {
+    expect(layoutOverlay([], 0)).toEqual({ visible: [], hiddenCompleted: 0, truncatedTail: 0 })
+  })
+
+  it('shows the whole list when its length exactly equals the budget', () => {
+    const todos = [pending(1, 'a'), pending(2, 'b'), pending(3, 'c')]
+    expect(layoutOverlay(todos, 3)).toEqual({ visible: todos, hiddenCompleted: 0, truncatedTail: 0 })
+  })
+
+  it('reserves the whole single-row budget for the summary when one todo overflows', () => {
+    // budget 1 leaves innerBudget 0, so nothing is visible and both are counted.
+    expect(layoutOverlay([pending(1, 'a'), pending(2, 'b')], 1)).toEqual({ visible: [], hiddenCompleted: 0, truncatedTail: 2 })
+  })
+
+  it('hides every completed todo when the budget leaves no inner rows', () => {
+    expect(layoutOverlay([completed(1, 'a'), completed(2, 'b')], 1)).toEqual({ visible: [], hiddenCompleted: 2, truncatedTail: 0 })
+  })
+
+  it('counts both hidden completed and a truncated pending tail together', () => {
+    // budget 6 -> innerBudget 5; 6 pending exceed it, so 5 show, 1 truncates, 2 completed hide.
+    const todos = [...Array.from({ length: 6 }, (_, i) => pending(i + 1, `p${i + 1}`)), completed(7, 'x'), completed(8, 'y')]
+    const layout = layoutOverlay(todos, 6)
+    expect(layout.visible.map((t) => t.id)).toEqual([1, 2, 3, 4, 5])
+    expect(layout.hiddenCompleted).toBe(2)
+    expect(layout.truncatedTail).toBe(1)
+  })
+})
+
+describe('session replay', () => {
+  it('rebuilds todos and the id counter from the last todo result on the branch', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire(
+      'session_start',
+      {},
+      branchCtx(
+        [
+          resultEntry([{ id: 1, text: 'a', status: 'completed' }], 2),
+          resultEntry(
+            [
+              { id: 1, text: 'a', status: 'completed' },
+              { id: 2, text: 'b', status: 'pending' },
+            ],
+            3,
+          ),
+        ],
+        ui,
+      ),
+    )
+
+    const listed = await h.call({ action: 'list' })
+    expect(listed.content[0].text).toBe('[x] #1: a\n[ ] #2: b')
+    const added = await h.call({ action: 'add', text: 'c' })
+    expect(added.details?.todos.at(-1)?.id).toBe(3)
+  })
+
+  it('migrates legacy done flags found on the branch', async () => {
+    const h = setup()
+    await h.fire('session_start', {}, branchCtx([resultEntry([{ id: 1, text: 'old', done: true }], 2)], fakeUI()))
+    expect((await h.call({ action: 'list' })).content[0].text).toBe('[x] #1: old')
+  })
+
+  it('ignores branch entries that are not todo tool results', async () => {
+    const h = setup()
+    const entries = [
+      { type: 'checkpoint' },
+      { type: 'message', message: { role: 'assistant', content: 'hi' } },
+      { type: 'message', message: { role: 'toolResult', toolName: 'bash', details: { action: 'add', todos: [{ id: 9, text: 'nope', status: 'pending' }], nextId: 10 } } },
+      resultEntry([{ id: 1, text: 'kept', status: 'pending' }], 2),
+      { type: 'message', message: { role: 'toolResult', toolName: 'todo', details: undefined } },
+    ]
+    await h.fire('session_start', {}, branchCtx(entries, fakeUI()))
+    expect((await h.call({ action: 'list' })).content[0].text).toBe('[ ] #1: kept')
+  })
+
+  it('replaces existing todos on a session_tree replay', async () => {
+    const h = setup()
+    await h.call({ action: 'add', text: 'local' })
+    await h.fire('session_tree', {}, branchCtx([resultEntry([{ id: 7, text: 'branch', status: 'pending' }], 8)], fakeUI()))
+    expect((await h.call({ action: 'list' })).content[0].text).toBe('[ ] #7: branch')
+  })
+
+  it('keeps the current todos when a compaction replay hits a stale context', async () => {
+    const h = setup()
+    await h.call({ action: 'add', text: 'survivor' })
+    const staleCtx = {
+      hasUI: false,
+      ui: fakeUI().ui,
+      sessionManager: {
+        getBranch: () => {
+          throw new Error('ExtensionContext is stale after session replacement')
+        },
+      },
+    }
+    await expect(h.fire('session_compact', {}, staleCtx)).resolves.toBeUndefined()
+    expect((await h.call({ action: 'list' })).content[0].text).toBe('[ ] #1: survivor')
+  })
+
+  it('propagates a replay error that is not a stale context', async () => {
+    const h = setup()
+    const brokenCtx = {
+      hasUI: false,
+      ui: fakeUI().ui,
+      sessionManager: {
+        getBranch: () => {
+          throw new Error('disk exploded')
+        },
+      },
+    }
+    await expect(h.fire('session_tree', {}, brokenCtx)).rejects.toThrow('disk exploded')
+  })
+})
+
+describe('todo overlay widget', () => {
+  it('registers no widget while the todo list is empty', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([], ui))
+    expect(ui.widgetCalls).toEqual([])
+  })
+
+  it('registers the widget above the editor once the branch replays todos', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([{ id: 1, text: 'a', status: 'pending' }], 2)], ui))
+    expect(ui.widgetCalls.map((c) => c.key)).toEqual(['todos'])
+  })
+
+  it('registers no widget when the session has no UI', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([{ id: 1, text: 'a', status: 'pending' }], 2)], ui, false))
+    expect(ui.widgetCalls).toEqual([])
+  })
+
+  it('draws a heading, one row per todo and a trailing spacer', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([pending(1, 'alpha'), completed(2, 'beta')], 3)], ui))
+    expect(ui.widget().render(60)).toEqual(['● Todos (1/2)', '├─ ○ alpha', '└─ ✓ beta', ''])
+  })
+
+  it('marks the heading as inactive once every todo is completed', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([completed(1, 'a')], 2)], ui))
+    expect(ui.widget().render(60)[0]).toBe('○ Todos (1/1)')
+  })
+
+  it('shows the activeForm label instead of the text for the in_progress todo', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    const todo = { id: 1, text: 'write tests', status: 'in_progress', activeForm: 'Writing tests' }
+    await h.fire('session_start', {}, branchCtx([resultEntry([todo], 2)], ui))
+    expect(ui.widget().render(60)[1]).toBe('└─ ◐ Writing tests')
+  })
+
+  it('falls back to the todo text when an in_progress todo has no activeForm', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([{ id: 1, text: 'write tests', status: 'in_progress' }], 2)], ui))
+    expect(ui.widget().render(60)[1]).toBe('└─ ◐ write tests')
+  })
+
+  it('summarises the pending tail it could not fit', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    // 12 todos against the 11-row content budget: 10 rows show, 2 pending truncate.
+    const todos = Array.from({ length: 12 }, (_, i) => pending(i + 1, `p${i + 1}`))
+    await h.fire('session_start', {}, branchCtx([resultEntry(todos, 13)], ui))
+    const lines = ui.widget().render(60)
+    expect(lines[0]).toBe('● Todos (0/12)')
+    expect(lines.slice(1, 11)).toEqual(todos.slice(0, 10).map((t) => `├─ ○ ${t.text}`))
+    expect(lines[11]).toBe('└─ +2 more (2 pending)')
+    expect(lines[12]).toBe('')
+  })
+
+  it('summarises the completed todos it dropped to make room', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    // 8 pending + 4 completed: all pending fit, 2 completed fill the budget, 2 hide.
+    const todos = [...Array.from({ length: 8 }, (_, i) => pending(i + 1, `p${i + 1}`)), ...Array.from({ length: 4 }, (_, i) => completed(i + 9, `c${i + 1}`))]
+    await h.fire('session_start', {}, branchCtx([resultEntry(todos, 13)], ui))
+    const lines = ui.widget().render(60)
+    expect(lines.at(-2)).toBe('└─ +2 more (2 completed)')
+  })
+
+  it('names both hidden groups in the summary row', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    // 11 pending + 2 completed: 10 pending show, 1 pending truncates, 2 completed hide.
+    const todos = [...Array.from({ length: 11 }, (_, i) => pending(i + 1, `p${i + 1}`)), completed(12, 'x'), completed(13, 'y')]
+    await h.fire('session_start', {}, branchCtx([resultEntry(todos, 14)], ui))
+    expect(ui.widget().render(60).at(-2)).toBe('└─ +3 more (2 completed, 1 pending)')
+  })
+
+  it('truncates a row that is wider than the terminal', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([pending(1, 'ABCDEFGHIJKLMNOP')], 2)], ui))
+    // "└─ ○ " is 5 columns wide, leaving 2 characters plus the ellipsis at width 8.
+    expect(plain(ui.widget().render(8)[1])).toBe('└─ ○ AB…')
+  })
+
+  it('renders no lines when the list emptied out from under a live component', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([pending(1, 'a')], 2)], ui))
+    const component = ui.widget()
+    await h.call({ action: 'clear' })
+    expect(component.render(60)).toEqual([])
+  })
+
+  it('re-renders through the TUI instead of re-registering an already-registered widget', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([pending(1, 'a')], 2)], ui))
+    ui.widget()
+    await h.call({ action: 'add', text: 'b' })
+    await h.fire('tool_execution_end', { toolName: 'todo', isError: false }, {})
+    expect(ui.widgetCalls).toHaveLength(1)
+    expect(ui.renderRequests()).toBe(1)
+  })
+
+  it('re-registers the widget after the TUI invalidates the component', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([pending(1, 'a')], 2)], ui))
+    ui.widget().invalidate?.()
+    await h.fire('tool_execution_end', { toolName: 'todo', isError: false }, {})
+    expect(ui.widgetCalls).toHaveLength(2)
+    expect(ui.renderRequests()).toBe(0)
+  })
+
+  it('clears the widget when the last todo is deleted', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([pending(1, 'a')], 2)], ui))
+    await h.call({ action: 'delete', id: 1 })
+    await h.fire('tool_execution_end', { toolName: 'todo', isError: false }, {})
+    expect(ui.widgetCalls.at(-1)).toEqual({ key: 'todos', content: undefined })
+  })
+
+  it('ignores tool_execution_end for other tools', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([], ui))
+    await h.call({ action: 'add', text: 'a' })
+    await h.fire('tool_execution_end', { toolName: 'bash', isError: false }, {})
+    expect(ui.widgetCalls).toEqual([])
+  })
+
+  it('ignores a failed todo execution', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([], ui))
+    await h.call({ action: 'add', text: 'a' })
+    await h.fire('tool_execution_end', { toolName: 'todo', isError: true }, {})
+    expect(ui.widgetCalls).toEqual([])
+  })
+
+  it('clears the widget on shutdown and stops updating afterwards', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.fire('session_start', {}, branchCtx([resultEntry([pending(1, 'a')], 2)], ui))
+    await h.fire('session_shutdown', {}, {})
+    expect(ui.widgetCalls.at(-1)).toEqual({ key: 'todos', content: undefined })
+
+    await h.call({ action: 'add', text: 'b' })
+    await h.fire('tool_execution_end', { toolName: 'todo', isError: false }, {})
+    expect(ui.widgetCalls).toHaveLength(2)
+  })
+
+  it('re-registers the widget when a reload swaps the UI context', async () => {
+    const h = setup()
+    const first = fakeUI()
+    const second = fakeUI()
+    const entries = [resultEntry([pending(1, 'a')], 2)]
+    await h.fire('session_start', {}, branchCtx(entries, first))
+    await h.fire('session_start', {}, branchCtx(entries, second))
+    expect(first.widgetCalls).toHaveLength(1)
+    expect(second.widgetCalls.map((c) => c.key)).toEqual(['todos'])
+  })
+
+  it('does not re-register the widget when the same UI context restarts', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    const entries = [resultEntry([pending(1, 'a')], 2)]
+    const ctx = branchCtx(entries, ui)
+    await h.fire('session_start', {}, ctx)
+    ui.widget()
+    await h.fire('session_start', {}, ctx)
+    expect(ui.widgetCalls).toHaveLength(1)
+    expect(ui.renderRequests()).toBe(1)
+  })
+})
+
+describe('renderCall', () => {
+  it('renders the action alone when no other argument is set', () => {
+    expect(setup().renderCall({ action: 'list' })).toEqual(['todo list'])
+  })
+
+  it('appends the id, text and activeForm in that order', () => {
+    expect(setup().renderCall({ action: 'add', id: 3, text: 'write tests', activeForm: 'Writing tests' })).toEqual(['todo add #3 "write tests" (Writing tests)'])
+  })
+
+  it('renders id zero rather than treating it as absent', () => {
+    expect(setup().renderCall({ action: 'complete', id: 0 })).toEqual(['todo complete #0'])
+  })
+})
+
+describe('renderResult', () => {
+  const result = (text: string, details?: Record<string, unknown>): ToolResult => ({ content: [{ type: 'text', text }], details: details as never })
+
+  it('falls back to the message text when the result has no details', () => {
+    expect(setup().renderResult({ content: [{ type: 'text', text: 'raw output' }] }, false)).toEqual(['raw output'])
+  })
+
+  it('renders nothing when a detail-less result carries no text content', () => {
+    expect(setup().renderResult({ content: [{ type: 'image' }] }, false)).toEqual([])
+  })
+
+  it('renders the error message for a failed call', () => {
+    expect(setup().renderResult(result('Error: #9 not found', { action: 'start', todos: [], nextId: 1, error: '#9 not found' }), false)).toEqual(['Error: #9 not found'])
+  })
+
+  it('renders an empty-list placeholder for a list action with no todos', () => {
+    expect(setup().renderResult(result('No todos', { action: 'list', todos: [], nextId: 1 }), false)).toEqual(['No todos'])
+  })
+
+  it('renders a count header and one glyph row per todo', () => {
+    const todos = [pending(1, 'a'), completed(2, 'b'), { id: 3, text: 'c', status: 'in_progress' }]
+    expect(setup().renderResult(result('...', { action: 'list', todos, nextId: 4 }), false)).toEqual(['3 todo(s):', '○ #1 a', '✓ #2 b', '◐ #3 c'])
+  })
+
+  it('caps a collapsed list at five rows and counts the remainder', () => {
+    const todos = Array.from({ length: 7 }, (_, i) => pending(i + 1, `t${i + 1}`))
+    const lines = setup().renderResult(result('...', { action: 'list', todos, nextId: 8 }), false)
+    expect(lines).toEqual(['7 todo(s):', '○ #1 t1', '○ #2 t2', '○ #3 t3', '○ #4 t4', '○ #5 t5', '... 2 more'])
+  })
+
+  it('shows every row and no remainder line when expanded', () => {
+    const todos = Array.from({ length: 7 }, (_, i) => pending(i + 1, `t${i + 1}`))
+    const lines = setup().renderResult(result('...', { action: 'list', todos, nextId: 8 }), true)
+    expect(lines).toHaveLength(8)
+    expect(lines.at(-1)).toBe('○ #7 t7')
+  })
+
+  it('shows exactly five rows without a remainder line at the collapse boundary', () => {
+    const todos = Array.from({ length: 5 }, (_, i) => pending(i + 1, `t${i + 1}`))
+    const lines = setup().renderResult(result('...', { action: 'list', todos, nextId: 6 }), false)
+    expect(lines).toEqual(['5 todo(s):', '○ #1 t1', '○ #2 t2', '○ #3 t3', '○ #4 t4', '○ #5 t5'])
+  })
+
+  it('prefixes a start result with the in_progress glyph', () => {
+    expect(setup().renderResult(result('Started #1: a', { action: 'start', todos: [], nextId: 2 }), false)).toEqual(['◐ Started #1: a'])
+  })
+
+  it('prefixes any other successful result with the success glyph', () => {
+    expect(setup().renderResult(result('Added todo #1: a', { action: 'add', todos: [], nextId: 2 }), false)).toEqual(['✓ Added todo #1: a'])
+  })
+
+  it('renders only the glyph when a non-list result has no text content', () => {
+    expect(setup().renderResult({ content: [], details: { action: 'clear', todos: [], nextId: 1 } as never }, false)).toEqual(['✓'])
+  })
+})
+
+describe('/todos command', () => {
+  it('is registered under the name todos', () => {
+    expect(setup().commandNames).toEqual(['todos'])
+  })
+
+  it('notifies instead of opening the list outside interactive mode', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.runCommand('todos', { hasUI: false, ui: ui.ui })
+    expect(ui.notices).toEqual([{ message: '/todos requires interactive mode', type: 'error' }])
+    expect(ui.customFactories).toHaveLength(0)
+  })
+
+  it('renders an invitation when the list is empty', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    const lines = ui.customFactories[0](null, theme, null, () => {}).render(60)
+    expect(lines[3]).toBe('  No todos yet. Ask the agent to add some!')
+    expect(lines.at(-2)).toBe('  Press Escape to close')
+  })
+
+  it('renders a completion count, a row per todo and the activeForm suffix', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.call({ action: 'add', text: 'first' })
+    await h.call({ action: 'add', text: 'second' })
+    await h.call({ action: 'complete', id: 1 })
+    await h.call({ action: 'start', id: 2, activeForm: 'Doing second' })
+    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+
+    const lines = ui.customFactories[0](null, theme, null, () => {}).render(60)
+    expect(lines[0]).toBe('')
+    expect(lines[1]).toBe(`${'─'.repeat(3)} Todos ${'─'.repeat(50)}`)
+    expect(lines[3]).toBe('  1/2 completed')
+    expect(lines[5]).toBe('  ✓ #1 first')
+    expect(lines[6]).toBe('  ◐ #2 second (Doing second)')
+  })
+
+  it('closes the list on escape', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    let closed = 0
+    const component = ui.customFactories[0](null, theme, null, () => {
+      closed++
+    })
+    component.handleInput?.('\x1b')
+    expect(closed).toBe(1)
+  })
+
+  it('closes the list on ctrl+c', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    let closed = 0
+    const component = ui.customFactories[0](null, theme, null, () => {
+      closed++
+    })
+    component.handleInput?.('\x03')
+    expect(closed).toBe(1)
+  })
+
+  it('ignores unrelated keystrokes', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    let closed = 0
+    const component = ui.customFactories[0](null, theme, null, () => {
+      closed++
+    })
+    component.handleInput?.('x')
+    expect(closed).toBe(0)
+  })
+
+  it('reuses the cached lines for a repeated width and drops them on invalidate', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.call({ action: 'add', text: 'first' })
+    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    const component = ui.customFactories[0](null, theme, null, () => {})
+
+    const first = component.render(60)
+    expect(component.render(60)).toBe(first)
+    component.invalidate?.()
+    expect(component.render(60)).not.toBe(first)
+  })
+
+  it('re-lays out when the width changes', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.call({ action: 'add', text: 'first' })
+    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    const component = ui.customFactories[0](null, theme, null, () => {})
+
+    component.render(60)
+    expect(component.render(20)[1]).toBe(`${'─'.repeat(3)} Todos ${'─'.repeat(10)}`)
+  })
+})
+
+describe('todo tool argument validation', () => {
+  it('rejects start without an id', async () => {
+    const result = await setup().call({ action: 'start' })
+    expect(result.details?.error).toBe('id required for start')
+  })
+
+  it('rejects complete without an id', async () => {
+    const result = await setup().call({ action: 'complete' })
+    expect(result.details?.error).toBe('id required for complete')
+  })
+
+  it('rejects delete without an id', async () => {
+    const result = await setup().call({ action: 'delete' })
+    expect(result.details?.error).toBe('id required for delete')
+  })
+
+  it('rejects add with empty text', async () => {
+    const result = await setup().call({ action: 'add', text: '' })
+    expect(result.details?.error).toBe('text required for add')
+    expect(result.details?.todos).toEqual([])
+  })
+
+  it('stores whitespace-only text verbatim', async () => {
+    const result = await setup().call({ action: 'add', text: '   ' })
+    expect(result.details?.todos).toEqual([{ id: 1, text: '   ', status: 'pending', activeForm: undefined }])
+  })
+
+  it('keeps an existing activeForm when start is called again without one', async () => {
+    const h = setup()
+    await h.call({ action: 'add', text: 'a' })
+    await h.call({ action: 'start', id: 1, activeForm: 'Doing a' })
+    await h.call({ action: 'complete', id: 1 })
+    const result = await h.call({ action: 'start', id: 1 })
+    expect(result.details?.todos[0]).toEqual({ id: 1, text: 'a', status: 'in_progress', activeForm: 'Doing a' })
+  })
+
+  it('demotes every other in_progress todo, naming each in the message', async () => {
+    const h = setup()
+    // Replay seeds two simultaneous in_progress todos, which start must collapse.
+    await h.fire(
+      'session_start',
+      {},
+      branchCtx(
+        [
+          resultEntry(
+            [
+              { id: 1, text: 'a', status: 'in_progress' },
+              { id: 2, text: 'b', status: 'in_progress' },
+              { id: 3, text: 'c', status: 'pending' },
+            ],
+            4,
+          ),
+        ],
+        fakeUI(),
+      ),
+    )
+    const result = await h.call({ action: 'start', id: 3 })
+    expect(result.content[0].text).toBe('Started #3: c (moved #1, #2 back to pending)')
+    expect(result.details?.todos.map((t) => t.status)).toEqual(['pending', 'pending', 'in_progress'])
+  })
+
+  it('marks an in_progress todo with [>] in the list output', async () => {
+    const h = setup()
+    await h.call({ action: 'add', text: 'a' })
+    await h.call({ action: 'start', id: 1 })
+    expect((await h.call({ action: 'list' })).content[0].text).toBe('[>] #1: a')
+  })
+
+  it('reports zero cleared todos for an empty list', async () => {
+    const result = await setup().call({ action: 'clear' })
+    expect(result.content[0].text).toBe('Cleared 0 todos')
+  })
+
+  it('deletes the first match when the branch replayed duplicate ids', async () => {
+    const h = setup()
+    await h.fire(
+      'session_start',
+      {},
+      branchCtx(
+        [
+          resultEntry(
+            [
+              { id: 1, text: 'first', status: 'pending' },
+              { id: 1, text: 'second', status: 'pending' },
+            ],
+            2,
+          ),
+        ],
+        fakeUI(),
+      ),
+    )
+    const result = await h.call({ action: 'delete', id: 1 })
+    expect(result.content[0].text).toBe('Deleted #1: first')
+    expect(result.details?.todos).toEqual([{ id: 1, text: 'second', status: 'pending' }])
+  })
+})

--- a/tests/todo-more.test.ts
+++ b/tests/todo-more.test.ts
@@ -571,10 +571,12 @@ describe('/todos command', () => {
     await h.runCommand('todos', { hasUI: true, ui: ui.ui })
     const component = ui.customFactories[0](null, theme, null, () => {})
 
-    const first = component.render(60)
-    expect(component.render(60)).toBe(first)
+    const before = component.render(60)
+    await h.call({ action: 'add', text: 'second' })
+    expect(component.render(60)).toEqual(before)
+
     component.invalidate?.()
-    expect(component.render(60)).not.toBe(first)
+    expect(component.render(60).join('\n')).toContain('second')
   })
 
   it('re-lays out when the width changes', async () => {

--- a/tests/web-more.test.ts
+++ b/tests/web-more.test.ts
@@ -118,7 +118,16 @@ describe('web_fetch responses', () => {
   })
 
   it('treats a missing content-type as non-html and skips html stripping', async () => {
-    fetchMock.mockResolvedValue(respond('<b>raw</b>', { contentType: null }))
+    // Response() synthesizes text/plain for a string body, so a header-less
+    // reply has to be duck-typed to actually reach the `?? ''` fallback.
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      url: 'https://example.com/unknown',
+      body: null,
+      text: async () => '<b>raw</b>',
+    } as unknown as Response)
     const result = await setup().fetchUrl('https://example.com/unknown')
     expect(result.content[0].text).toBe('<b>raw</b>')
   })

--- a/tests/web-more.test.ts
+++ b/tests/web-more.test.ts
@@ -1,0 +1,291 @@
+import { lookup } from 'node:dns/promises'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import webExtension from '../extensions/web.ts'
+
+vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }))
+
+type ToolResult = { content: Array<{ type: string; text: string }>; details: Record<string, unknown> }
+type Execute = (id: string, params: Record<string, unknown>) => Promise<ToolResult>
+
+/** Register the extension against a stub API and expose both tools by name. */
+const setup = (): { search: (params: Record<string, unknown>) => Promise<ToolResult>; fetchUrl: (url: string) => Promise<ToolResult> } => {
+  const tools = new Map<string, Execute>()
+  webExtension({
+    on: () => {},
+    registerCommand: () => {},
+    registerTool: (tool: { name: string; execute: Execute }) => tools.set(tool.name, tool.execute),
+  } as never)
+  const search = tools.get('web_search')
+  const fetchUrl = tools.get('web_fetch')
+  if (!search || !fetchUrl) throw new Error('web tools were not registered')
+  return { search: (params) => search('call-1', params), fetchUrl: (url) => fetchUrl('call-1', { url }) }
+}
+
+const lookupMock = vi.mocked(lookup)
+const fetchMock = vi.fn()
+const originalFetch = globalThis.fetch
+
+const respond = (body: string | ReadableStream<Uint8Array> | null, opts: { status?: number; contentType?: string | null; location?: string } = {}): Response => {
+  const headers = new Headers()
+  if (opts.contentType !== null) headers.set('content-type', opts.contentType ?? 'text/html; charset=utf-8')
+  if (opts.location) headers.set('location', opts.location)
+  return new Response(body, { status: opts.status ?? 200, headers })
+}
+
+const publicAddresses = [{ address: '93.184.216.34', family: 4 }]
+
+const requestUrls = (): string[] => fetchMock.mock.calls.map((call) => String(call[0]))
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  lookupMock.mockReset()
+  lookupMock.mockResolvedValue(publicAddresses as never)
+  globalThis.fetch = fetchMock as unknown as typeof fetch
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+describe('web_fetch scheme validation', () => {
+  it.each(['file:///etc/passwd', 'ftp://example.com/x', 'javascript:alert(1)', 'data:text/html,<b>x</b>', '/relative/path', 'example.com', 'HTTPS://example.com'])('rejects %s without touching DNS or the network', async (url) => {
+    const result = await setup().fetchUrl(url)
+    expect(result.content).toEqual([{ type: 'text', text: 'Only http(s) URLs are supported.' }])
+    expect(lookupMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it.each(['http://example.com/a', 'https://example.com/a'])('accepts %s', async (url) => {
+    fetchMock.mockResolvedValue(respond('ok', { contentType: 'text/plain' }))
+    const result = await setup().fetchUrl(url)
+    expect(result.content[0].text).toBe('ok')
+    expect(requestUrls()).toEqual([url])
+  })
+})
+
+describe('web_fetch responses', () => {
+  it('converts an html body to readable text and drops scripts', async () => {
+    fetchMock.mockResolvedValue(respond('<html><script>evil()</script><body><h1>Hi</h1><p>One &amp; two</p></body></html>'))
+    const result = await setup().fetchUrl('https://example.com/page')
+    expect(result.content[0].text).toBe('Hi\nOne & two')
+    expect(result.details).toEqual({})
+  })
+
+  it('returns non-html bodies verbatim, capped at 30000 chars with no truncation marker', async () => {
+    fetchMock.mockResolvedValue(respond('x'.repeat(40_000), { contentType: 'application/json' }))
+    const result = await setup().fetchUrl('https://example.com/data.json')
+    expect(result.content[0].text).toBe('x'.repeat(30_000))
+  })
+
+  it('caps the raw download at 200000 chars before the 30000 char output cap', async () => {
+    fetchMock.mockResolvedValue(respond('a'.repeat(250_000)))
+    const result = await setup().fetchUrl('https://example.com/huge')
+    // 250k downloaded -> 200k kept by readCapped -> 30k emitted, 170k reported as dropped.
+    expect(result.content[0].text).toBe(`${'a'.repeat(30_000)}\n[truncated 170000 chars]`)
+  })
+
+  it('reassembles multi-byte characters split across stream chunks', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([0x63, 0x61, 0x66, 0xc3])) // "caf" + first byte of "é"
+        controller.enqueue(new Uint8Array([0xa9, 0x21])) // second byte of "é" + "!"
+        controller.close()
+      },
+    })
+    fetchMock.mockResolvedValue(respond(stream, { contentType: 'text/plain' }))
+    const result = await setup().fetchUrl('https://example.com/utf8')
+    expect(result.content[0].text).toBe('café!')
+  })
+
+  it('falls back to response.text() when the response exposes no body stream', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: null,
+      headers: new Headers({ 'content-type': 'text/plain' }),
+      text: async () => 'body-less payload',
+    })
+    const result = await setup().fetchUrl('https://example.com/nobody')
+    expect(result.content[0].text).toBe('body-less payload')
+  })
+
+  it('reports an empty body as (empty response)', async () => {
+    fetchMock.mockResolvedValue(respond('', { contentType: 'text/plain' }))
+    const result = await setup().fetchUrl('https://example.com/empty')
+    expect(result.content[0].text).toBe('(empty response)')
+  })
+
+  it('treats a missing content-type as non-html and skips html stripping', async () => {
+    fetchMock.mockResolvedValue(respond('<b>raw</b>', { contentType: null }))
+    const result = await setup().fetchUrl('https://example.com/unknown')
+    expect(result.content[0].text).toBe('<b>raw</b>')
+  })
+
+  it('sends the pi user agent, a timeout signal, and manual redirect handling', async () => {
+    fetchMock.mockResolvedValue(respond('ok', { contentType: 'text/plain' }))
+    await setup().fetchUrl('https://example.com/a')
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.headers).toEqual({ 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) pi-code-web/0.1' })
+    expect(init.redirect).toBe('manual')
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+    expect((init.signal as AbortSignal).aborted).toBe(false)
+  })
+})
+
+describe('web_fetch failures', () => {
+  it.each([404, 410, 500, 503])('surfaces HTTP %i as an error naming the status and url', async (status) => {
+    fetchMock.mockResolvedValue(respond('nope', { status }))
+    await expect(setup().fetchUrl('https://example.com/missing')).rejects.toThrow(`HTTP ${status} for https://example.com/missing`)
+  })
+
+  it('propagates a network-level fetch rejection', async () => {
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'))
+    await expect(setup().fetchUrl('https://example.com/a')).rejects.toThrow('fetch failed')
+  })
+
+  it('propagates an abort when the request times out', async () => {
+    fetchMock.mockRejectedValue(new DOMException('The operation was aborted due to timeout', 'TimeoutError'))
+    await expect(setup().fetchUrl('https://example.com/slow')).rejects.toThrow('The operation was aborted due to timeout')
+  })
+
+  it('propagates a malformed absolute url before any lookup', async () => {
+    await expect(setup().fetchUrl('https://')).rejects.toThrow(/Invalid URL/)
+    expect(lookupMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('web_fetch SSRF guard', () => {
+  it('refuses a host that resolves to a private address, naming host and address', async () => {
+    lookupMock.mockResolvedValue([{ address: '10.0.0.5', family: 4 }] as never)
+    await expect(setup().fetchUrl('http://intranet.test/secret')).rejects.toThrow('refusing to fetch private/internal address for intranet.test (10.0.0.5)')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses when any address in a multi-record answer is private', async () => {
+    lookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '169.254.169.254', family: 4 },
+    ] as never)
+    await expect(setup().fetchUrl('http://metadata.test/')).rejects.toThrow('refusing to fetch private/internal address for metadata.test (169.254.169.254)')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('strips brackets from an ipv6 literal host before resolving it', async () => {
+    lookupMock.mockResolvedValue([{ address: '::1', family: 6 }] as never)
+    await expect(setup().fetchUrl('http://[::1]:8080/admin')).rejects.toThrow('refusing to fetch private/internal address for [::1] (::1)')
+    expect(lookupMock).toHaveBeenCalledWith('::1', { all: true, verbatim: true })
+  })
+
+  it('asks dns for every hostname with all+verbatim and allows public answers through', async () => {
+    fetchMock.mockResolvedValue(respond('fine', { contentType: 'text/plain' }))
+    const result = await setup().fetchUrl('https://example.com/a')
+    expect(lookupMock).toHaveBeenCalledWith('example.com', { all: true, verbatim: true })
+    expect(result.content[0].text).toBe('fine')
+  })
+
+  it('propagates a dns resolution failure', async () => {
+    lookupMock.mockRejectedValue(Object.assign(new Error('getaddrinfo ENOTFOUND nope.invalid'), { code: 'ENOTFOUND' }))
+    await expect(setup().fetchUrl('https://nope.invalid/')).rejects.toThrow('ENOTFOUND')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('web_fetch redirects', () => {
+  it('follows a relative redirect resolved against the current url and re-checks dns', async () => {
+    fetchMock.mockResolvedValueOnce(respond(null, { status: 302, location: '/moved/here' })).mockResolvedValueOnce(respond('arrived', { contentType: 'text/plain' }))
+    const result = await setup().fetchUrl('https://example.com/start/page')
+    expect(requestUrls()).toEqual(['https://example.com/start/page', 'https://example.com/moved/here'])
+    expect(lookupMock).toHaveBeenCalledTimes(2)
+    expect(result.content[0].text).toBe('arrived')
+  })
+
+  it('re-applies the SSRF guard to the redirect target', async () => {
+    fetchMock.mockResolvedValueOnce(respond(null, { status: 301, location: 'http://internal.test/' }))
+    lookupMock.mockResolvedValueOnce(publicAddresses as never).mockResolvedValueOnce([{ address: '192.168.1.9', family: 4 }] as never)
+    await expect(setup().fetchUrl('https://example.com/a')).rejects.toThrow('refusing to fetch private/internal address for internal.test (192.168.1.9)')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('errors when a redirect omits the location header', async () => {
+    fetchMock.mockResolvedValue(respond(null, { status: 302 }))
+    await expect(setup().fetchUrl('https://example.com/a')).rejects.toThrow('redirect without location from example.com')
+  })
+
+  it('gives up after 6 hops with a too many redirects error', async () => {
+    fetchMock.mockResolvedValue(respond(null, { status: 307, location: 'https://example.com/loop' }))
+    await expect(setup().fetchUrl('https://example.com/loop')).rejects.toThrow('too many redirects for https://example.com/loop')
+    expect(fetchMock).toHaveBeenCalledTimes(6)
+  })
+
+  it('treats status 299 as a body, not a redirect, even with a location header', async () => {
+    fetchMock.mockResolvedValue(respond('body', { status: 299, contentType: 'text/plain', location: 'https://elsewhere.test/' }))
+    const result = await setup().fetchUrl('https://example.com/a')
+    expect(result.content[0].text).toBe('body')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats status 400 as an error, not a redirect, even with a location header', async () => {
+    fetchMock.mockResolvedValue(respond('body', { status: 400, contentType: 'text/plain', location: 'https://elsewhere.test/' }))
+    await expect(setup().fetchUrl('https://example.com/a')).rejects.toThrow('HTTP 400 for https://example.com/a')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+const resultHtml = (n: number): string => Array.from({ length: n }, (_, i) => `<div class="result"><a class="result__a" href="https://site${i}.test/">Title ${i}</a><a class="result__snippet">Snippet ${i}</a></div>`).join('')
+
+describe('web_search', () => {
+  it('hits the duckduckgo html endpoint with the query percent-encoded', async () => {
+    fetchMock.mockResolvedValue(respond(resultHtml(1)))
+    await setup().search({ query: 'pi & code' })
+    expect(requestUrls()).toEqual(['https://html.duckduckgo.com/html/?q=pi%20%26%20code'])
+  })
+
+  it('formats numbered results with url and snippet lines', async () => {
+    fetchMock.mockResolvedValue(respond(resultHtml(2)))
+    const result = await setup().search({ query: 'pi' })
+    expect(result.content[0].text).toBe('1. Title 0\n   https://site0.test/\n   Snippet 0\n2. Title 1\n   https://site1.test/\n   Snippet 1')
+    expect(result.details).toEqual({})
+  })
+
+  it('defaults to 5 results', async () => {
+    fetchMock.mockResolvedValue(respond(resultHtml(8)))
+    const result = await setup().search({ query: 'pi' })
+    expect(result.content[0].text.split('\n').filter((line) => /^\d+\. /.test(line))).toHaveLength(5)
+  })
+
+  it('honours a smaller explicit count', async () => {
+    fetchMock.mockResolvedValue(respond(resultHtml(8)))
+    const result = await setup().search({ query: 'pi', count: 2 })
+    expect(result.content[0].text).toBe('1. Title 0\n   https://site0.test/\n   Snippet 0\n2. Title 1\n   https://site1.test/\n   Snippet 1')
+  })
+
+  it('caps an oversized count at 10', async () => {
+    fetchMock.mockResolvedValue(respond(resultHtml(25)))
+    const result = await setup().search({ query: 'pi', count: 50 })
+    const numbered = result.content[0].text.split('\n').filter((line) => /^\d+\. /.test(line))
+    expect(numbered).toHaveLength(10)
+    expect(numbered.at(-1)).toBe('10. Title 9')
+  })
+
+  it.each([
+    ['an empty page', ''],
+    ['markup with no result anchors', '<html><body><p>nothing here</p></body></html>'],
+  ])('reports no results for %s', async (_label, body) => {
+    fetchMock.mockResolvedValue(respond(body))
+    const result = await setup().search({ query: 'pi' })
+    expect(result.content).toEqual([{ type: 'text', text: 'No results found.' }])
+  })
+
+  it('keeps a duckduckgo redirect href verbatim when its uddg payload is not decodable', async () => {
+    fetchMock.mockResolvedValue(respond('<a class="result__a" href="//duckduckgo.com/l/?uddg=%E0%A4%A">Broken</a><a class="result__snippet">S</a>'))
+    const result = await setup().search({ query: 'pi' })
+    expect(result.content[0].text).toBe('1. Broken\n   //duckduckgo.com/l/?uddg=%E0%A4%A\n   S')
+  })
+
+  it('surfaces an upstream http failure from the search endpoint', async () => {
+    fetchMock.mockResolvedValue(respond('rate limited', { status: 429 }))
+    await expect(setup().search({ query: 'pi' })).rejects.toThrow('HTTP 429 for https://html.duckduckgo.com/html/?q=pi')
+  })
+})


### PR DESCRIPTION
Statement coverage 32.9% -> 71.2%.

| File | Before | After |
|---|---|---|
| `todo.ts` | 39.9% | 100% |
| `mcp.ts` | 25.9% | 100% lines |
| `web.ts` | 57.4% | 99.1% |
| `question.ts` | 0% | 95.7% |
| `subagent/index.ts` | 2.3% | 65.4% |
| `git-checkpoint.ts` | 64.5% | 68.5% |

New test files: `question`, `web-more`, `mcp-more`, `todo-more`, `subagent-render`.

`extensions/subagent/index.ts`: six pure helpers gain an `export` keyword. No logic changes.

`tests/git-checkpoint.test.ts`: rewritten for per-test isolation. It shared state across tests under one `beforeAll` and failed under `--sequence.shuffle`, and wrote a real bare repo into `~/.pi/agent/checkpoints/` because the shadow repo resolves under `os.homedir()`.

README: badges grouped into rows.