### PR TITLE
Share one output guard across tools instead of per-tool caps

### DIFF
--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -24,11 +24,11 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js' // 
 import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { Type } from 'typebox'
+import { capForContext } from './output-guard.js'
 import { isProjectApproved } from './project-approval.js'
 
 const CONNECT_TIMEOUT_MS = 10_000
 const CALL_TIMEOUT_MS = 120_000
-const MAX_INLINE_RESULT = 50_000
 // Tool names an MCP server must never take over. formatToolName always emits
 // `<server>_<tool>`, so only names containing an underscore are actually reachable:
 // pi's own built-ins (read, bash, edit, ...) cannot be produced and are not listed.
@@ -115,8 +115,7 @@ export function mapContent(content: McpContentBlock[] | undefined, structured?: 
   }
   return content.map((block) => {
     if (block.type === 'text') {
-      const text = block.text ?? ''
-      return text.length > MAX_INLINE_RESULT ? { type: 'text', text: `${text.slice(0, MAX_INLINE_RESULT)}\n[truncated ${text.length - MAX_INLINE_RESULT} chars]` } : { type: 'text', text }
+      return { type: 'text', text: capForContext(block.text ?? '') }
     }
     if (block.type === 'image' && block.data) {
       return { type: 'image', data: block.data, mimeType: block.mimeType ?? 'image/png' }

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -11,8 +11,9 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { StringEnum } from '@earendil-works/pi-ai'
-import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, type ExtensionAPI, formatSize, truncateHead } from '@earendil-works/pi-coding-agent'
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { Type } from 'typebox'
+import { capForContext } from './output-guard.js'
 
 const INDEX_FILE = 'MEMORY.md'
 
@@ -61,17 +62,6 @@ function readIndex(dir: string): string {
   } catch {
     return ''
   }
-}
-
-/**
- * Keep a memory inside pi's context budget. truncateHead keeps whole lines, so a
- * single oversized line yields nothing; fall back to a hard slice in that case.
- */
-function capForContext(body: string): string {
-  const cut = truncateHead(body, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES })
-  if (!cut.truncated) return body
-  const kept = cut.content || body.slice(0, DEFAULT_MAX_BYTES)
-  return `${kept}\n\n[truncated: ${formatSize(cut.totalBytes)} total]`
 }
 
 export default function memoryExtension(pi: ExtensionAPI) {

--- a/extensions/output-guard.ts
+++ b/extensions/output-guard.ts
@@ -1,0 +1,23 @@
+/**
+ * Output Guard
+ *
+ * pi requires every tool to truncate its output, at 50KB or 2000 lines, whichever is hit
+ * first (docs/extensions.md, "Tool output"). Each tool used to decide that for itself, so
+ * the budgets and the truncation notices diverged and a byte-only cap let thousands of
+ * short lines through. This is the single place that decision lives.
+ *
+ * `truncateHead` keeps whole lines, which means a single line over the budget yields no
+ * content at all. That trap is handled here once rather than at each call site.
+ */
+
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from '@earendil-works/pi-coding-agent'
+
+/** Trim `text` to pi's documented tool-output budget, noting what was dropped. */
+export function capForContext(text: string): string {
+  const cut = truncateHead(text, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES })
+  if (!cut.truncated) return text
+  const kept = cut.content || text.slice(0, DEFAULT_MAX_BYTES)
+  const capped = `${kept}\n\n[truncated: ${formatSize(cut.totalBytes)} total, ${cut.totalLines} lines]`
+  // Just over the budget, the notice can cost more than the trim saves.
+  return capped.length < text.length ? capped : text
+}

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -663,6 +663,20 @@ describe('mcp tool execution', () => {
   })
 })
 
+it('truncates a result with too many lines even when it is under the byte budget', async () => {
+  // pi's budget is 50KB or 2000 lines, whichever hits first; 3000 short lines is well
+  // under the byte cap but still floods the context.
+  const many = Array.from({ length: 3000 }, (_, i) => `line ${i}`).join('\n')
+  hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: many }] })
+  withTools([{ name: 'dump' }])
+  const harness = await setupStarted({ user: { srv: { command: 'x' } } })
+
+  const out = await harness.tools[0].execute('c1', {})
+  const text = out.content[0].text ?? ''
+  expect(text.split('\n').length).toBeLessThan(2100)
+  expect(text).toContain('truncated')
+})
+
 describe('mcp failure reporting', () => {
   it('records the error message of a server that fails to connect', async () => {
     hoisted.control.connect = async () => {

--- a/tests/output-guard.test.ts
+++ b/tests/output-guard.test.ts
@@ -1,0 +1,50 @@
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from '@earendil-works/pi-coding-agent'
+import { describe, expect, it } from 'vitest'
+
+import { capForContext } from '../extensions/output-guard.ts'
+
+const lines = (count: number): string => Array.from({ length: count }, (_, i) => `line ${i}`).join('\n')
+
+describe('capForContext', () => {
+  it('returns short output untouched', () => {
+    expect(capForContext('just this')).toBe('just this')
+    expect(capForContext('')).toBe('')
+  })
+
+  it('caps on line count even when well under the byte budget', () => {
+    const many = lines(DEFAULT_MAX_LINES + 1000)
+    expect(many.length).toBeLessThan(DEFAULT_MAX_BYTES)
+
+    const capped = capForContext(many)
+    expect(capped.split('\n').length).toBeLessThan(DEFAULT_MAX_LINES + 10)
+    expect(capped).toContain('truncated')
+  })
+
+  it('caps on bytes when a few lines are enormous', () => {
+    const huge = `${'x'.repeat(DEFAULT_MAX_BYTES * 2)}\nsecond line`
+    const capped = capForContext(huge)
+    expect(capped.length).toBeLessThan(huge.length)
+    expect(capped).toContain('truncated')
+  })
+
+  it('never returns more than it was given', () => {
+    // Just over the budget the notice can cost more than the trim saves.
+    const barelyOver = `${'x'.repeat(DEFAULT_MAX_BYTES)}\nsecond line`
+    expect(capForContext(barelyOver).length).toBeLessThanOrEqual(barelyOver.length)
+  })
+
+  it('still returns content when the very first line exceeds the budget', () => {
+    // truncateHead keeps whole lines, so it yields nothing here on its own.
+    const oneLongLine = 'x'.repeat(DEFAULT_MAX_BYTES * 2)
+    const capped = capForContext(oneLongLine)
+
+    expect(capped.startsWith('x')).toBe(true)
+    expect(capped.length).toBeGreaterThan(1000)
+    expect(capped).toContain('truncated')
+  })
+
+  it('reports the original size and line count in the notice', () => {
+    const capped = capForContext(lines(5000))
+    expect(capped).toMatch(/\[truncated: .+ total, 5000 lines\]/)
+  })
+})


### PR DESCRIPTION
pi's guide requires every tool to truncate its output, at 50KB or 2000 lines, whichever is hit first. `mcp.ts` capped characters only, so a 5,000-line result under 50KB reached the model untouched.

The fix is not that one cap. Each tool had been deciding truncation for itself: `web.ts` at 30k/200k chars, `mcp.ts` at 50k chars, `memory.ts` at pi's documented budget after an earlier fix. Three budgets, three notices, one concern, and a new tool starts from nothing.

`output-guard.ts` is now the single place that decision lives, built on pi's exported `truncateHead` and `DEFAULT_MAX_*`. It also absorbs two traps that would otherwise be rediscovered per call site:

- `truncateHead` keeps whole lines, so a single line over the budget returns **no content at all**. The guard falls back to a hard slice.
- Just over the budget, the truncation notice can cost more than the trim saves. The guard returns the original rather than inflating it. The first version had this bug; the test caught it.

`mcp` and `memory` both use it. `web` keeps its tighter 30KB cap on fetched page text, which is a deliberate decision about page size rather than a context-budget concern, and is already well under pi's byte budget.

Seven tests cover both budget axes, the first-line-too-long fallback, the no-inflation invariant, and the exact notice format.