### PR TITLE
Fix Sonar findings across extensions

### DIFF
--- a/extensions/claude-rules.ts
+++ b/extensions/claude-rules.ts
@@ -42,10 +42,14 @@ function parsePaths(frontmatter: string): string[] {
   const inline = lines[index].replace(/^\s*paths\s*:/, '').trim()
   if (inline) return splitInline(inline)
   const items: string[] = []
+  // Matched with string ops rather than a regex: the equivalent pattern needs two
+  // adjacent whitespace quantifiers, which backtracks super-linearly on long lines.
   for (let i = index + 1; i < lines.length; i++) {
-    const match = /^\s*-\s*(\S.*)$/.exec(lines[i])
-    if (!match) break
-    items.push(unquote(match[1].trim()))
+    const entry = lines[i].trimStart()
+    if (!entry.startsWith('-')) break
+    const value = entry.slice(1).trim()
+    if (!value) break
+    items.push(unquote(value))
   }
   return items
 }

--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -65,6 +65,20 @@ function checkpointLabel(checkpoint: Checkpoint, index: number): string {
   return `${index + 1}. ${time}  ${checkpoint.prompt || '(empty prompt)'}${marker}`
 }
 
+async function restoreConversation(ctx: ExtensionCommandContext, entryId: string): Promise<boolean> {
+  try {
+    // navigateTree's published type omits editorText, but it is present at runtime (docs/extensions.md)
+    const result = (await ctx.navigateTree(entryId, { summarize: false })) as { cancelled: boolean; editorText?: string }
+    if (result.cancelled) return false
+    if (typeof result.editorText === 'string') ctx.ui.setEditorText(result.editorText)
+    return true
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    ctx.ui.notify(`Conversation restore failed: ${message}`, 'error')
+    return false
+  }
+}
+
 export default function gitCheckpointExtension(pi: ExtensionAPI) {
   const checkpoints = new Map<string, Checkpoint>()
   let pending: { ref: string; createdAt: string } | undefined
@@ -115,20 +129,6 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
       return false
     }
     return true
-  }
-
-  async function restoreConversation(ctx: ExtensionCommandContext, entryId: string): Promise<boolean> {
-    try {
-      // navigateTree's published type omits editorText, but it is present at runtime (docs/extensions.md)
-      const result = (await ctx.navigateTree(entryId, { summarize: false })) as { cancelled: boolean; editorText?: string }
-      if (result.cancelled) return false
-      if (typeof result.editorText === 'string') ctx.ui.setEditorText(result.editorText)
-      return true
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      ctx.ui.notify(`Conversation restore failed: ${message}`, 'error')
-      return false
-    }
   }
 
   async function runRestoreMode(ctx: ExtensionCommandContext, checkpoint: Checkpoint): Promise<void> {

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -18,6 +18,8 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+// NOSONAR: SSE is deprecated in favour of Streamable HTTP, but the SDK notes servers
+// still on the old spec exist, so this stays as a fallback for the migration period.
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
@@ -167,7 +169,7 @@ async function connect(name: string, config: ServerConfig): Promise<Client> {
   } catch (error) {
     if (String(error).includes('Unauthorized')) throw error
     const fallback = new Client({ name: 'pi-code-mcp', version: '0.1.0' })
-    const transport = new SSEClientTransport(url, { requestInit: { headers } })
+    const transport = new SSEClientTransport(url, { requestInit: { headers } }) // NOSONAR: deliberate legacy fallback
     await withTimeout(fallback.connect(transport), CONNECT_TIMEOUT_MS, `connect ${name} (sse)`)
     return fallback
   }

--- a/extensions/notify.ts
+++ b/extensions/notify.ts
@@ -32,8 +32,8 @@ function notifyWindows(title: string, body: string): void {
   const { execFile } = require('node:child_process')
   // Resolve powershell from a fixed system path rather than through PATH, and let the callback
   // capture a spawn failure instead of an unhandled 'error' event crashing the host.
-  const root = process.env.SystemRoot ?? 'C:\\Windows'
-  const powershell = `${root}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`
+  const root = process.env.SystemRoot ?? String.raw`C:\Windows`
+  const powershell = String.raw`${root}\System32\WindowsPowerShell\v1.0\powershell.exe`
   execFile(powershell, ['-NoProfile', '-Command', windowsToastScript(title, body)], () => {})
 }
 

--- a/extensions/plan-mode/index.ts
+++ b/extensions/plan-mode/index.ts
@@ -14,7 +14,7 @@
 
 import type { AgentMessage } from '@earendil-works/pi-agent-core'
 import type { AssistantMessage, TextContent } from '@earendil-works/pi-ai'
-import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
+import type { ExtensionAPI, ExtensionContext, SessionEntry } from '@earendil-works/pi-coding-agent'
 import { Key } from '@earendil-works/pi-tui'
 import { Type } from 'typebox'
 import { extractTodoItems, isSafeCommand, markCompletedSteps, planToTodos, type TodoItem } from './utils.js'
@@ -33,6 +33,23 @@ function getTextContent(message: AssistantMessage): string {
     .filter((block): block is TextContent => block.type === 'text')
     .map((block) => block.text)
     .join('\n')
+}
+
+// Last element matching the predicate (the lib target predates Array.prototype.findLast)
+function findLast<T>(items: T[], match: (item: T) => boolean): T | undefined {
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (match(items[i])) return items[i]
+  }
+  return undefined
+}
+
+// Index of the last plan-mode-execute entry, or -1 when the current run never started one
+function findLastExecuteIndex(entries: SessionEntry[]): number {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i] as { customType?: string }
+    if (entry.customType === 'plan-mode-execute') return i
+  }
+  return -1
 }
 
 export default function planModeExtension(pi: ExtensionAPI): void {
@@ -106,6 +123,62 @@ export default function planModeExtension(pi: ExtensionAPI): void {
       todos: todoItems,
       executing: executionMode,
     })
+  }
+
+  // Announce completion and reset once every step is done
+  function finalizeCompletedExecution(ctx: ExtensionContext): void {
+    if (!todoItems.every((t) => t.completed)) return
+    const completedList = todoItems.map((t) => `~~${t.text}~~`).join('\n')
+    pi.sendMessage({ customType: 'plan-complete', content: `**Plan Complete!** ✓\n\n${completedList}`, display: true }, { triggerTurn: false })
+    executionMode = false
+    todoItems = []
+    restoreTools()
+    updateStatus(ctx)
+    persistState() // Save cleared state so resume doesn't restore old execution mode
+  }
+
+  // Fall back to extracting a plan from the last assistant message's prose
+  function deriveTodosFromProse(messages: AgentMessage[]): void {
+    const lastAssistant = [...messages].reverse().find(isAssistantMessage)
+    if (!lastAssistant) return
+    const extracted = extractTodoItems(getTextContent(lastAssistant))
+    if (extracted.length > 0) {
+      todoItems = extracted
+    }
+  }
+
+  // Ask the user how to proceed after a plan is ready
+  async function promptPlanNextAction(ctx: ExtensionContext): Promise<void> {
+    const choice = await ctx.ui.select('Plan mode - what next?', [todoItems.length > 0 ? 'Execute the plan (track progress)' : 'Execute the plan', 'Stay in plan mode', 'Refine the plan'])
+
+    if (choice?.startsWith('Execute')) {
+      planModeEnabled = false
+      executionMode = todoItems.length > 0
+      planFromTool = false
+      restoreTools()
+      updateStatus(ctx)
+
+      const execMessage = todoItems.length > 0 ? `Execute the plan. Start with: ${todoItems[0].text}` : 'Execute the plan you just created.'
+      pi.sendMessage({ customType: 'plan-mode-execute', content: execMessage, display: true }, { triggerTurn: true })
+    } else if (choice === 'Refine the plan') {
+      const refinement = await ctx.ui.editor('Refine the plan:', '')
+      if (refinement?.trim()) {
+        pi.sendUserMessage(refinement.trim())
+      }
+    }
+  }
+
+  // Rebuild completion state from assistant messages after the last execute marker
+  function rescanCompletion(entries: SessionEntry[]): void {
+    const executeIndex = findLastExecuteIndex(entries)
+    const messages: AssistantMessage[] = []
+    for (let i = executeIndex + 1; i < entries.length; i++) {
+      const entry = entries[i]
+      if (entry.type === 'message' && 'message' in entry && isAssistantMessage(entry.message as AgentMessage)) {
+        messages.push(entry.message as AssistantMessage)
+      }
+    }
+    markCompletedSteps(messages.map(getTextContent).join('\n'), todoItems)
   }
 
   pi.registerCommand('plan', {
@@ -244,15 +317,7 @@ After completing a step, include a [DONE:n] tag in your response.`,
   pi.on('agent_end', async (event, ctx) => {
     // Check if execution is complete
     if (executionMode && todoItems.length > 0) {
-      if (todoItems.every((t) => t.completed)) {
-        const completedList = todoItems.map((t) => `~~${t.text}~~`).join('\n')
-        pi.sendMessage({ customType: 'plan-complete', content: `**Plan Complete!** ✓\n\n${completedList}`, display: true }, { triggerTurn: false })
-        executionMode = false
-        todoItems = []
-        restoreTools()
-        updateStatus(ctx)
-        persistState() // Save cleared state so resume doesn't restore old execution mode
-      }
+      finalizeCompletedExecution(ctx)
       return
     }
 
@@ -260,13 +325,7 @@ After completing a step, include a [DONE:n] tag in your response.`,
 
     // Prefer an explicitly submitted plan; fall back to extracting from prose
     if (!planFromTool) {
-      const lastAssistant = [...event.messages].reverse().find(isAssistantMessage)
-      if (lastAssistant) {
-        const extracted = extractTodoItems(getTextContent(lastAssistant))
-        if (extracted.length > 0) {
-          todoItems = extracted
-        }
-      }
+      deriveTodosFromProse(event.messages)
     }
 
     // Show plan steps and prompt for next action
@@ -282,23 +341,7 @@ After completing a step, include a [DONE:n] tag in your response.`,
       )
     }
 
-    const choice = await ctx.ui.select('Plan mode - what next?', [todoItems.length > 0 ? 'Execute the plan (track progress)' : 'Execute the plan', 'Stay in plan mode', 'Refine the plan'])
-
-    if (choice?.startsWith('Execute')) {
-      planModeEnabled = false
-      executionMode = todoItems.length > 0
-      planFromTool = false
-      restoreTools()
-      updateStatus(ctx)
-
-      const execMessage = todoItems.length > 0 ? `Execute the plan. Start with: ${todoItems[0].text}` : 'Execute the plan you just created.'
-      pi.sendMessage({ customType: 'plan-mode-execute', content: execMessage, display: true }, { triggerTurn: true })
-    } else if (choice === 'Refine the plan') {
-      const refinement = await ctx.ui.editor('Refine the plan:', '')
-      if (refinement?.trim()) {
-        pi.sendUserMessage(refinement.trim())
-      }
-    }
+    await promptPlanNextAction(ctx)
   })
 
   // Restore state on session start/resume
@@ -310,7 +353,7 @@ After completing a step, include a [DONE:n] tag in your response.`,
     const entries = ctx.sessionManager.getEntries()
 
     // Restore persisted state
-    const planModeEntry = entries.filter((e: { type: string; customType?: string }) => e.type === 'custom' && e.customType === 'plan-mode').pop() as { data?: { enabled: boolean; todos?: TodoItem[]; executing?: boolean } } | undefined
+    const planModeEntry = findLast(entries, (e: { type: string; customType?: string }) => e.type === 'custom' && e.customType === 'plan-mode') as { data?: { enabled: boolean; todos?: TodoItem[]; executing?: boolean } } | undefined
 
     if (planModeEntry?.data) {
       planModeEnabled = planModeEntry.data.enabled ?? planModeEnabled
@@ -318,30 +361,11 @@ After completing a step, include a [DONE:n] tag in your response.`,
       executionMode = planModeEntry.data.executing ?? executionMode
     }
 
-    // On resume: re-scan messages to rebuild completion state
-    // Only scan messages AFTER the last "plan-mode-execute" to avoid picking up [DONE:n] from previous plans
+    // On resume: re-scan messages after the last "plan-mode-execute" to rebuild
+    // completion state without picking up [DONE:n] from previous plans
     const isResume = planModeEntry !== undefined
     if (isResume && executionMode && todoItems.length > 0) {
-      // Find the index of the last plan-mode-execute entry (marks when current execution started)
-      let executeIndex = -1
-      for (let i = entries.length - 1; i >= 0; i--) {
-        const entry = entries[i] as { type: string; customType?: string }
-        if (entry.customType === 'plan-mode-execute') {
-          executeIndex = i
-          break
-        }
-      }
-
-      // Only scan messages after the execute marker
-      const messages: AssistantMessage[] = []
-      for (let i = executeIndex + 1; i < entries.length; i++) {
-        const entry = entries[i]
-        if (entry.type === 'message' && 'message' in entry && isAssistantMessage(entry.message as AgentMessage)) {
-          messages.push(entry.message as AssistantMessage)
-        }
-      }
-      const allText = messages.map(getTextContent).join('\n')
-      markCompletedSteps(allText, todoItems)
+      rescanCompletion(entries)
     }
 
     if (planModeEnabled) {

--- a/extensions/plan-mode/utils.ts
+++ b/extensions/plan-mode/utils.ts
@@ -129,7 +129,9 @@ export function extractTodoItems(message: string): TodoItem[] {
   if (!headerMatch) return items
 
   const planSection = message.slice(message.indexOf(headerMatch[0]) + headerMatch[0].length)
-  const numberedPattern = /^\s*(\d+)[.)]\s+\*{0,2}([^*\n]+)/gm
+  // Capture starts on a non-whitespace char so the leading \s+ owns all separator
+  // whitespace unambiguously (avoids super-linear backtracking); output is unchanged.
+  const numberedPattern = /^\s*(\d+)[.)]\s+\*{0,2}([^\s*\n][^*\n]*)/gm
 
   for (const match of planSection.matchAll(numberedPattern)) {
     const text = match[2]

--- a/extensions/question.ts
+++ b/extensions/question.ts
@@ -4,7 +4,7 @@
  * Escape in editor returns to options, Escape in options cancels
  */
 
-import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import type { ExtensionAPI, Theme } from '@earendil-works/pi-coding-agent'
 import { Editor, type EditorTheme, Key, matchesKey, Text, truncateToWidth } from '@earendil-works/pi-tui'
 import { Type } from 'typebox'
 
@@ -32,6 +32,60 @@ const QuestionParams = Type.Object({
   question: Type.String({ description: 'The question to ask the user' }),
   options: Type.Array(OptionSchema, { description: 'Options for the user to choose from' }),
 })
+
+function optionLine(opt: DisplayOption, index: number, selected: boolean, editMode: boolean, theme: Theme): string {
+  const label = `${index + 1}. ${opt.label}`
+  const prefix = selected ? theme.fg('accent', '> ') : '  '
+  if (opt.isOther === true && editMode) {
+    return prefix + theme.fg('accent', `${label} ✎`)
+  }
+  if (selected) {
+    return prefix + theme.fg('accent', label)
+  }
+  return `  ${theme.fg('text', label)}`
+}
+
+interface QuestionView {
+  width: number
+  question: string
+  options: DisplayOption[]
+  optionIndex: number
+  editMode: boolean
+  editor: Editor
+  theme: Theme
+}
+
+function buildQuestionLines(view: QuestionView): string[] {
+  const { width, question, options, optionIndex, editMode, editor, theme } = view
+  const lines: string[] = []
+  const add = (s: string) => lines.push(truncateToWidth(s, width))
+
+  add(theme.fg('accent', '─'.repeat(width)))
+  add(theme.fg('text', ` ${question}`))
+  lines.push('')
+
+  for (let i = 0; i < options.length; i++) {
+    const opt = options[i]
+    add(optionLine(opt, i, i === optionIndex, editMode, theme))
+    if (opt.description) {
+      add(`     ${theme.fg('muted', opt.description)}`)
+    }
+  }
+
+  if (editMode) {
+    lines.push('')
+    add(theme.fg('muted', ' Your answer:'))
+    for (const line of editor.render(width - 2)) {
+      add(` ${line}`)
+    }
+  }
+
+  lines.push('')
+  add(theme.fg('dim', editMode ? ' Enter to submit • Esc to go back' : ' ↑↓ navigate • Enter to select • Esc to cancel'))
+  add(theme.fg('accent', '─'.repeat(width)))
+
+  return lines
+}
 
 export default function question(pi: ExtensionAPI) {
   pi.registerTool({
@@ -137,53 +191,9 @@ export default function question(pi: ExtensionAPI) {
 
         function render(width: number): string[] {
           if (cachedLines && cachedWidth === width) return cachedLines
-
-          const lines: string[] = []
-          const add = (s: string) => lines.push(truncateToWidth(s, width))
-
-          add(theme.fg('accent', '─'.repeat(width)))
-          add(theme.fg('text', ` ${params.question}`))
-          lines.push('')
-
-          for (let i = 0; i < allOptions.length; i++) {
-            const opt = allOptions[i]
-            const selected = i === optionIndex
-            const isOther = opt.isOther === true
-            const prefix = selected ? theme.fg('accent', '> ') : '  '
-
-            if (isOther && editMode) {
-              add(prefix + theme.fg('accent', `${i + 1}. ${opt.label} ✎`))
-            } else if (selected) {
-              add(prefix + theme.fg('accent', `${i + 1}. ${opt.label}`))
-            } else {
-              add(`  ${theme.fg('text', `${i + 1}. ${opt.label}`)}`)
-            }
-
-            // Show description if present
-            if (opt.description) {
-              add(`     ${theme.fg('muted', opt.description)}`)
-            }
-          }
-
-          if (editMode) {
-            lines.push('')
-            add(theme.fg('muted', ' Your answer:'))
-            for (const line of editor.render(width - 2)) {
-              add(` ${line}`)
-            }
-          }
-
-          lines.push('')
-          if (editMode) {
-            add(theme.fg('dim', ' Enter to submit • Esc to go back'))
-          } else {
-            add(theme.fg('dim', ' ↑↓ navigate • Enter to select • Esc to cancel'))
-          }
-          add(theme.fg('accent', '─'.repeat(width)))
-
           cachedWidth = width
-          cachedLines = lines
-          return lines
+          cachedLines = buildQuestionLines({ width, question: params.question, options: allOptions, optionIndex, editMode, editor, theme })
+          return cachedLines
         }
 
         return {
@@ -234,7 +244,8 @@ export default function question(pi: ExtensionAPI) {
       if (opts.length) {
         const labels = opts.map((o: OptionWithDesc) => o.label)
         const numbered = [...labels, 'Type something.'].map((o, i) => `${i + 1}. ${o}`)
-        text += `\n${theme.fg('dim', `  Options: ${numbered.join(', ')}`)}`
+        const optionsLine = `  Options: ${numbered.join(', ')}`
+        text += `\n${theme.fg('dim', optionsLine)}`
       }
       return new Text(text, 0, 0)
     },

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -111,6 +111,17 @@ function findNearestDir(cwd: string, relative: string): string | null {
   }
 }
 
+function buildAgentMap(userAgents: AgentConfig[], projectAgents: AgentConfig[], scope: AgentScope): Map<string, AgentConfig> {
+  const agentMap = new Map<string, AgentConfig>()
+  const register = (agents: AgentConfig[]): void => {
+    for (const agent of agents) agentMap.set(agent.name, agent)
+  }
+  // user agents first so project agents win on name conflicts
+  if (scope !== 'project') register(userAgents)
+  if (scope !== 'user') register(projectAgents)
+  return agentMap
+}
+
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
   const userDir = path.join(getAgentDir(), 'agents')
   const claudeUserDir = path.join(os.homedir(), '.claude', 'agents')
@@ -122,17 +133,7 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
   // project .claude/agents loads first so project .pi/agents wins on name conflicts
   const projectAgents = scope === 'user' ? [] : [...(projectClaudeDir ? loadAgentsFromDir(projectClaudeDir, 'project') : []), ...(projectPiDir ? loadAgentsFromDir(projectPiDir, 'project') : [])]
 
-  const agentMap = new Map<string, AgentConfig>()
-
-  if (scope === 'both') {
-    for (const agent of userAgents) agentMap.set(agent.name, agent)
-    for (const agent of projectAgents) agentMap.set(agent.name, agent)
-  } else if (scope === 'user') {
-    for (const agent of userAgents) agentMap.set(agent.name, agent)
-  } else {
-    for (const agent of projectAgents) agentMap.set(agent.name, agent)
-  }
-
+  const agentMap = buildAgentMap(userAgents, projectAgents, scope)
   return { agents: Array.from(agentMap.values()), projectAgentsDir: projectPiDir }
 }
 

--- a/extensions/todo.ts
+++ b/extensions/todo.ts
@@ -134,7 +134,7 @@ class TodoOverlay {
   private uiCtx?: ExtensionUIContext
   private widgetRegistered = false
   private tui?: TUI
-  private getTodos: () => Todo[]
+  private readonly getTodos: () => Todo[]
 
   constructor(getTodos: () => Todo[]) {
     this.getTodos = getTodos
@@ -225,9 +225,9 @@ class TodoOverlay {
  * UI component for the /todos command
  */
 class TodoListComponent {
-  private todos: Todo[]
-  private theme: Theme
-  private onClose: () => void
+  private readonly todos: Todo[]
+  private readonly theme: Theme
+  private readonly onClose: () => void
   private cachedWidth?: number
   private cachedLines?: string[]
 
@@ -254,15 +254,14 @@ class TodoListComponent {
     lines.push('')
     const title = th.fg('accent', ' Todos ')
     const headerLine = th.fg('borderMuted', '─'.repeat(3)) + title + th.fg('borderMuted', '─'.repeat(Math.max(0, width - 10)))
-    lines.push(truncateToWidth(headerLine, width))
-    lines.push('')
+    lines.push(truncateToWidth(headerLine, width), '')
 
     if (this.todos.length === 0) {
       lines.push(truncateToWidth(`  ${th.fg('dim', 'No todos yet. Ask the agent to add some!')}`, width))
     } else {
       const completed = this.todos.filter((t) => t.status === 'completed').length
-      lines.push(truncateToWidth(`  ${th.fg('muted', `${completed}/${this.todos.length} completed`)}`, width))
-      lines.push('')
+      const completedLabel = `${completed}/${this.todos.length} completed`
+      lines.push(truncateToWidth(`  ${th.fg('muted', completedLabel)}`, width), '')
 
       for (const todo of this.todos) {
         const glyph = statusGlyph(todo.status, th)
@@ -270,15 +269,14 @@ class TodoListComponent {
         const text = todo.status === 'completed' ? th.fg('dim', todo.text) : th.fg('text', todo.text)
         let line = `  ${glyph} ${id} ${text}`
         if (todo.status === 'in_progress' && todo.activeForm) {
-          line += ` ${th.fg('dim', `(${todo.activeForm})`)}`
+          const activeFormLabel = `(${todo.activeForm})`
+          line += ` ${th.fg('dim', activeFormLabel)}`
         }
         lines.push(truncateToWidth(line, width))
       }
     }
 
-    lines.push('')
-    lines.push(truncateToWidth(`  ${th.fg('dim', 'Press Escape to close')}`, width))
-    lines.push('')
+    lines.push('', truncateToWidth(`  ${th.fg('dim', 'Press Escape to close')}`, width), '')
 
     this.cachedWidth = width
     this.cachedLines = lines
@@ -296,7 +294,27 @@ class TodoListComponent {
 // genuine replay bugs still propagate instead of being silently swallowed.
 const isStaleCtxError = (e: unknown): boolean => /stale after session replacement/.test(String(e))
 
-export default function (pi: ExtensionAPI) {
+const LIST_RESULT_PREVIEW = 5
+
+const renderTodoListResult = (todoList: Todo[], expanded: boolean, theme: Theme): Text => {
+  if (todoList.length === 0) {
+    return new Text(theme.fg('dim', 'No todos'), 0, 0)
+  }
+  let listText = theme.fg('muted', `${todoList.length} todo(s):`)
+  const display = expanded ? todoList : todoList.slice(0, LIST_RESULT_PREVIEW)
+  for (const t of display) {
+    const idLabel = `#${t.id}`
+    const itemText = t.status === 'completed' ? theme.fg('dim', t.text) : theme.fg('muted', t.text)
+    listText += `\n${statusGlyph(t.status, theme)} ${theme.fg('accent', idLabel)} ${itemText}`
+  }
+  if (!expanded && todoList.length > LIST_RESULT_PREVIEW) {
+    const moreLabel = `... ${todoList.length - LIST_RESULT_PREVIEW} more`
+    listText += `\n${theme.fg('dim', moreLabel)}`
+  }
+  return new Text(listText, 0, 0)
+}
+
+export default function todoExtension(pi: ExtensionAPI) {
   // In-memory state (reconstructed from session on load)
   let todos: Todo[] = []
   let nextId = 1
@@ -382,7 +400,10 @@ export default function (pi: ExtensionAPI) {
     todo.status = 'in_progress'
     if (params.activeForm) todo.activeForm = params.activeForm
     let text = `Started #${todo.id}: ${todo.text}`
-    if (demoted.length > 0) text += ` (moved ${demoted.map((t) => `#${t.id}`).join(', ')} back to pending)`
+    if (demoted.length > 0) {
+      const movedIds = demoted.map((t) => `#${t.id}`).join(', ')
+      text += ` (moved ${movedIds} back to pending)`
+    }
     return ok('start', text)
   }
 
@@ -446,9 +467,18 @@ export default function (pi: ExtensionAPI) {
 
     renderCall(args, theme, _context) {
       let text = theme.fg('toolTitle', theme.bold('todo ')) + theme.fg('muted', args.action)
-      if (args.id !== undefined) text += ` ${theme.fg('accent', `#${args.id}`)}`
-      if (args.text) text += ` ${theme.fg('dim', `"${args.text}"`)}`
-      if (args.activeForm) text += ` ${theme.fg('dim', `(${args.activeForm})`)}`
+      if (args.id !== undefined) {
+        const idLabel = `#${args.id}`
+        text += ` ${theme.fg('accent', idLabel)}`
+      }
+      if (args.text) {
+        const textLabel = `"${args.text}"`
+        text += ` ${theme.fg('dim', textLabel)}`
+      }
+      if (args.activeForm) {
+        const activeFormLabel = `(${args.activeForm})`
+        text += ` ${theme.fg('dim', activeFormLabel)}`
+      }
       return new Text(text, 0, 0)
     },
 
@@ -464,20 +494,7 @@ export default function (pi: ExtensionAPI) {
       }
 
       if (details.action === 'list') {
-        const todoList = details.todos
-        if (todoList.length === 0) {
-          return new Text(theme.fg('dim', 'No todos'), 0, 0)
-        }
-        let listText = theme.fg('muted', `${todoList.length} todo(s):`)
-        const display = expanded ? todoList : todoList.slice(0, 5)
-        for (const t of display) {
-          const itemText = t.status === 'completed' ? theme.fg('dim', t.text) : theme.fg('muted', t.text)
-          listText += `\n${statusGlyph(t.status, theme)} ${theme.fg('accent', `#${t.id}`)} ${itemText}`
-        }
-        if (!expanded && todoList.length > 5) {
-          listText += `\n${theme.fg('dim', `... ${todoList.length - 5} more`)}`
-        }
-        return new Text(listText, 0, 0)
+        return renderTodoListResult(details.todos, expanded, theme)
       }
 
       const text = result.content[0]


### PR DESCRIPTION
Behavior-preserving refactors only. No feature or output changes; the 628-test suite passes unchanged throughout.

| File | Findings addressed |
|---|---|
| `todo.ts` | readonly members, nested template literals, merged `push` calls, cognitive complexity, named function |
| `plan-mode/index.ts` | `findLast` over `filter().pop()`, two cognitive-complexity functions |
| `plan-mode/utils.ts` | regex backtracking |
| `question.ts` | cognitive complexity, nesting depth, nested template literals |
| `subagent/agents.ts` | cognitive complexity |
| `notify.ts` | `String.raw` for the Windows powershell path |
| `claude-rules.ts` | regex backtracking |
| `git-checkpoint.ts` | `restoreConversation` moved to module scope |
| `mcp.ts` | deprecated SSE transport, suppressed with justification |

## Notes

`claude-rules.ts` drops the block-list regex for string operations. The equivalent pattern needs two adjacent whitespace quantifiers, which is what backtracks; string ops remove the class of problem rather than reshuffling it.

`mcp.ts` keeps `SSEClientTransport`. The SDK's deprecation note states servers still using SSE exist and clients may need both transports during the migration period, so removing the fallback would drop support for those servers. Marked `NOSONAR` with that reason.

The `TODO` comment findings in `todo.ts` are not addressed: they are the word "TODO" in the todo extension's own documentation, not outstanding tasks.