### PR TITLE
Release 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-code",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, and subagents",
   "keywords": [
     "pi-package"


### PR DESCRIPTION
Patch bump. Changes since 0.1.0 are bug fixes, internal quality work and docs; no new features.

Fixes:
- The question overlay cached rendered lines without keying on width, so a terminal resize repainted at the stale width.
- A bare `-` in a `paths:` block list pushed an empty path and kept scanning.
- `stripTags` / `htmlToText` no longer backtrack on unclosed tags. Malformed nested input such as `<a<b>` now emits the stray text instead of swallowing it.

Also: statement coverage 36.9% to 98%, Sonar code smells 77 to near zero, and the install section now documents the npm source.