### PR TITLE
Scan plan step lines instead of matching them with a regex

### DIFF
--- a/extensions/plan-mode/utils.ts
+++ b/extensions/plan-mode/utils.ts
@@ -127,19 +127,49 @@ export function cleanStepText(text: string): string {
 // the following \n, which is what backtracks super-linearly.
 const PLAN_HEADER = /\*{0,2}Plan:\*{0,2}[^\S\n]*\n/i
 
+const isBlank = (ch: string | undefined): boolean => ch !== undefined && ch !== '\n' && ch.trim() === ''
+
+/**
+ * Text of a `1. step` / `2) step` line, stopping at an inline `*`, or undefined when
+ * the line is not a numbered step. Scanned rather than matched: the equivalent
+ * pattern needs adjacent quantifiers over overlapping classes, which backtracks
+ * super-linearly on a long line that turns out not to be a step.
+ */
+function numberedStepText(line: string): string | undefined {
+  let i = 0
+  while (isBlank(line[i])) i++
+
+  const digitsStart = i
+  while (line[i] >= '0' && line[i] <= '9') i++
+  if (i === digitsStart) return undefined
+
+  if (line[i] !== '.' && line[i] !== ')') return undefined
+  i++
+
+  const spaceStart = i
+  while (isBlank(line[i])) i++
+  if (i === spaceStart) return undefined // the marker must be followed by whitespace
+
+  for (let stars = 0; stars < 2 && line[i] === '*'; stars++) i++
+  const first = line[i]
+  if (first === undefined || first === '*' || isBlank(first)) return undefined
+
+  const rest = line.slice(i)
+  const star = rest.indexOf('*')
+  return star === -1 ? rest : rest.slice(0, star)
+}
+
 export function extractTodoItems(message: string): TodoItem[] {
   const items: TodoItem[] = []
   const headerMatch = PLAN_HEADER.exec(message)
   if (!headerMatch) return items
 
   const planSection = message.slice(message.indexOf(headerMatch[0]) + headerMatch[0].length)
-  // Separators are horizontal whitespace only: under /m the anchor already sits at
-  // each line start, so letting \s cross newlines only adds backtracking. The capture
-  // starts on a non-whitespace char so the preceding run owns all separator space.
-  const numberedPattern = /^[^\S\n]*(\d+)[.)][^\S\n]+\*{0,2}([^\s*][^*\n]*)/gm
 
-  for (const match of planSection.matchAll(numberedPattern)) {
-    const text = match[2]
+  for (const line of planSection.split('\n')) {
+    const captured = numberedStepText(line)
+    if (captured === undefined) continue
+    const text = captured
       .trim()
       .replace(/\*{1,2}$/, '')
       .trim()


### PR DESCRIPTION
Clears the remaining `typescript:S8786` finding on `extensions/plan-mode/utils.ts`.

The numbered-step pattern `/^[^\S\n]*(\d+)[.)][^\S\n]+\*{0,2}([^\s*][^*\n]*)/gm` needs adjacent quantifiers over overlapping character classes. Three attempts to reshape it (anchoring the capture on a non-whitespace char, then restricting the separators to horizontal whitespace) each cleared one report and left the rule firing. Scanning the line character by character removes the class of problem rather than reshuffling it, and is the same approach already used for the `paths:` block list in `claude-rules.ts`.

## Equivalence

Checked against the old pattern over **60,029 inputs** — 28 curated cases plus 60,000 fuzzed strings over a plan-ish alphabet — with **zero divergences**. Curated coverage: indentation, `.` and `)` markers, missing separator space, one/two/three leading asterisks, inline and trailing asterisks, tabs, multi-digit and zero indices, CRLF line endings, unicode text, blank lines between steps, and a 300-character step.

The one divergence class, found and then excluded deliberately, is input containing a lone `\r` not followed by `\n` (classic Mac line endings). The old regex handled those inconsistently in any case: under `/m` a `\r` starts a new line for the anchor, but `[^*\n]` lets a capture run straight through it. Plan text reaching this function is `\n` or `\r\n`.

## Performance

No measured speedup, and none is claimed. I could not construct an input where the old pattern degrades — V8 handles the adjacent-quantifier cases here without blowing up. On a 200k-character non-step line the regex is in fact marginally faster (0.7ms vs 1.5ms). The change removes a latent backtracking risk and clears the rule; it is not a performance fix.