### PR TITLE
Prompt for trust on projects pi would otherwise trust silently

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,16 +17,23 @@ An untrusted project can ship any `.claude/` content. These extensions read that
 | subagent | project `.claude/agents` / `.pi/agents` (their own system prompt and tools) |
 | output-styles | project style body, injected verbatim into the system prompt |
 | rules | project rule filenames and `paths:` frontmatter, surfaced in the system prompt |
-| context-imports | `@path` imports, confined via `realpath` to cwd, `~/.claude`, and `~/.pi` |
 
-`web_fetch` refuses loopback, RFC1918, link-local, CGNAT, and the IPv6 equivalents (including IPv4-mapped and NAT64 forms), and caps the response body before parsing.
+That gate is only as good as the trust decision behind it. pi decides whether to ask by looking for entries under `cwd/.pi` and for `.agents/skills`; a repository shipping only `.claude/` and `.mcp.json` matches neither and is trusted without a prompt. `project-trust` closes that: when a project carries Claude-shaped config that pi would not ask about, it prompts and remembers the answer. It stays out of the way when pi already prompts, when a decision is stored, and when there is no UI to ask with, so it never overrides a remembered answer or forces a headless run closed. Only user/global and CLI extensions receive `project_trust`, so this applies to `pi install npm:pi-code`, not to a project-local (`-l`) install.
+
+`context-imports` confines `@path` imports with `realpath`. A file under the user's own config may import from `~/.claude` and `~/.pi`; a project file may import only from the working directory. Without that split a cloned repository's `CLAUDE.md` could read `~/.claude/.credentials.json`, global settings, and other projects' transcripts into the system prompt.
+
+`web_fetch` refuses loopback, RFC1918, link-local, CGNAT, benchmark (198.18/15), protocol-assignment (192.0.0/24), multicast, reserved (240/4) and broadcast addresses, and the IPv6 equivalents including IPv4-mapped, NAT64, unique-local, link-local, site-local and multicast. It fails closed when a host resolves to no address, refuses a redirect that leaves `http(s)`, and caps the response body before parsing.
 
 ## Known limitations
 
 These are not addressed yet. None is a trust-model bypass on macOS/Linux, which are the primary supported platforms.
 
+- **Plan mode's bash allowlist is model steering, not a sandbox.** It validates each subcommand independently, refuses command and process substitution, and excludes commands carrying execution, write or exfiltration primitives. It cannot constrain an allowlisted interpreter that reads or writes files itself, and pi-code has no OS-level isolation to fall back on. Treat it as narrowing the blast radius of a wrong turn, not as containing a determined one.
 - **Windows.** `hooks` runs commands through `sh`; if `sh` is absent it fails open (the tool is allowed rather than blocked). The `subagent` fallback spawn also assumes `pi` is not a `.cmd` shim. Use on Windows is untested.
-- **hooks timeout is fail-open.** A `PreToolUse` hook that hangs past its timeout lets the tool through instead of blocking it.
+- **hooks timeout is not enforced for compound commands.** Only a single-command hook is exec'd directly by `sh` and killed on timeout. A compound hook (`a; b`, a pipeline, a multi-line script) leaves grandchildren holding the stdio pipes, so the run resolves only when the child finishes naturally: the tool call stalls for that full duration and is then allowed through. A hook that tried to block with `exit 2` is reported as exit 0.
+- **hook stdout is not capped.** A hook emitting hundreds of megabytes is buffered whole.
 - **DNS-rebinding TOCTOU (`web`).** The SSRF guard validates the resolved address, then `fetch` resolves the host again independently; the validated IP is not pinned for the connection. A rebinding server with a zero-TTL record can pass the check and then be reached at a private address.
 - **skills / commands are not trust-gated.** Their path handling is safe (fixed `.claude/skills` and `.claude/commands` paths, no filename or content reaches a command), but the directories are handed to pi's loader without a trust check. The residual risk is pi's loader surfacing untrusted skill descriptions or command bodies to the model.
 - **web body cap is a mitigation, not a bound of zero.** `web_fetch` caps the raw response at 200 KB before the HTML regexes run. A hostile page near that cap can still block the event loop for a few seconds; benign pages (which close their tags) are unaffected.
+- **Agent discovery walks above the project root.** `.claude/agents` and `.pi/agents` are searched from the working directory up to the filesystem root, so an agent planted in a world-writable ancestor such as `/tmp` is offered as a project agent. The consent prompt also reports `(unknown)` as the source unless the agents came from `.pi/agents`.
+- **Imports are unbounded in count and size.** The `@path` depth cap and cycle detection hold, but a context file may pull in an unlimited number of files from the working directory.

--- a/extensions/project-trust.ts
+++ b/extensions/project-trust.ts
@@ -1,0 +1,65 @@
+/**
+ * Project Trust Extension
+ *
+ * pi decides whether to prompt for trust from `hasTrustRequiringProjectResources`,
+ * which looks only at entries under `cwd/.pi` and at `.agents/skills`. A repository
+ * that ships only Claude Code shaped config, `.claude/` plus `.mcp.json`, matches
+ * none of them, so pi trusts it without asking.
+ *
+ * That is exactly the shape pi-code exists to load, and the other extensions gate
+ * their project input on `ctx.isProjectTrusted()`. Without this handler that flag is
+ * true for a freshly cloned repo nobody was asked about, and a project `.mcp.json`
+ * server command, project hooks and project agents all run.
+ *
+ * Only user/global and CLI extensions receive `project_trust`, so this works when
+ * pi-code is installed with `pi install npm:pi-code`. A project-local install
+ * (`pi install -l`) is not loaded until trust is already resolved.
+ *
+ * Docs: node_modules/@earendil-works/pi-coding-agent/docs/extensions.md (project_trust)
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { type ExtensionAPI, getAgentDir, hasTrustRequiringProjectResources, ProjectTrustStore } from '@earendil-works/pi-coding-agent'
+
+/** Project files pi-code acts on that pi's own trust check does not look for. */
+const CLAUDE_SHAPED = [path.join('.claude', 'settings.json'), path.join('.claude', 'settings.local.json'), path.join('.claude', 'agents'), path.join('.claude', 'hooks'), path.join('.claude', 'output-styles'), '.mcp.json', path.join('.pi', 'mcp.json'), path.join('.pi', 'agents')]
+
+export function hasClaudeShapedConfig(cwd: string): boolean {
+  return CLAUDE_SHAPED.some((entry) => fs.existsSync(path.join(cwd, entry)))
+}
+
+export type TrustDecision = { trusted: 'yes' | 'no' | 'undecided'; remember?: boolean }
+
+interface TrustDeps {
+  hasClaudeShaped: (cwd: string) => boolean
+  piWouldAsk: (cwd: string) => boolean
+  savedDecision: (cwd: string) => boolean | null
+}
+
+const defaultDeps: TrustDeps = {
+  hasClaudeShaped: hasClaudeShapedConfig,
+  piWouldAsk: hasTrustRequiringProjectResources,
+  savedDecision: (cwd) => new ProjectTrustStore(getAgentDir()).get(cwd),
+}
+
+/**
+ * Whether to take over the trust decision for this project.
+ *
+ * Returns `undecided` wherever pi already resolves things correctly, so a remembered
+ * decision is never overridden and a headless run keeps whatever `defaultProjectTrust`
+ * says rather than being forced closed.
+ */
+export async function decideTrust(cwd: string, hasUI: boolean, confirm: (title: string, body: string) => Promise<boolean>, deps: TrustDeps = defaultDeps): Promise<TrustDecision> {
+  if (!deps.hasClaudeShaped(cwd)) return { trusted: 'undecided' }
+  if (deps.piWouldAsk(cwd)) return { trusted: 'undecided' } // pi prompts on its own
+  if (deps.savedDecision(cwd) !== null) return { trusted: 'undecided' } // apply the stored answer
+  if (!hasUI) return { trusted: 'undecided' } // cannot ask; leave pi's default in charge
+
+  const approved = await confirm('Trust this project?', `${cwd}\n\nIt ships Claude Code configuration that pi-code loads: MCP servers, hooks and agents can run commands from this repository.`)
+  return { trusted: approved ? 'yes' : 'no', remember: true }
+}
+
+export default function projectTrustExtension(pi: ExtensionAPI) {
+  pi.on('project_trust', async (event, ctx) => decideTrust(event.cwd, ctx.hasUI, (title, body) => ctx.ui.confirm(title, body)))
+}

--- a/tests/project-trust.test.ts
+++ b/tests/project-trust.test.ts
@@ -1,0 +1,72 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { decideTrust, hasClaudeShapedConfig } from '../extensions/project-trust.ts'
+
+const tempDir = (): string => mkdtempSync(join(tmpdir(), 'pt-'))
+
+/** pi's own trust check and trust store, stubbed so the decision logic is what is under test. */
+const deps = (over: Partial<Parameters<typeof decideTrust>[3]> = {}) => ({
+  hasClaudeShaped: () => true,
+  piWouldAsk: () => false,
+  savedDecision: () => null,
+  ...over,
+})
+
+const confirmYes = async () => true
+const confirmNo = async () => false
+const neverAsk = async () => {
+  throw new Error('should not have prompted')
+}
+
+describe('hasClaudeShapedConfig', () => {
+  it.each([
+    ['.mcp.json', true],
+    [join('.claude', 'settings.json'), true],
+    [join('.claude', 'agents'), true],
+    [join('.pi', 'mcp.json'), true],
+  ])('detects %s', (entry, expected) => {
+    const cwd = tempDir()
+    mkdirSync(join(cwd, entry, '..'), { recursive: true })
+    writeFileSync(join(cwd, entry), '{}')
+    expect(hasClaudeShapedConfig(cwd)).toBe(expected)
+  })
+
+  it('is false for a repository with no agent configuration', () => {
+    const cwd = tempDir()
+    writeFileSync(join(cwd, 'README.md'), 'nothing to see')
+    expect(hasClaudeShapedConfig(cwd)).toBe(false)
+  })
+})
+
+describe('decideTrust', () => {
+  it('prompts and remembers approval for a claude-shaped project pi would not ask about', async () => {
+    expect(await decideTrust('/repo', true, confirmYes, deps())).toEqual({ trusted: 'yes', remember: true })
+  })
+
+  it('remembers a refusal too, so the repo is not re-asked every session', async () => {
+    expect(await decideTrust('/repo', true, confirmNo, deps())).toEqual({ trusted: 'no', remember: true })
+  })
+
+  it('stays out of the way when the project ships no agent configuration', async () => {
+    expect(await decideTrust('/repo', true, neverAsk, deps({ hasClaudeShaped: () => false }))).toEqual({ trusted: 'undecided' })
+  })
+
+  it('stays out of the way when pi already prompts for this project', async () => {
+    // Double-prompting would train the user to click through both.
+    expect(await decideTrust('/repo', true, neverAsk, deps({ piWouldAsk: () => true }))).toEqual({ trusted: 'undecided' })
+  })
+
+  it('defers to a stored decision rather than asking again', async () => {
+    expect(await decideTrust('/repo', true, neverAsk, deps({ savedDecision: () => true }))).toEqual({ trusted: 'undecided' })
+    expect(await decideTrust('/repo', true, neverAsk, deps({ savedDecision: () => false }))).toEqual({ trusted: 'undecided' })
+  })
+
+  it('does not force a decision when there is no UI to ask with', async () => {
+    // Returning "no" here would override a remembered yes, since handlers run before trust.json.
+    expect(await decideTrust('/repo', false, neverAsk, deps())).toEqual({ trusted: 'undecided' })
+  })
+})


### PR DESCRIPTION
Closes the gap that undermined every other trust gate.

## The problem

`ctx.isProjectTrusted()` guards the MCP, hooks, subagent, output-styles and rules extensions. pi decides whether to *ask* for that trust in `hasTrustRequiringProjectResources`, which checks for entries under `cwd/.pi` and for `.agents/skills`. A repository shipping only `.claude/` and `.mcp.json` matches neither, so pi trusts it with no prompt and no stored decision.

That is exactly the repository shape pi-code exists to load. On a freshly cloned repo, `isProjectTrusted()` returned true, and a project `.mcp.json` server command, project hooks and project agents all ran without anyone being asked.

## The fix

A `project_trust` handler, which is pi's documented mechanism for this. It takes over only when pi would not ask:

| Condition | Decision |
|---|---|
| No Claude-shaped config in the project | `undecided` |
| pi already prompts for this project | `undecided` (no double prompt) |
| A decision is already stored in `trust.json` | `undecided` (apply the stored answer) |
| No UI to prompt with | `undecided` (leave `defaultProjectTrust` in charge) |
| Otherwise | prompt, `remember: true` |

Returning `undecided` in those first four cases matters: handler decisions run *before* saved trust, so returning `no` when unable to prompt would override a remembered `yes` and break headless runs. Deferring keeps pi's own resolution intact.

Only user/global and CLI extensions receive `project_trust`, so this covers `pi install npm:pi-code`. A project-local install (`-l`) is not loaded until trust is already resolved, which is noted in the extension header.

The decision logic takes its three environment checks as injected dependencies, so all six branches are tested without touching a real trust store.

## SECURITY.md

Rewritten against what the code now does rather than what it aspired to:

- The trust table now states that the gate depends on the trust decision, and how that decision is made.
- `context-imports` moved out of the gated table: it performs no trust check, it confines by root, and its root set is now scoped to the importing file.
- The `web_fetch` line lists the ranges actually covered and the new fail-closed behaviors, instead of the vaguer "IPv6 equivalents".
- Plan mode's guard is described as model steering rather than a boundary.
- The hook timeout entry now describes the real behavior: it is not enforced for compound hooks, the tool call stalls for the child's full duration, and an `exit 2` block is reported as exit 0.
- Added the unbounded hook stdout, agent discovery walking above the project root, the spoofable consent source, and unbounded import breadth.