### PR TITLE
Release 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-code",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-code",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-code",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, and subagents",
   "keywords": [
     "pi-package"


### PR DESCRIPTION
Minor bump rather than patch: several changes alter behavior a working setup may depend on.

## Behavior changes

- Plan mode no longer allows `curl`, `wget`, `awk`, `sed`, `env` or `printenv`, and validates each subcommand of a compound command independently.
- MCP stdio servers receive the SDK's default environment plus their own `env` block, not the full process environment. A server relying on an ambient variable must now name it.
- A trust prompt appears for projects that ship Claude-shaped config, which pi previously trusted without asking.
- `web_fetch` refuses more address ranges, fails closed when a host resolves to nothing, and refuses redirects that leave `http(s)`.
- An MCP server can no longer register `web_fetch`, `web_search` or `plan_mode_complete`.
- A project `CLAUDE.md` can no longer `@import` from `~/.claude` or `~/.pi`.
- `memory` read truncates at pi's 50KB / 2000 line budget.

## Fixes

- The question overlay cached rendered lines without keying on width, so a terminal resize repainted at the stale width.
- A failed subagent run was reported to the model as a success.
- MCP servers were connected from the extension factory, so `pi list`, `pi config` and `pi update` spawned every configured server.
- A bare `-` in a `paths:` block list pushed an empty path and kept scanning.
- `stripTags` / `htmlToText` no longer backtrack on unclosed tags.

## Quality

Statement coverage 36.9% to 97.7% (698 tests). Sonar code smells 77 to near zero. SECURITY.md rewritten to describe actual behavior, including the limitations that remain.