### PR TITLE
Fix remaining Sonar findings

### DIFF
--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -54,6 +54,41 @@ export interface ImportedFile {
   body: string
 }
 
+/** The `@path` targets of a context file, in document order, skipping fenced code blocks. */
+function importTargets(content: string): string[] {
+  const targets: string[] = []
+  let inFence = false
+  for (const line of content.split('\n')) {
+    if (line.trimStart().startsWith('```')) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
+    for (const match of line.matchAll(/(^|\s)@(\S+)/g)) targets.push(match[2])
+  }
+  return targets
+}
+
+/** Read one `@path` target, or null when it is unresolvable, already seen, outside `allowedRoots`, or unreadable. */
+function readImport(target: string, fromDir: string, home: string, allowedRoots: string[], seen: Set<string>): { real: string; body: string } | null {
+  const resolved = path.resolve(fromDir, expandHome(target, home))
+  let real: string
+  try {
+    real = fs.realpathSync(resolved)
+  } catch {
+    return null
+  }
+  if (seen.has(real)) return null
+  seen.add(real)
+  if (!isUnder(real, allowedRoots)) return null
+  try {
+    // real may be a directory (EISDIR) or vanish after the realpath (ENOENT/EACCES).
+    return { real, body: fs.readFileSync(real, 'utf-8') }
+  } catch {
+    return null
+  }
+}
+
 /**
  * Collect the contents of every file transitively imported via `@path`, in
  * discovery order. Imports are resolved through symlinks and kept within
@@ -62,34 +97,10 @@ export interface ImportedFile {
 export function collectImports(content: string, fromDir: string, home: string, allowedRoots: string[], seen: Set<string>, depth = 0): ImportedFile[] {
   if (depth >= MAX_IMPORT_DEPTH) return []
   const out: ImportedFile[] = []
-  let inFence = false
-  for (const line of content.split('\n')) {
-    if (line.trimStart().startsWith('```')) {
-      inFence = !inFence
-      continue
-    }
-    if (inFence) continue
-    for (const match of line.matchAll(/(^|\s)@(\S+)/g)) {
-      const resolved = path.resolve(fromDir, expandHome(match[2], home))
-      let real: string
-      try {
-        real = fs.realpathSync(resolved)
-      } catch {
-        continue
-      }
-      if (seen.has(real)) continue
-      seen.add(real)
-      if (!isUnder(real, allowedRoots)) continue
-      let body: string
-      try {
-        // real may be a directory (EISDIR) or vanish after the realpath (ENOENT/EACCES).
-        body = fs.readFileSync(real, 'utf-8')
-      } catch {
-        continue
-      }
-      out.push({ path: real, body: body.trim() })
-      out.push(...collectImports(body, path.dirname(real), home, allowedRoots, seen, depth + 1))
-    }
+  for (const target of importTargets(content)) {
+    const file = readImport(target, fromDir, home, allowedRoots, seen)
+    if (!file) continue
+    out.push({ path: file.real, body: file.body.trim() }, ...collectImports(file.body, path.dirname(file.real), home, allowedRoots, seen, depth + 1))
   }
   return out
 }

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -18,9 +18,9 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-// NOSONAR: SSE is deprecated in favour of Streamable HTTP, but the SDK notes servers
-// still on the old spec exist, so this stays as a fallback for the migration period.
-import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
+// SSE is deprecated in favour of Streamable HTTP, but the SDK notes servers still on
+// the old spec exist, so this stays as a fallback for the migration period.
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js' // NOSONAR
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { Type } from 'typebox'

--- a/extensions/plan-mode/utils.ts
+++ b/extensions/plan-mode/utils.ts
@@ -123,15 +123,20 @@ export function cleanStepText(text: string): string {
   return cleaned
 }
 
+// Horizontal whitespace before the newline: \s would include \n itself and overlap
+// the following \n, which is what backtracks super-linearly.
+const PLAN_HEADER = /\*{0,2}Plan:\*{0,2}[^\S\n]*\n/i
+
 export function extractTodoItems(message: string): TodoItem[] {
   const items: TodoItem[] = []
-  const headerMatch = /\*{0,2}Plan:\*{0,2}\s*\n/i.exec(message)
+  const headerMatch = PLAN_HEADER.exec(message)
   if (!headerMatch) return items
 
   const planSection = message.slice(message.indexOf(headerMatch[0]) + headerMatch[0].length)
-  // Capture starts on a non-whitespace char so the leading \s+ owns all separator
-  // whitespace unambiguously (avoids super-linear backtracking); output is unchanged.
-  const numberedPattern = /^\s*(\d+)[.)]\s+\*{0,2}([^\s*\n][^*\n]*)/gm
+  // Separators are horizontal whitespace only: under /m the anchor already sits at
+  // each line start, so letting \s cross newlines only adds backtracking. The capture
+  // starts on a non-whitespace char so the preceding run owns all separator space.
+  const numberedPattern = /^[^\S\n]*(\d+)[.)][^\S\n]+\*{0,2}([^\s*][^*\n]*)/gm
 
   for (const match of planSection.matchAll(numberedPattern)) {
     const text = match[2]
@@ -172,6 +177,6 @@ export function markCompletedSteps(text: string, items: TodoItem[]): number {
  * the tool input is already known to be the plan itself.
  */
 export function planToTodos(plan: string): TodoItem[] {
-  const withHeader = /\*{0,2}Plan:\*{0,2}\s*\n/i.test(plan) ? plan : `Plan:\n${plan}`
+  const withHeader = PLAN_HEADER.test(plan) ? plan : `Plan:\n${plan}`
   return extractTodoItems(withHeader)
 }

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -19,9 +19,9 @@ import * as path from 'node:path'
 import type { AgentToolResult } from '@earendil-works/pi-agent-core'
 import type { Message } from '@earendil-works/pi-ai'
 import { StringEnum } from '@earendil-works/pi-ai'
-import { type ExtensionAPI, getMarkdownTheme, type Theme, withFileMutationQueue } from '@earendil-works/pi-coding-agent'
+import { type ExtensionAPI, type ExtensionContext, getMarkdownTheme, type Theme, withFileMutationQueue } from '@earendil-works/pi-coding-agent'
 import { Container, Markdown, Spacer, Text } from '@earendil-works/pi-tui'
-import { Type } from 'typebox'
+import { type Static, Type } from 'typebox'
 import { type AgentConfig, type AgentScope, discoverAgents } from './agents.js'
 import { backgroundStatusText, startBackgroundRun } from './background.js'
 
@@ -83,7 +83,8 @@ export function formatToolCall(toolName: string, args: Record<string, unknown>, 
       if (offset !== undefined || limit !== undefined) {
         const startLine = offset ?? 1
         const endLine = limit !== undefined ? startLine + limit - 1 : ''
-        text += themeFg('warning', `:${startLine}${endLine ? `-${endLine}` : ''}`)
+        const rangeSuffix = endLine ? `-${endLine}` : ''
+        text += themeFg('warning', `:${startLine}${rangeSuffix}`)
       }
       return themeFg('muted', 'read ') + text
     }
@@ -224,7 +225,38 @@ function getPiInvocation(args: string[]): { command: string; args: string[] } {
 
 type OnUpdateCallback = (partial: AgentToolResult<SubagentDetails>) => void
 
-async function runSingleAgent(defaultCwd: string, agents: AgentConfig[], agentName: string, task: string, cwd: string | undefined, step: number | undefined, signal: AbortSignal | undefined, onUpdate: OnUpdateCallback | undefined, makeDetails: (results: SingleResult[]) => SubagentDetails): Promise<SingleResult> {
+type AssistantMessage = Extract<Message, { role: 'assistant' }>
+
+function accumulateAssistantMessage(result: SingleResult, msg: AssistantMessage): void {
+  result.usage.turns++
+  const usage = msg.usage
+  if (usage) {
+    result.usage.input += usage.input || 0
+    result.usage.output += usage.output || 0
+    result.usage.cacheRead += usage.cacheRead || 0
+    result.usage.cacheWrite += usage.cacheWrite || 0
+    result.usage.cost += usage.cost?.total || 0
+    result.usage.contextTokens = usage.totalTokens || 0
+  }
+  if (!result.model && msg.model) result.model = msg.model
+  if (msg.stopReason) result.stopReason = msg.stopReason
+  if (msg.errorMessage) result.errorMessage = msg.errorMessage
+}
+
+interface RunAgentOptions {
+  defaultCwd: string
+  agents: AgentConfig[]
+  agentName: string
+  task: string
+  cwd?: string
+  step?: number
+  signal?: AbortSignal
+  onUpdate?: OnUpdateCallback
+  makeDetails: (results: SingleResult[]) => SubagentDetails
+}
+
+async function runSingleAgent(options: RunAgentOptions): Promise<SingleResult> {
+  const { defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails } = options
   const agent = agents.find((a) => a.name === agentName)
 
   if (!agent) {
@@ -298,29 +330,14 @@ async function runSingleAgent(defaultCwd: string, agents: AgentConfig[], agentNa
           return
         }
 
-        if (event.type === 'message_end' && event.message) {
+        if (!event.message) return
+
+        if (event.type === 'message_end') {
           const msg = event.message as Message
           currentResult.messages.push(msg)
-
-          if (msg.role === 'assistant') {
-            currentResult.usage.turns++
-            const usage = msg.usage
-            if (usage) {
-              currentResult.usage.input += usage.input || 0
-              currentResult.usage.output += usage.output || 0
-              currentResult.usage.cacheRead += usage.cacheRead || 0
-              currentResult.usage.cacheWrite += usage.cacheWrite || 0
-              currentResult.usage.cost += usage.cost?.total || 0
-              currentResult.usage.contextTokens = usage.totalTokens || 0
-            }
-            if (!currentResult.model && msg.model) currentResult.model = msg.model
-            if (msg.stopReason) currentResult.stopReason = msg.stopReason
-            if (msg.errorMessage) currentResult.errorMessage = msg.errorMessage
-          }
+          if (msg.role === 'assistant') accumulateAssistantMessage(currentResult, msg)
           emitUpdate()
-        }
-
-        if (event.type === 'tool_result_end' && event.message) {
+        } else if (event.type === 'tool_result_end') {
           currentResult.messages.push(event.message as Message)
           emitUpdate()
         }
@@ -437,7 +454,548 @@ export function projectAgentGate(projectAgentCount: number, trusted: boolean, ha
   return trusted ? 'allow' : 'refuse'
 }
 
-export default function (pi: ExtensionAPI) {
+/** The runtime result carries an isError flag that AgentToolResult does not declare. */
+type ToolResult = AgentToolResult<SubagentDetails> & { isError?: boolean }
+type SubagentMode = 'single' | 'parallel' | 'chain'
+type MakeDetails = (mode: SubagentMode) => (results: SingleResult[]) => SubagentDetails
+type SubagentParamsStatic = Static<typeof SubagentParams>
+type ChainStepParam = Static<typeof ChainItem>
+type TaskItemParam = Static<typeof TaskItem>
+
+/** Everything a mode handler needs from the surrounding execute() call. */
+interface ModeContext {
+  agents: AgentConfig[]
+  defaultCwd: string
+  signal: AbortSignal | undefined
+  onUpdate: OnUpdateCallback | undefined
+  makeDetails: MakeDetails
+}
+
+async function checkProjectAgentGate(params: SubagentParamsStatic, agents: AgentConfig[], ctx: ExtensionContext, projectAgentsDir: string | null, gateMode: SubagentMode, makeDetails: MakeDetails): Promise<ToolResult | null> {
+  const requestedAgentNames = new Set<string>()
+  if (params.agent) requestedAgentNames.add(params.agent)
+  for (const step of params.chain ?? []) requestedAgentNames.add(step.agent)
+  for (const t of params.tasks ?? []) requestedAgentNames.add(t.agent)
+  const requestedProjectAgents = [...requestedAgentNames].map((name) => agents.find((a) => a.name === name)).filter((a): a is AgentConfig => a?.source === 'project')
+
+  const gate = projectAgentGate(requestedProjectAgents.length, ctx.isProjectTrusted?.() ?? false, ctx.hasUI, params.confirmProjectAgents ?? true)
+  const names = requestedProjectAgents.map((a) => a.name).join(', ')
+  if (gate === 'refuse') {
+    return { content: [{ type: 'text', text: `Project-local agents (${names}) require a trusted project; refusing in non-interactive mode.` }], details: makeDetails(gateMode)([]) }
+  }
+  if (gate === 'confirm') {
+    const dir = projectAgentsDir ?? '(unknown)'
+    const ok = await ctx.ui.confirm('Run project-local agents?', `Agents: ${names}\nSource: ${dir}\n\nProject agents are repo-controlled. Only continue for trusted repositories.`)
+    if (!ok) return { content: [{ type: 'text', text: 'Canceled: project-local agents not approved.' }], details: makeDetails(gateMode)([]) }
+  }
+  return null
+}
+
+async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConfig[], defaultCwd: string, pi: ExtensionAPI, makeDetails: MakeDetails): Promise<ToolResult> {
+  const task = params.task
+  const agentName = params.agent
+  if (!task || !agentName) {
+    return {
+      content: [{ type: 'text', text: 'background: true requires single mode (agent + task).' }],
+      details: makeDetails('single')([]),
+    }
+  }
+  const agent = agents.find((a) => a.name === agentName)
+  if (!agent) {
+    const available = agents.map((a) => `"${a.name}"`).join(', ') || 'none'
+    return {
+      content: [{ type: 'text', text: `Unknown agent: "${agentName}". Available agents: ${available}.` }],
+      details: makeDetails('single')([]),
+    }
+  }
+  const args: string[] = ['--mode', 'json', '-p', '--no-session']
+  if (agent.model) args.push('--model', agent.model)
+  if (agent.tools && agent.tools.length > 0) args.push('--tools', agent.tools.join(','))
+  let tmpPrompt: { dir: string; filePath: string } | undefined
+  if (agent.systemPrompt.trim()) {
+    tmpPrompt = await writePromptToTempFile(agent.name, agent.systemPrompt)
+    args.push('--append-system-prompt', tmpPrompt.filePath)
+  }
+  args.push(`Task: ${task}`)
+  const invocation = getPiInvocation(args)
+  const id = startBackgroundRun(agent.name, task, { command: invocation.command, args: invocation.args, cwd: params.cwd ?? defaultCwd }, (run) => {
+    if (tmpPrompt) {
+      try {
+        fs.unlinkSync(tmpPrompt.filePath)
+      } catch {
+        /* ignore */
+      }
+      try {
+        fs.rmdirSync(tmpPrompt.dir)
+      } catch {
+        /* ignore */
+      }
+    }
+    const output = run.output || '(no output)'
+    pi.sendMessage(
+      {
+        customType: 'subagent-background',
+        content: `Background subagent run ${run.id} (${run.agent}) ${run.state} after ${run.turns} turns.\n\n${output}`,
+        display: true,
+      },
+      { triggerTurn: true },
+    )
+  })
+  return {
+    content: [{ type: 'text', text: `Started background run ${id} (${agent.name}). A notification will arrive on completion; check progress with {status: true}.` }],
+    details: makeDetails('single')([]),
+  }
+}
+
+async function runChainMode(chain: ChainStepParam[], mode: ModeContext): Promise<ToolResult> {
+  const { agents, defaultCwd, signal, onUpdate, makeDetails } = mode
+  const results: SingleResult[] = []
+  let previousOutput = ''
+
+  for (let i = 0; i < chain.length; i++) {
+    const step = chain[i]
+    const taskWithContext = step.task.replaceAll('{previous}', previousOutput)
+
+    // Create update callback that includes all previous results
+    const chainUpdate: OnUpdateCallback | undefined = onUpdate
+      ? (partial) => {
+          // Combine completed results with current streaming result
+          const currentResult = partial.details?.results[0]
+          if (currentResult) {
+            const allResults = [...results, currentResult]
+            onUpdate({
+              content: partial.content,
+              details: makeDetails('chain')(allResults),
+            })
+          }
+        }
+      : undefined
+
+    const result = await runSingleAgent({
+      defaultCwd,
+      agents,
+      agentName: step.agent,
+      task: taskWithContext,
+      cwd: step.cwd,
+      step: i + 1,
+      signal,
+      onUpdate: chainUpdate,
+      makeDetails: makeDetails('chain'),
+    })
+    results.push(result)
+
+    const isError = result.exitCode !== 0 || result.stopReason === 'error' || result.stopReason === 'aborted'
+    if (isError) {
+      const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || '(no output)'
+      return {
+        content: [{ type: 'text', text: `Chain stopped at step ${i + 1} (${step.agent}): ${errorMsg}` }],
+        details: makeDetails('chain')(results),
+        isError: true,
+      }
+    }
+    previousOutput = getFinalOutput(result.messages)
+  }
+  return {
+    content: [{ type: 'text', text: getFinalOutput(results.at(-1)?.messages ?? []) || '(no output)' }],
+    details: makeDetails('chain')(results),
+  }
+}
+
+async function runParallelMode(tasks: TaskItemParam[], mode: ModeContext): Promise<ToolResult> {
+  const { agents, defaultCwd, signal, onUpdate, makeDetails } = mode
+  if (tasks.length > MAX_PARALLEL_TASKS)
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Too many parallel tasks (${tasks.length}). Max is ${MAX_PARALLEL_TASKS}.`,
+        },
+      ],
+      details: makeDetails('parallel')([]),
+    }
+
+  // Track all results for streaming updates
+  const allResults: SingleResult[] = new Array(tasks.length)
+
+  // Initialize placeholder results
+  for (let i = 0; i < tasks.length; i++) {
+    allResults[i] = {
+      agent: tasks[i].agent,
+      agentSource: 'unknown',
+      task: tasks[i].task,
+      exitCode: -1, // -1 = still running
+      messages: [],
+      stderr: '',
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+    }
+  }
+
+  const emitParallelUpdate = () => {
+    if (onUpdate) {
+      const running = allResults.filter((r) => r.exitCode === -1).length
+      const done = allResults.filter((r) => r.exitCode !== -1).length
+      onUpdate({
+        content: [{ type: 'text', text: `Parallel: ${done}/${allResults.length} done, ${running} running...` }],
+        details: makeDetails('parallel')([...allResults]),
+      })
+    }
+  }
+
+  const results = await mapWithConcurrencyLimit(tasks, MAX_CONCURRENCY, async (t, index) => {
+    const result = await runSingleAgent({
+      defaultCwd,
+      agents,
+      agentName: t.agent,
+      task: t.task,
+      cwd: t.cwd,
+      signal,
+      // Per-task update callback
+      onUpdate: (partial) => {
+        if (partial.details?.results[0]) {
+          allResults[index] = partial.details.results[0]
+          emitParallelUpdate()
+        }
+      },
+      makeDetails: makeDetails('parallel'),
+    })
+    allResults[index] = result
+    emitParallelUpdate()
+    return result
+  })
+
+  const successCount = results.filter((r) => r.exitCode === 0).length
+  const summaries = results.map((r) => {
+    const output = getFinalOutput(r.messages)
+    const preview = output.slice(0, 100) + (output.length > 100 ? '...' : '')
+    const status = r.exitCode === 0 ? 'completed' : 'failed'
+    return `[${r.agent}] ${status}: ${preview || '(no output)'}`
+  })
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Parallel: ${successCount}/${results.length} succeeded\n\n${summaries.join('\n\n')}`,
+      },
+    ],
+    details: makeDetails('parallel')(results),
+  }
+}
+
+async function runSingleMode(agentName: string, task: string, cwd: string | undefined, mode: ModeContext): Promise<ToolResult> {
+  const { agents, defaultCwd, signal, onUpdate, makeDetails } = mode
+  const result = await runSingleAgent({
+    defaultCwd,
+    agents,
+    agentName,
+    task,
+    cwd,
+    signal,
+    onUpdate,
+    makeDetails: makeDetails('single'),
+  })
+  const isError = result.exitCode !== 0 || result.stopReason === 'error' || result.stopReason === 'aborted'
+  if (isError) {
+    const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || '(no output)'
+    return {
+      content: [{ type: 'text', text: `Agent ${result.stopReason || 'failed'}: ${errorMsg}` }],
+      details: makeDetails('single')([result]),
+      isError: true,
+    }
+  }
+  return {
+    content: [{ type: 'text', text: getFinalOutput(result.messages) || '(no output)' }],
+    details: makeDetails('single')([result]),
+  }
+}
+
+interface CallItem {
+  agent: string
+  task: string
+}
+
+function renderChainCall(chain: CallItem[], scope: AgentScope, theme: Theme): Text {
+  let text = theme.fg('toolTitle', theme.bold('subagent ')) + theme.fg('accent', `chain (${chain.length} steps)`) + theme.fg('muted', ` [${scope}]`)
+  for (let i = 0; i < Math.min(chain.length, 3); i++) {
+    const step = chain[i]
+    // Clean up {previous} placeholder for display
+    const cleanTask = step.task.replaceAll('{previous}', '').trim()
+    const preview = cleanTask.length > 40 ? `${cleanTask.slice(0, 40)}...` : cleanTask
+    const stepNumber = theme.fg('muted', `${i + 1}.`)
+    const stepLabel = theme.fg('accent', step.agent) + theme.fg('dim', ` ${preview}`)
+    text += `\n  ${stepNumber} ${stepLabel}`
+  }
+  if (chain.length > 3) {
+    const more = theme.fg('muted', `... +${chain.length - 3} more`)
+    text += `\n  ${more}`
+  }
+  return new Text(text, 0, 0)
+}
+
+function renderParallelCall(tasks: CallItem[], scope: AgentScope, theme: Theme): Text {
+  let text = theme.fg('toolTitle', theme.bold('subagent ')) + theme.fg('accent', `parallel (${tasks.length} tasks)`) + theme.fg('muted', ` [${scope}]`)
+  for (const t of tasks.slice(0, 3)) {
+    const preview = t.task.length > 40 ? `${t.task.slice(0, 40)}...` : t.task
+    const taskLabel = theme.fg('accent', t.agent) + theme.fg('dim', ` ${preview}`)
+    text += `\n  ${taskLabel}`
+  }
+  if (tasks.length > 3) {
+    const more = theme.fg('muted', `... +${tasks.length - 3} more`)
+    text += `\n  ${more}`
+  }
+  return new Text(text, 0, 0)
+}
+
+function renderSingleCall(agent: string | undefined, task: string | undefined, scope: AgentScope, theme: Theme): Text {
+  const agentName = agent || '...'
+  let preview = '...'
+  if (task) preview = task.length > 60 ? `${task.slice(0, 60)}...` : task
+  let text = theme.fg('toolTitle', theme.bold('subagent ')) + theme.fg('accent', agentName) + theme.fg('muted', ` [${scope}]`)
+  text += `\n  ${theme.fg('dim', preview)}`
+  return new Text(text, 0, 0)
+}
+
+type MarkdownTheme = ReturnType<typeof getMarkdownTheme>
+
+function aggregateUsage(results: SingleResult[]) {
+  const total = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 }
+  for (const r of results) {
+    total.input += r.usage.input
+    total.output += r.usage.output
+    total.cacheRead += r.usage.cacheRead
+    total.cacheWrite += r.usage.cacheWrite
+    total.cost += r.usage.cost
+    total.turns += r.usage.turns
+  }
+  return total
+}
+
+function renderDisplayItems(items: DisplayItem[], expanded: boolean, theme: Theme, limit?: number): string {
+  const toShow = limit ? items.slice(-limit) : items
+  const skipped = limit && items.length > limit ? items.length - limit : 0
+  let text = ''
+  if (skipped > 0) text += theme.fg('muted', `... ${skipped} earlier items\n`)
+  for (const item of toShow) {
+    if (item.type === 'text') {
+      const preview = expanded ? item.text : item.text.split('\n').slice(0, 3).join('\n')
+      text += `${theme.fg('toolOutput', preview)}\n`
+    } else {
+      text += `${theme.fg('muted', '→ ') + formatToolCall(item.name, item.args, theme.fg.bind(theme))}\n`
+    }
+  }
+  return text.trimEnd()
+}
+
+function addToolCallNodes(container: Container, items: DisplayItem[], theme: Theme): void {
+  for (const item of items) {
+    if (item.type === 'toolCall') {
+      container.addChild(new Text(theme.fg('muted', '→ ') + formatToolCall(item.name, item.args, theme.fg.bind(theme)), 0, 0))
+    }
+  }
+}
+
+function addTotalUsage(container: Container, results: SingleResult[], theme: Theme): void {
+  const usageStr = formatUsageStats(aggregateUsage(results))
+  if (usageStr) {
+    container.addChild(new Spacer(1))
+    const totalLine = theme.fg('dim', `Total: ${usageStr}`)
+    container.addChild(new Text(totalLine, 0, 0))
+  }
+}
+
+function renderSingleExpanded(r: SingleResult, isError: boolean, icon: string, theme: Theme, mdTheme: MarkdownTheme): Container {
+  const container = new Container()
+  const source = theme.fg('muted', ` (${r.agentSource})`)
+  let header = `${icon} ${theme.fg('toolTitle', theme.bold(r.agent))}${source}`
+  if (isError && r.stopReason) {
+    const reason = theme.fg('error', `[${r.stopReason}]`)
+    header += ` ${reason}`
+  }
+  container.addChild(new Text(header, 0, 0))
+  if (isError && r.errorMessage) container.addChild(new Text(theme.fg('error', `Error: ${r.errorMessage}`), 0, 0))
+  container.addChild(new Spacer(1))
+  container.addChild(new Text(theme.fg('muted', '─── Task ───'), 0, 0))
+  container.addChild(new Text(theme.fg('dim', r.task), 0, 0))
+  container.addChild(new Spacer(1))
+  container.addChild(new Text(theme.fg('muted', '─── Output ───'), 0, 0))
+
+  const displayItems = getDisplayItems(r.messages)
+  const finalOutput = getFinalOutput(r.messages)
+  if (displayItems.length === 0 && !finalOutput) {
+    container.addChild(new Text(theme.fg('muted', '(no output)'), 0, 0))
+  } else {
+    addToolCallNodes(container, displayItems, theme)
+    if (finalOutput) {
+      container.addChild(new Spacer(1))
+      container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme))
+    }
+  }
+
+  const usageStr = formatUsageStats(r.usage, r.model)
+  if (usageStr) {
+    container.addChild(new Spacer(1))
+    container.addChild(new Text(theme.fg('dim', usageStr), 0, 0))
+  }
+  return container
+}
+
+function renderSingleCollapsed(r: SingleResult, isError: boolean, icon: string, theme: Theme, expanded: boolean): Text {
+  const displayItems = getDisplayItems(r.messages)
+  const source = theme.fg('muted', ` (${r.agentSource})`)
+  let text = `${icon} ${theme.fg('toolTitle', theme.bold(r.agent))}${source}`
+  if (isError && r.stopReason) {
+    const reason = theme.fg('error', `[${r.stopReason}]`)
+    text += ` ${reason}`
+  }
+  if (isError && r.errorMessage) {
+    const errorLine = theme.fg('error', `Error: ${r.errorMessage}`)
+    text += `\n${errorLine}`
+  } else if (displayItems.length === 0) text += `\n${theme.fg('muted', '(no output)')}`
+  else {
+    text += `\n${renderDisplayItems(displayItems, expanded, theme, COLLAPSED_ITEM_COUNT)}`
+    if (displayItems.length > COLLAPSED_ITEM_COUNT) text += `\n${theme.fg('muted', '(Ctrl+O to expand)')}`
+  }
+  const usageStr = formatUsageStats(r.usage, r.model)
+  if (usageStr) text += `\n${theme.fg('dim', usageStr)}`
+  return new Text(text, 0, 0)
+}
+
+function renderSingleResult(r: SingleResult, expanded: boolean, theme: Theme, mdTheme: MarkdownTheme): Container | Text {
+  const isError = r.exitCode !== 0 || r.stopReason === 'error' || r.stopReason === 'aborted'
+  const icon = isError ? theme.fg('error', '✗') : theme.fg('success', '✓')
+  if (expanded) return renderSingleExpanded(r, isError, icon, theme, mdTheme)
+  return renderSingleCollapsed(r, isError, icon, theme, expanded)
+}
+
+function renderChainExpanded(results: SingleResult[], successCount: number, icon: string, theme: Theme, mdTheme: MarkdownTheme): Container {
+  const container = new Container()
+  const summary = theme.fg('accent', `${successCount}/${results.length} steps`)
+  container.addChild(new Text(`${icon} ${theme.fg('toolTitle', theme.bold('chain '))}${summary}`, 0, 0))
+
+  for (const r of results) {
+    const rIcon = r.exitCode === 0 ? theme.fg('success', '✓') : theme.fg('error', '✗')
+    const displayItems = getDisplayItems(r.messages)
+    const finalOutput = getFinalOutput(r.messages)
+
+    container.addChild(new Spacer(1))
+    const stepLabel = theme.fg('muted', `─── Step ${r.step}: `) + theme.fg('accent', r.agent)
+    container.addChild(new Text(`${stepLabel} ${rIcon}`, 0, 0))
+    container.addChild(new Text(theme.fg('muted', 'Task: ') + theme.fg('dim', r.task), 0, 0))
+
+    addToolCallNodes(container, displayItems, theme)
+
+    if (finalOutput) {
+      container.addChild(new Spacer(1))
+      container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme))
+    }
+
+    const stepUsage = formatUsageStats(r.usage, r.model)
+    if (stepUsage) container.addChild(new Text(theme.fg('dim', stepUsage), 0, 0))
+  }
+
+  addTotalUsage(container, results, theme)
+  return container
+}
+
+function renderChainCollapsed(results: SingleResult[], successCount: number, icon: string, theme: Theme, expanded: boolean): Text {
+  const summary = theme.fg('accent', `${successCount}/${results.length} steps`)
+  let text = `${icon} ${theme.fg('toolTitle', theme.bold('chain '))}${summary}`
+  for (const r of results) {
+    const rIcon = r.exitCode === 0 ? theme.fg('success', '✓') : theme.fg('error', '✗')
+    const displayItems = getDisplayItems(r.messages)
+    const stepLabel = theme.fg('muted', `─── Step ${r.step}: `)
+    text += `\n\n${stepLabel}${theme.fg('accent', r.agent)} ${rIcon}`
+    if (displayItems.length === 0) text += `\n${theme.fg('muted', '(no output)')}`
+    else text += `\n${renderDisplayItems(displayItems, expanded, theme, 5)}`
+  }
+  const usageStr = formatUsageStats(aggregateUsage(results))
+  if (usageStr) {
+    const totalLine = theme.fg('dim', `Total: ${usageStr}`)
+    text += `\n\n${totalLine}`
+  }
+  text += `\n${theme.fg('muted', '(Ctrl+O to expand)')}`
+  return new Text(text, 0, 0)
+}
+
+function renderChainResult(results: SingleResult[], expanded: boolean, theme: Theme, mdTheme: MarkdownTheme): Container | Text {
+  const successCount = results.filter((r) => r.exitCode === 0).length
+  const icon = successCount === results.length ? theme.fg('success', '✓') : theme.fg('error', '✗')
+  if (expanded) return renderChainExpanded(results, successCount, icon, theme, mdTheme)
+  return renderChainCollapsed(results, successCount, icon, theme, expanded)
+}
+
+function renderParallelExpanded(results: SingleResult[], icon: string, status: string, theme: Theme, mdTheme: MarkdownTheme): Container {
+  const container = new Container()
+  const summary = theme.fg('accent', status)
+  container.addChild(new Text(`${icon} ${theme.fg('toolTitle', theme.bold('parallel '))}${summary}`, 0, 0))
+
+  for (const r of results) {
+    const rIcon = r.exitCode === 0 ? theme.fg('success', '✓') : theme.fg('error', '✗')
+    const displayItems = getDisplayItems(r.messages)
+    const finalOutput = getFinalOutput(r.messages)
+
+    container.addChild(new Spacer(1))
+    const agentLabel = theme.fg('muted', '─── ') + theme.fg('accent', r.agent)
+    container.addChild(new Text(`${agentLabel} ${rIcon}`, 0, 0))
+    container.addChild(new Text(theme.fg('muted', 'Task: ') + theme.fg('dim', r.task), 0, 0))
+
+    addToolCallNodes(container, displayItems, theme)
+
+    if (finalOutput) {
+      container.addChild(new Spacer(1))
+      container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme))
+    }
+
+    const taskUsage = formatUsageStats(r.usage, r.model)
+    if (taskUsage) container.addChild(new Text(theme.fg('dim', taskUsage), 0, 0))
+  }
+
+  addTotalUsage(container, results, theme)
+  return container
+}
+
+function renderParallelCollapsed(results: SingleResult[], icon: string, status: string, theme: Theme, expanded: boolean, isRunning: boolean): Text {
+  const summary = theme.fg('accent', status)
+  let text = `${icon} ${theme.fg('toolTitle', theme.bold('parallel '))}${summary}`
+  for (const r of results) {
+    let rIcon = theme.fg('error', '✗')
+    if (r.exitCode === -1) rIcon = theme.fg('warning', '⏳')
+    else if (r.exitCode === 0) rIcon = theme.fg('success', '✓')
+    const displayItems = getDisplayItems(r.messages)
+    text += `\n\n${theme.fg('muted', '─── ')}${theme.fg('accent', r.agent)} ${rIcon}`
+    if (displayItems.length === 0) {
+      const placeholder = r.exitCode === -1 ? '(running...)' : '(no output)'
+      text += `\n${theme.fg('muted', placeholder)}`
+    } else text += `\n${renderDisplayItems(displayItems, expanded, theme, 5)}`
+  }
+  if (!isRunning) {
+    const usageStr = formatUsageStats(aggregateUsage(results))
+    if (usageStr) {
+      const totalLine = theme.fg('dim', `Total: ${usageStr}`)
+      text += `\n\n${totalLine}`
+    }
+  }
+  if (!expanded) text += `\n${theme.fg('muted', '(Ctrl+O to expand)')}`
+  return new Text(text, 0, 0)
+}
+
+function renderParallelResult(results: SingleResult[], expanded: boolean, theme: Theme, mdTheme: MarkdownTheme): Container | Text {
+  const running = results.filter((r) => r.exitCode === -1).length
+  const successCount = results.filter((r) => r.exitCode === 0).length
+  const failCount = results.filter((r) => r.exitCode > 0).length
+  const isRunning = running > 0
+
+  let icon = theme.fg('success', '✓')
+  if (isRunning) icon = theme.fg('warning', '⏳')
+  else if (failCount > 0) icon = theme.fg('warning', '◐')
+
+  let status = `${successCount}/${results.length} tasks`
+  if (isRunning) status = `${successCount + failCount}/${results.length} done, ${running} running`
+
+  if (expanded && !isRunning) return renderParallelExpanded(results, icon, status, theme, mdTheme)
+  return renderParallelCollapsed(results, icon, status, theme, expanded, isRunning)
+}
+
+export default function subagentExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: 'subagent',
     label: 'Subagent',
@@ -454,7 +1012,6 @@ export default function (pi: ExtensionAPI) {
       const agentScope: AgentScope = params.agentScope ?? 'user'
       const discovery = discoverAgents(ctx.cwd, agentScope)
       const agents = discovery.agents
-      const confirmProjectAgents = params.confirmProjectAgents ?? true
 
       const hasChain = (params.chain?.length ?? 0) > 0
       const hasTasks = (params.tasks?.length ?? 0) > 0
@@ -488,218 +1045,19 @@ export default function (pi: ExtensionAPI) {
       }
 
       // Gate repo-controlled project agents before any run (background included).
-      const requestedAgentNames = new Set<string>()
-      if (params.agent) requestedAgentNames.add(params.agent)
-      for (const step of params.chain ?? []) requestedAgentNames.add(step.agent)
-      for (const t of params.tasks ?? []) requestedAgentNames.add(t.agent)
-      const requestedProjectAgents = [...requestedAgentNames].map((name) => agents.find((a) => a.name === name)).filter((a): a is AgentConfig => a?.source === 'project')
+      let gateMode: SubagentMode = 'single'
+      if (hasChain) gateMode = 'chain'
+      else if (hasTasks) gateMode = 'parallel'
+      const gateResult = await checkProjectAgentGate(params, agents, ctx, discovery.projectAgentsDir, gateMode, makeDetails)
+      if (gateResult) return gateResult
 
-      const gateMode = hasChain ? 'chain' : hasTasks ? 'parallel' : 'single'
-      const gate = projectAgentGate(requestedProjectAgents.length, ctx.isProjectTrusted?.() ?? false, ctx.hasUI, confirmProjectAgents)
-      if (gate === 'refuse') {
-        const names = requestedProjectAgents.map((a) => a.name).join(', ')
-        return { content: [{ type: 'text', text: `Project-local agents (${names}) require a trusted project; refusing in non-interactive mode.` }], details: makeDetails(gateMode)([]) }
-      }
-      if (gate === 'confirm') {
-        const names = requestedProjectAgents.map((a) => a.name).join(', ')
-        const dir = discovery.projectAgentsDir ?? '(unknown)'
-        const ok = await ctx.ui.confirm('Run project-local agents?', `Agents: ${names}\nSource: ${dir}\n\nProject agents are repo-controlled. Only continue for trusted repositories.`)
-        if (!ok) return { content: [{ type: 'text', text: 'Canceled: project-local agents not approved.' }], details: makeDetails(gateMode)([]) }
-      }
+      if (params.background) return runBackgroundMode(params, agents, ctx.cwd, pi, makeDetails)
 
-      if (params.background) {
-        const task = params.task
-        const agentName = params.agent
-        if (!hasSingle || !task || !agentName) {
-          return {
-            content: [{ type: 'text', text: 'background: true requires single mode (agent + task).' }],
-            details: makeDetails('single')([]),
-          }
-        }
-        const agent = agents.find((a) => a.name === agentName)
-        if (!agent) {
-          const available = agents.map((a) => `"${a.name}"`).join(', ') || 'none'
-          return {
-            content: [{ type: 'text', text: `Unknown agent: "${agentName}". Available agents: ${available}.` }],
-            details: makeDetails('single')([]),
-          }
-        }
-        const args: string[] = ['--mode', 'json', '-p', '--no-session']
-        if (agent.model) args.push('--model', agent.model)
-        if (agent.tools && agent.tools.length > 0) args.push('--tools', agent.tools.join(','))
-        let tmpPrompt: { dir: string; filePath: string } | undefined
-        if (agent.systemPrompt.trim()) {
-          tmpPrompt = await writePromptToTempFile(agent.name, agent.systemPrompt)
-          args.push('--append-system-prompt', tmpPrompt.filePath)
-        }
-        args.push(`Task: ${task}`)
-        const invocation = getPiInvocation(args)
-        const id = startBackgroundRun(agent.name, task, { command: invocation.command, args: invocation.args, cwd: params.cwd ?? ctx.cwd }, (run) => {
-          if (tmpPrompt) {
-            try {
-              fs.unlinkSync(tmpPrompt.filePath)
-            } catch {
-              /* ignore */
-            }
-            try {
-              fs.rmdirSync(tmpPrompt.dir)
-            } catch {
-              /* ignore */
-            }
-          }
-          pi.sendMessage(
-            {
-              customType: 'subagent-background',
-              content: `Background subagent run ${run.id} (${run.agent}) ${run.state} after ${run.turns} turns.\n\n${run.output || '(no output)'}`,
-              display: true,
-            },
-            { triggerTurn: true },
-          )
-        })
-        return {
-          content: [{ type: 'text', text: `Started background run ${id} (${agent.name}). A notification will arrive on completion; check progress with {status: true}.` }],
-          details: makeDetails('single')([]),
-        }
-      }
+      const mode: ModeContext = { agents, defaultCwd: ctx.cwd, signal, onUpdate, makeDetails }
 
-      if (params.chain && params.chain.length > 0) {
-        const results: SingleResult[] = []
-        let previousOutput = ''
-
-        for (let i = 0; i < params.chain.length; i++) {
-          const step = params.chain[i]
-          const taskWithContext = step.task.replace(/\{previous\}/g, previousOutput)
-
-          // Create update callback that includes all previous results
-          const chainUpdate: OnUpdateCallback | undefined = onUpdate
-            ? (partial) => {
-                // Combine completed results with current streaming result
-                const currentResult = partial.details?.results[0]
-                if (currentResult) {
-                  const allResults = [...results, currentResult]
-                  onUpdate({
-                    content: partial.content,
-                    details: makeDetails('chain')(allResults),
-                  })
-                }
-              }
-            : undefined
-
-          const result = await runSingleAgent(ctx.cwd, agents, step.agent, taskWithContext, step.cwd, i + 1, signal, chainUpdate, makeDetails('chain'))
-          results.push(result)
-
-          const isError = result.exitCode !== 0 || result.stopReason === 'error' || result.stopReason === 'aborted'
-          if (isError) {
-            const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || '(no output)'
-            return {
-              content: [{ type: 'text', text: `Chain stopped at step ${i + 1} (${step.agent}): ${errorMsg}` }],
-              details: makeDetails('chain')(results),
-              isError: true,
-            }
-          }
-          previousOutput = getFinalOutput(result.messages)
-        }
-        return {
-          content: [{ type: 'text', text: getFinalOutput(results[results.length - 1].messages) || '(no output)' }],
-          details: makeDetails('chain')(results),
-        }
-      }
-
-      if (params.tasks && params.tasks.length > 0) {
-        if (params.tasks.length > MAX_PARALLEL_TASKS)
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Too many parallel tasks (${params.tasks.length}). Max is ${MAX_PARALLEL_TASKS}.`,
-              },
-            ],
-            details: makeDetails('parallel')([]),
-          }
-
-        // Track all results for streaming updates
-        const allResults: SingleResult[] = new Array(params.tasks.length)
-
-        // Initialize placeholder results
-        for (let i = 0; i < params.tasks.length; i++) {
-          allResults[i] = {
-            agent: params.tasks[i].agent,
-            agentSource: 'unknown',
-            task: params.tasks[i].task,
-            exitCode: -1, // -1 = still running
-            messages: [],
-            stderr: '',
-            usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
-          }
-        }
-
-        const emitParallelUpdate = () => {
-          if (onUpdate) {
-            const running = allResults.filter((r) => r.exitCode === -1).length
-            const done = allResults.filter((r) => r.exitCode !== -1).length
-            onUpdate({
-              content: [{ type: 'text', text: `Parallel: ${done}/${allResults.length} done, ${running} running...` }],
-              details: makeDetails('parallel')([...allResults]),
-            })
-          }
-        }
-
-        const results = await mapWithConcurrencyLimit(params.tasks, MAX_CONCURRENCY, async (t, index) => {
-          const result = await runSingleAgent(
-            ctx.cwd,
-            agents,
-            t.agent,
-            t.task,
-            t.cwd,
-            undefined,
-            signal,
-            // Per-task update callback
-            (partial) => {
-              if (partial.details?.results[0]) {
-                allResults[index] = partial.details.results[0]
-                emitParallelUpdate()
-              }
-            },
-            makeDetails('parallel'),
-          )
-          allResults[index] = result
-          emitParallelUpdate()
-          return result
-        })
-
-        const successCount = results.filter((r) => r.exitCode === 0).length
-        const summaries = results.map((r) => {
-          const output = getFinalOutput(r.messages)
-          const preview = output.slice(0, 100) + (output.length > 100 ? '...' : '')
-          return `[${r.agent}] ${r.exitCode === 0 ? 'completed' : 'failed'}: ${preview || '(no output)'}`
-        })
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Parallel: ${successCount}/${results.length} succeeded\n\n${summaries.join('\n\n')}`,
-            },
-          ],
-          details: makeDetails('parallel')(results),
-        }
-      }
-
-      if (params.agent && params.task) {
-        const result = await runSingleAgent(ctx.cwd, agents, params.agent, params.task, params.cwd, undefined, signal, onUpdate, makeDetails('single'))
-        const isError = result.exitCode !== 0 || result.stopReason === 'error' || result.stopReason === 'aborted'
-        if (isError) {
-          const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || '(no output)'
-          return {
-            content: [{ type: 'text', text: `Agent ${result.stopReason || 'failed'}: ${errorMsg}` }],
-            details: makeDetails('single')([result]),
-            isError: true,
-          }
-        }
-        return {
-          content: [{ type: 'text', text: getFinalOutput(result.messages) || '(no output)' }],
-          details: makeDetails('single')([result]),
-        }
-      }
+      if (params.chain?.length) return runChainMode(params.chain, mode)
+      if (params.tasks?.length) return runParallelMode(params.tasks, mode)
+      if (params.agent && params.task) return runSingleMode(params.agent, params.task, params.cwd, mode)
 
       const available = agents.map((a) => `${a.name} (${a.source})`).join(', ') || 'none'
       return {
@@ -710,32 +1068,9 @@ export default function (pi: ExtensionAPI) {
 
     renderCall(args, theme, _context) {
       const scope: AgentScope = args.agentScope ?? 'user'
-      if (args.chain && args.chain.length > 0) {
-        let text = theme.fg('toolTitle', theme.bold('subagent ')) + theme.fg('accent', `chain (${args.chain.length} steps)`) + theme.fg('muted', ` [${scope}]`)
-        for (let i = 0; i < Math.min(args.chain.length, 3); i++) {
-          const step = args.chain[i]
-          // Clean up {previous} placeholder for display
-          const cleanTask = step.task.replace(/\{previous\}/g, '').trim()
-          const preview = cleanTask.length > 40 ? `${cleanTask.slice(0, 40)}...` : cleanTask
-          text += `\n  ${theme.fg('muted', `${i + 1}.`)} ${theme.fg('accent', step.agent)}${theme.fg('dim', ` ${preview}`)}`
-        }
-        if (args.chain.length > 3) text += `\n  ${theme.fg('muted', `... +${args.chain.length - 3} more`)}`
-        return new Text(text, 0, 0)
-      }
-      if (args.tasks && args.tasks.length > 0) {
-        let text = theme.fg('toolTitle', theme.bold('subagent ')) + theme.fg('accent', `parallel (${args.tasks.length} tasks)`) + theme.fg('muted', ` [${scope}]`)
-        for (const t of args.tasks.slice(0, 3)) {
-          const preview = t.task.length > 40 ? `${t.task.slice(0, 40)}...` : t.task
-          text += `\n  ${theme.fg('accent', t.agent)}${theme.fg('dim', ` ${preview}`)}`
-        }
-        if (args.tasks.length > 3) text += `\n  ${theme.fg('muted', `... +${args.tasks.length - 3} more`)}`
-        return new Text(text, 0, 0)
-      }
-      const agentName = args.agent || '...'
-      const preview = args.task ? (args.task.length > 60 ? `${args.task.slice(0, 60)}...` : args.task) : '...'
-      let text = theme.fg('toolTitle', theme.bold('subagent ')) + theme.fg('accent', agentName) + theme.fg('muted', ` [${scope}]`)
-      text += `\n  ${theme.fg('dim', preview)}`
-      return new Text(text, 0, 0)
+      if (args.chain && args.chain.length > 0) return renderChainCall(args.chain, scope, theme)
+      if (args.tasks && args.tasks.length > 0) return renderParallelCall(args.tasks, scope, theme)
+      return renderSingleCall(args.agent, args.task, scope, theme)
     },
 
     renderResult(result, { expanded }, theme, _context) {
@@ -747,204 +1082,9 @@ export default function (pi: ExtensionAPI) {
 
       const mdTheme = getMarkdownTheme()
 
-      const renderDisplayItems = (items: DisplayItem[], limit?: number) => {
-        const toShow = limit ? items.slice(-limit) : items
-        const skipped = limit && items.length > limit ? items.length - limit : 0
-        let text = ''
-        if (skipped > 0) text += theme.fg('muted', `... ${skipped} earlier items\n`)
-        for (const item of toShow) {
-          if (item.type === 'text') {
-            const preview = expanded ? item.text : item.text.split('\n').slice(0, 3).join('\n')
-            text += `${theme.fg('toolOutput', preview)}\n`
-          } else {
-            text += `${theme.fg('muted', '→ ') + formatToolCall(item.name, item.args, theme.fg.bind(theme))}\n`
-          }
-        }
-        return text.trimEnd()
-      }
-
-      if (details.mode === 'single' && details.results.length === 1) {
-        const r = details.results[0]
-        const isError = r.exitCode !== 0 || r.stopReason === 'error' || r.stopReason === 'aborted'
-        const icon = isError ? theme.fg('error', '✗') : theme.fg('success', '✓')
-        const displayItems = getDisplayItems(r.messages)
-        const finalOutput = getFinalOutput(r.messages)
-
-        if (expanded) {
-          const container = new Container()
-          let header = `${icon} ${theme.fg('toolTitle', theme.bold(r.agent))}${theme.fg('muted', ` (${r.agentSource})`)}`
-          if (isError && r.stopReason) header += ` ${theme.fg('error', `[${r.stopReason}]`)}`
-          container.addChild(new Text(header, 0, 0))
-          if (isError && r.errorMessage) container.addChild(new Text(theme.fg('error', `Error: ${r.errorMessage}`), 0, 0))
-          container.addChild(new Spacer(1))
-          container.addChild(new Text(theme.fg('muted', '─── Task ───'), 0, 0))
-          container.addChild(new Text(theme.fg('dim', r.task), 0, 0))
-          container.addChild(new Spacer(1))
-          container.addChild(new Text(theme.fg('muted', '─── Output ───'), 0, 0))
-          if (displayItems.length === 0 && !finalOutput) {
-            container.addChild(new Text(theme.fg('muted', '(no output)'), 0, 0))
-          } else {
-            for (const item of displayItems) {
-              if (item.type === 'toolCall') container.addChild(new Text(theme.fg('muted', '→ ') + formatToolCall(item.name, item.args, theme.fg.bind(theme)), 0, 0))
-            }
-            if (finalOutput) {
-              container.addChild(new Spacer(1))
-              container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme))
-            }
-          }
-          const usageStr = formatUsageStats(r.usage, r.model)
-          if (usageStr) {
-            container.addChild(new Spacer(1))
-            container.addChild(new Text(theme.fg('dim', usageStr), 0, 0))
-          }
-          return container
-        }
-
-        let text = `${icon} ${theme.fg('toolTitle', theme.bold(r.agent))}${theme.fg('muted', ` (${r.agentSource})`)}`
-        if (isError && r.stopReason) text += ` ${theme.fg('error', `[${r.stopReason}]`)}`
-        if (isError && r.errorMessage) text += `\n${theme.fg('error', `Error: ${r.errorMessage}`)}`
-        else if (displayItems.length === 0) text += `\n${theme.fg('muted', '(no output)')}`
-        else {
-          text += `\n${renderDisplayItems(displayItems, COLLAPSED_ITEM_COUNT)}`
-          if (displayItems.length > COLLAPSED_ITEM_COUNT) text += `\n${theme.fg('muted', '(Ctrl+O to expand)')}`
-        }
-        const usageStr = formatUsageStats(r.usage, r.model)
-        if (usageStr) text += `\n${theme.fg('dim', usageStr)}`
-        return new Text(text, 0, 0)
-      }
-
-      const aggregateUsage = (results: SingleResult[]) => {
-        const total = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 }
-        for (const r of results) {
-          total.input += r.usage.input
-          total.output += r.usage.output
-          total.cacheRead += r.usage.cacheRead
-          total.cacheWrite += r.usage.cacheWrite
-          total.cost += r.usage.cost
-          total.turns += r.usage.turns
-        }
-        return total
-      }
-
-      if (details.mode === 'chain') {
-        const successCount = details.results.filter((r) => r.exitCode === 0).length
-        const icon = successCount === details.results.length ? theme.fg('success', '✓') : theme.fg('error', '✗')
-
-        if (expanded) {
-          const container = new Container()
-          container.addChild(new Text(`${icon} ${theme.fg('toolTitle', theme.bold('chain '))}${theme.fg('accent', `${successCount}/${details.results.length} steps`)}`, 0, 0))
-
-          for (const r of details.results) {
-            const rIcon = r.exitCode === 0 ? theme.fg('success', '✓') : theme.fg('error', '✗')
-            const displayItems = getDisplayItems(r.messages)
-            const finalOutput = getFinalOutput(r.messages)
-
-            container.addChild(new Spacer(1))
-            container.addChild(new Text(`${theme.fg('muted', `─── Step ${r.step}: `) + theme.fg('accent', r.agent)} ${rIcon}`, 0, 0))
-            container.addChild(new Text(theme.fg('muted', 'Task: ') + theme.fg('dim', r.task), 0, 0))
-
-            // Show tool calls
-            for (const item of displayItems) {
-              if (item.type === 'toolCall') {
-                container.addChild(new Text(theme.fg('muted', '→ ') + formatToolCall(item.name, item.args, theme.fg.bind(theme)), 0, 0))
-              }
-            }
-
-            // Show final output as markdown
-            if (finalOutput) {
-              container.addChild(new Spacer(1))
-              container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme))
-            }
-
-            const stepUsage = formatUsageStats(r.usage, r.model)
-            if (stepUsage) container.addChild(new Text(theme.fg('dim', stepUsage), 0, 0))
-          }
-
-          const usageStr = formatUsageStats(aggregateUsage(details.results))
-          if (usageStr) {
-            container.addChild(new Spacer(1))
-            container.addChild(new Text(theme.fg('dim', `Total: ${usageStr}`), 0, 0))
-          }
-          return container
-        }
-
-        // Collapsed view
-        let text = `${icon} ${theme.fg('toolTitle', theme.bold('chain '))}${theme.fg('accent', `${successCount}/${details.results.length} steps`)}`
-        for (const r of details.results) {
-          const rIcon = r.exitCode === 0 ? theme.fg('success', '✓') : theme.fg('error', '✗')
-          const displayItems = getDisplayItems(r.messages)
-          text += `\n\n${theme.fg('muted', `─── Step ${r.step}: `)}${theme.fg('accent', r.agent)} ${rIcon}`
-          if (displayItems.length === 0) text += `\n${theme.fg('muted', '(no output)')}`
-          else text += `\n${renderDisplayItems(displayItems, 5)}`
-        }
-        const usageStr = formatUsageStats(aggregateUsage(details.results))
-        if (usageStr) text += `\n\n${theme.fg('dim', `Total: ${usageStr}`)}`
-        text += `\n${theme.fg('muted', '(Ctrl+O to expand)')}`
-        return new Text(text, 0, 0)
-      }
-
-      if (details.mode === 'parallel') {
-        const running = details.results.filter((r) => r.exitCode === -1).length
-        const successCount = details.results.filter((r) => r.exitCode === 0).length
-        const failCount = details.results.filter((r) => r.exitCode > 0).length
-        const isRunning = running > 0
-        const icon = isRunning ? theme.fg('warning', '⏳') : failCount > 0 ? theme.fg('warning', '◐') : theme.fg('success', '✓')
-        const status = isRunning ? `${successCount + failCount}/${details.results.length} done, ${running} running` : `${successCount}/${details.results.length} tasks`
-
-        if (expanded && !isRunning) {
-          const container = new Container()
-          container.addChild(new Text(`${icon} ${theme.fg('toolTitle', theme.bold('parallel '))}${theme.fg('accent', status)}`, 0, 0))
-
-          for (const r of details.results) {
-            const rIcon = r.exitCode === 0 ? theme.fg('success', '✓') : theme.fg('error', '✗')
-            const displayItems = getDisplayItems(r.messages)
-            const finalOutput = getFinalOutput(r.messages)
-
-            container.addChild(new Spacer(1))
-            container.addChild(new Text(`${theme.fg('muted', '─── ') + theme.fg('accent', r.agent)} ${rIcon}`, 0, 0))
-            container.addChild(new Text(theme.fg('muted', 'Task: ') + theme.fg('dim', r.task), 0, 0))
-
-            // Show tool calls
-            for (const item of displayItems) {
-              if (item.type === 'toolCall') {
-                container.addChild(new Text(theme.fg('muted', '→ ') + formatToolCall(item.name, item.args, theme.fg.bind(theme)), 0, 0))
-              }
-            }
-
-            // Show final output as markdown
-            if (finalOutput) {
-              container.addChild(new Spacer(1))
-              container.addChild(new Markdown(finalOutput.trim(), 0, 0, mdTheme))
-            }
-
-            const taskUsage = formatUsageStats(r.usage, r.model)
-            if (taskUsage) container.addChild(new Text(theme.fg('dim', taskUsage), 0, 0))
-          }
-
-          const usageStr = formatUsageStats(aggregateUsage(details.results))
-          if (usageStr) {
-            container.addChild(new Spacer(1))
-            container.addChild(new Text(theme.fg('dim', `Total: ${usageStr}`), 0, 0))
-          }
-          return container
-        }
-
-        // Collapsed view (or still running)
-        let text = `${icon} ${theme.fg('toolTitle', theme.bold('parallel '))}${theme.fg('accent', status)}`
-        for (const r of details.results) {
-          const rIcon = r.exitCode === -1 ? theme.fg('warning', '⏳') : r.exitCode === 0 ? theme.fg('success', '✓') : theme.fg('error', '✗')
-          const displayItems = getDisplayItems(r.messages)
-          text += `\n\n${theme.fg('muted', '─── ')}${theme.fg('accent', r.agent)} ${rIcon}`
-          if (displayItems.length === 0) text += `\n${theme.fg('muted', r.exitCode === -1 ? '(running...)' : '(no output)')}`
-          else text += `\n${renderDisplayItems(displayItems, 5)}`
-        }
-        if (!isRunning) {
-          const usageStr = formatUsageStats(aggregateUsage(details.results))
-          if (usageStr) text += `\n\n${theme.fg('dim', `Total: ${usageStr}`)}`
-        }
-        if (!expanded) text += `\n${theme.fg('muted', '(Ctrl+O to expand)')}`
-        return new Text(text, 0, 0)
-      }
+      if (details.mode === 'single' && details.results.length === 1) return renderSingleResult(details.results[0], expanded, theme, mdTheme)
+      if (details.mode === 'chain') return renderChainResult(details.results, expanded, theme, mdTheme)
+      if (details.mode === 'parallel') return renderParallelResult(details.results, expanded, theme, mdTheme)
 
       const text = result.content[0]
       return new Text(text?.type === 'text' ? text.text : '(no output)', 0, 0)

--- a/extensions/web.ts
+++ b/extensions/web.ts
@@ -32,7 +32,9 @@ export function decodeEntities(text: string): string {
 }
 
 export function stripTags(html: string): string {
-  return decodeEntities(html.replace(/<[^>]*>/g, ''))
+  // [^<>] rather than [^>]: excluding `<` bounds a failed match at the next tag start
+  // instead of rescanning to end of input, which is what makes the strip linear.
+  return decodeEntities(html.replace(/<[^<>]*>/g, ''))
     .replace(/\s+/g, ' ')
     .trim()
 }
@@ -72,11 +74,44 @@ export function htmlToText(html: string): string {
     .replace(/<script[\s\S]*?<\/script>/gi, ' ')
     .replace(/<style[\s\S]*?<\/style>/gi, ' ')
     .replace(/<(br|\/p|\/div|\/h[1-6]|\/li|\/tr)[^>]*>/gi, '\n')
-  const text = decodeEntities(withoutBlocks.replace(/<[^>]*>/g, ' '))
+  const text = decodeEntities(withoutBlocks.replace(/<[^<>]*>/g, ' '))
     .replace(/[ \t]+/g, ' ')
     .replace(/\n\s+/g, '\n')
     .trim()
   return text.length > MAX_FETCH_CHARS ? `${text.slice(0, MAX_FETCH_CHARS)}\n[truncated ${text.length - MAX_FETCH_CHARS} chars]` : text
+}
+
+/**
+ * IPv4-mapped (::ffff:...) and NAT64 (64:ff9b::...) forms embed an IPv4 in the low 32 bits,
+ * in either dotted-decimal or hex; the WHATWG URL parser normalizes literals to the hex form.
+ */
+function embeddedIpv4(addr: string): string | null {
+  const dotted = /^(?:::ffff:|64:ff9b::)(\d+\.\d+\.\d+\.\d+)$/.exec(addr)
+  if (dotted) return dotted[1]
+  const hex = /^(?:::ffff:|64:ff9b::)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(addr)
+  if (!hex) return null
+  const hi = Number.parseInt(hex[1], 16)
+  const lo = Number.parseInt(hex[2], 16)
+  return `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`
+}
+
+function isPrivateIpv6(addr: string): boolean {
+  const embedded = embeddedIpv4(addr)
+  if (embedded) return isPrivateAddress(embedded)
+  if (addr === '::1' || addr === '::') return true
+  if (/^fe[89ab]/.test(addr)) return true // link-local fe80::/10
+  return /^f[cd]/.test(addr) // unique local fc00::/7
+}
+
+function isPrivateIpv4(addr: string): boolean {
+  const parts = addr.split('.').map(Number)
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return true
+  const [a, b] = parts
+  if (a === 0 || a === 10 || a === 127) return true
+  if (a === 169 && b === 254) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  return a === 100 && b >= 64 && b <= 127
 }
 
 /** SSRF guard: true for loopback, RFC1918, link-local, CGNAT, and private IPv6 ranges. Fails closed on unparseable input. */
@@ -85,31 +120,7 @@ export function isPrivateAddress(ip: string): boolean {
     .toLowerCase()
     .replace(/^\[|\]$/g, '')
     .split('%')[0]
-  if (addr.includes(':')) {
-    // IPv4-mapped (::ffff:...) and NAT64 (64:ff9b::...) forms embed an IPv4 in the low 32 bits,
-    // in either dotted-decimal or hex; the WHATWG URL parser normalizes literals to the hex form.
-    const dotted = /^(?:::ffff:|64:ff9b::)(\d+\.\d+\.\d+\.\d+)$/.exec(addr)
-    if (dotted) return isPrivateAddress(dotted[1])
-    const hex = /^(?:::ffff:|64:ff9b::)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(addr)
-    if (hex) {
-      const hi = Number.parseInt(hex[1], 16)
-      const lo = Number.parseInt(hex[2], 16)
-      return isPrivateAddress(`${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`)
-    }
-    if (addr === '::1' || addr === '::') return true
-    if (/^fe[89ab]/.test(addr)) return true // link-local fe80::/10
-    if (/^f[cd]/.test(addr)) return true // unique local fc00::/7
-    return false
-  }
-  const parts = addr.split('.').map(Number)
-  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return true
-  const [a, b] = parts
-  if (a === 0 || a === 10 || a === 127) return true
-  if (a === 169 && b === 254) return true
-  if (a === 172 && b >= 16 && b <= 31) return true
-  if (a === 192 && b === 168) return true
-  if (a === 100 && b >= 64 && b <= 127) return true
-  return false
+  return addr.includes(':') ? isPrivateIpv6(addr) : isPrivateIpv4(addr)
 }
 
 async function assertPublicHost(url: URL): Promise<void> {

--- a/tests/git-checkpoint-more.test.ts
+++ b/tests/git-checkpoint-more.test.ts
@@ -73,7 +73,7 @@ function setup() {
 
   const shadowHome = hoisted.home
   const sessionFile = join(repo, SESSION_FILE_NAME)
-  execFileSync('git', ['init', '-qb', 'main'], { cwd: repo })
+  execFileSync('git', ['init', '-qb', 'main'], { cwd: repo, stdio: ['pipe', 'pipe', 'pipe'] })
   writeFileSync(join(repo, 'tracked.txt'), 'v1\n')
 
   gitCheckpoint({
@@ -83,7 +83,7 @@ function setup() {
     exec: async (cmd: string, args: string[], options?: { cwd?: string }) => {
       execArgs.push(args)
       try {
-        return { stdout: execFileSync(cmd, args, { cwd: options?.cwd ?? repo, encoding: 'utf8' }), stderr: '', code: 0, killed: false }
+        return { stdout: execFileSync(cmd, args, { cwd: options?.cwd ?? repo, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }), stderr: '', code: 0, killed: false }
       } catch (err: any) {
         return { stdout: err.stdout ?? '', stderr: err.stderr ?? String(err), code: err.status ?? 1, killed: false }
       }

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -48,7 +48,7 @@ function setup() {
   tempDirs.push(repo, hoisted.home)
 
   const sessionFile = join(repo, 'session-test.jsonl')
-  execFileSync('git', ['init', '-qb', 'main'], { cwd: repo })
+  execFileSync('git', ['init', '-qb', 'main'], { cwd: repo, stdio: ['pipe', 'pipe', 'pipe'] })
   writeFileSync(join(repo, 'tracked.txt'), 'v1\n')
   writeFileSync(join(repo, 'untracked.txt'), 'precious\n')
 
@@ -58,7 +58,7 @@ function setup() {
     appendEntry: (customType: string, data: any) => appended.push({ type: 'custom', customType, data }),
     exec: async (cmd: string, args: string[], options?: { cwd?: string }) => {
       try {
-        return { stdout: execFileSync(cmd, args, { cwd: options?.cwd ?? repo, encoding: 'utf8' }), stderr: '', code: 0, killed: false }
+        return { stdout: execFileSync(cmd, args, { cwd: options?.cwd ?? repo, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }), stderr: '', code: 0, killed: false }
       } catch (err: any) {
         return { stdout: err.stdout ?? '', stderr: err.stderr ?? String(err), code: err.status ?? 1, killed: false }
       }


### PR DESCRIPTION
Clears the remaining findings after #3. 628 tests pass unchanged throughout.

| File | Findings |
|---|---|
| `subagent/index.ts` | cognitive complexity in `execute` (51), `renderResult` (157), `renderCall` (21), `processLine` (21); 16 nested template literals; 3 nested ternaries; 9-parameter `runSingleAgent`; anonymous default export; `replaceAll`; `.at(-1)` |
| `web.ts` | tag regex backtracking (x2), `isPrivateAddress` complexity |
| `context-imports.ts` | `collectImports` complexity, consecutive `push` calls |
| `plan-mode/utils.ts` | regex backtracking, duplicate character class |
| `mcp.ts` | SSE deprecation suppression moved onto the flagged line |

## Behavior change

One, deliberate. Making the tag regex linear required `<[^<>]*>` instead of `<[^>]*>`. On malformed nested input such as `<a<b>` the old pattern swallowed `<a`; the new one emits it as text. Verified across 6021 inputs (21 curated plus 6000 fuzzed) as the only divergence class. The two standard atomic-group workarounds were tried and both remain quadratic, so they would satisfy the rule without fixing the performance. On 40k unclosed tags: 2289ms to 0.21ms.

`isPrivateAddress` was split into helpers and checked against the original over 43,880 inputs with zero mismatches.

## Also

`tests/git-checkpoint*.test.ts` now pass `stdio` to `execFileSync`. Without it the child's stderr is forwarded to the parent, so the expected `fatal: not a git repository` probes from the shadow-repo path flooded test output and would hide a genuine failure.

## Not addressed

The `TODO` comment findings are false positives: they match the word "Todo" in prose describing the todo extension ("Todo Extension", "Todos move through a status machine"). There is no task to complete, and rewording accurate documentation to satisfy the rule would be worse. These want triage in SonarCloud rather than a code change.