### PR TITLE
Release 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-code",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-code",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-code",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, and subagents",
   "keywords": [
     "pi-package"


### PR DESCRIPTION
Corrects a security fix that shipped inert in 0.2.0, and the documentation that claimed it worked.

## Security

- **The trust mechanism in 0.2.0 could never run.** `resolveProjectTrusted` returns `true` before emitting `project_trust` when it finds no trust-requiring resources, and `.claude/` and `.mcp.json` are not on that list, so the event never fired for the projects it targeted. The decision now happens where the project config is consumed, in `mcp`, `hooks` and `subagent`.
- **SECURITY.md no longer claims that gap is closed by a `project_trust` handler.** It describes what pi actually does and what `project-approval` does instead.

## Fixes

- Plan mode's per-subcommand split was quote-blind, so ordinary reads were refused: `grep "foo;bar"`, `grep 'a|b'` and `echo "a && b"` all split mid-argument and failed the allowlist. The split now ignores separators inside quotes and fails closed on an unbalanced quote.

## Note for anyone on 0.2.0

0.2.0's trust prompt never appeared. If you are relying on it, upgrade. A project shipping only `.claude/` and `.mcp.json` was still auto-trusted under 0.2.0.