### PR TITLE
Release 0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-code",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-code",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-code",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, and subagents",
   "keywords": [
     "pi-package"


### PR DESCRIPTION
Patch bump. One security fix.

`web_fetch` resolved the host to validate the address, then let the connection resolve it again independently, so a zero-TTL rebinding record could answer public to the check and private to the connection. The host is now resolved once and the socket is pinned to that validated address (SNI and the `Host` header stay the real hostname, so TLS and virtual hosts are unaffected). This closes the last item in SECURITY.md's known limitations.