### PR TITLE
Release 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-code",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-code",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-code",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, and subagents",
   "keywords": [
     "pi-package"


### PR DESCRIPTION
Patch bump. Security hardening and the last of the documented limitations.

## Security

- Agent discovery is bounded by the project root (`.git` or `package.json`), so an agent planted in a world-writable ancestor such as `/tmp` is no longer offered as a project agent. The consent prompt names each agent's actual source directory and collapses whitespace in the name so it cannot forge a provenance line.
- Hook output is decoded on the stream, so a multi-byte character split across a pipe boundary is no longer mangled into an unparseable, non-blocking decision. Each stream is capped at 1MB.
- The hook timeout binds the whole process tree: the shell is spawned detached, the timeout kills the process group, and a timed-out `PreToolUse` hook fails closed instead of reading as a clean exit. POSIX only.
- A shared output guard caps every tool at pi's documented 50KB / 2000 line budget; `mcp` previously capped bytes only, so thousands of short lines passed untouched.
- Context imports are bounded by a shared 50 file / 256KB budget, with the number skipped stated in the prompt.

## Note

Continues the 0.2.x line. Nothing here changes a public API; the behavior changes are tighter limits on untrusted project input.