### PR TITLE
Remove dead exports kept alive only by their tests

### DIFF
--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -66,15 +66,6 @@ export function projectConfigPaths(cwd: string): string[] {
   return [path.join(cwd, '.mcp.json'), path.join(cwd, '.pi', 'mcp.json')]
 }
 
-/** All config files, later winning: user first, then project. */
-export function configPaths(cwd: string, home: string): string[] {
-  return [...userConfigPaths(home), ...projectConfigPaths(cwd)]
-}
-
-export function loadConfig(cwd: string): Record<string, ServerConfig> {
-  return loadConfigFrom(configPaths(cwd, os.homedir()))
-}
-
 export function loadConfigFrom(files: string[]): Record<string, ServerConfig> {
   const servers: Record<string, ServerConfig> = {}
   for (const file of files) {

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -159,13 +159,3 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
   const agentMap = buildAgentMap(userAgents, projectAgents, scope)
   return { agents: Array.from(agentMap.values()), projectAgentsDir: projectPiDir }
 }
-
-export function formatAgentList(agents: AgentConfig[], maxItems: number): { text: string; remaining: number } {
-  if (agents.length === 0) return { text: 'none', remaining: 0 }
-  const listed = agents.slice(0, maxItems)
-  const remaining = agents.length - listed.length
-  return {
-    text: listed.map((a) => `${a.name} (${a.source}): ${a.description}`).join('; '),
-    remaining,
-  }
-}

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -117,7 +117,6 @@ vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
 }))
 
 const mcpExtension = (await import('../extensions/mcp.ts')).default
-const { loadConfig } = await import('../extensions/mcp.ts')
 
 interface RegisteredTool {
   name: string
@@ -331,20 +330,6 @@ describe('mcp startup config scoping', () => {
 
     expect(harness.toolNames()).toEqual(['proj_query'])
     expect(hoisted.transports).toHaveLength(1)
-  })
-
-  it('loadConfig merges the user home and project files with project winning', () => {
-    const home = mkdtempSync(join(tmpdir(), 'mcp-home-'))
-    const cwd = mkdtempSync(join(tmpdir(), 'mcp-proj-'))
-    tempDirs.push(home, cwd)
-    hoisted.home = home
-    writeServers(join(home, '.claude.json'), { shared: { command: 'from-user' }, only: { command: 'user-only' } })
-    writeServers(join(cwd, '.mcp.json'), { shared: { command: 'from-project' } })
-
-    const merged = loadConfig(cwd)
-
-    expect(Object.keys(merged).sort()).toEqual(['only', 'shared'])
-    expect((merged.shared as { command: string }).command).toBe('from-project')
   })
 })
 

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { configPaths, formatToolName, interpolateEnv, loadConfigFrom, mapContent, normalizeSchema, projectConfigPaths, userConfigPaths } from '../extensions/mcp.ts'
+import { formatToolName, interpolateEnv, loadConfigFrom, mapContent, normalizeSchema, projectConfigPaths, userConfigPaths } from '../extensions/mcp.ts'
 
 describe('mcp adapter helpers', () => {
   // biome-ignore lint/suspicious/noTemplateCurlyInString: the title documents the ${VAR} syntax interpolateEnv parses
@@ -31,10 +31,6 @@ describe('mcp adapter helpers', () => {
     const broken = join(dir, 'broken.json')
     writeFileSync(broken, '{not json')
     expect(loadConfigFrom([join(dir, 'absent.json'), broken])).toEqual({})
-  })
-
-  it('reads Claude MCP config, ordered Claude-then-pi with project last', () => {
-    expect(configPaths('/proj', '/home')).toEqual(['/home/.claude.json', '/home/.pi/agent/mcp.json', '/proj/.mcp.json', '/proj/.pi/mcp.json'])
   })
 
   it('separates always-loaded user config from trust-gated project config', () => {

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { discoverAgents, formatAgentList } from '../extensions/subagent/agents.ts'
+import { discoverAgents } from '../extensions/subagent/agents.ts'
 
 /**
  * Covers extensions/subagent/agents.ts and extensions/subagent/background.ts.
@@ -258,36 +258,6 @@ describe('discoverAgents', () => {
     writeAgent(piUserDir, 'modelled.md', { name: 'modelled', description: 'pinned model', model: 'opus' })
 
     expect(discoverAgents(cwd, 'user').agents[0].model).toBe('opus')
-  })
-})
-
-describe('formatAgentList', () => {
-  const agent = (name: string, source: 'user' | 'project', description: string) => ({
-    name,
-    description,
-    systemPrompt: '',
-    source,
-    filePath: `/tmp/${name}.md`,
-  })
-
-  it('reports none with no remainder for an empty list', () => {
-    expect(formatAgentList([], 5)).toEqual({ text: 'none', remaining: 0 })
-  })
-
-  it('renders every agent as "name (source): description" joined by semicolons', () => {
-    const result = formatAgentList([agent('alpha', 'user', 'does alpha'), agent('beta', 'project', 'does beta')], 5)
-
-    expect(result).toEqual({ text: 'alpha (user): does alpha; beta (project): does beta', remaining: 0 })
-  })
-
-  it('truncates at maxItems and reports the remaining count', () => {
-    const list = [agent('a', 'user', 'first'), agent('b', 'user', 'second'), agent('c', 'user', 'third')]
-
-    expect(formatAgentList(list, 2)).toEqual({ text: 'a (user): first; b (user): second', remaining: 1 })
-  })
-
-  it('lists nothing and counts every agent as remaining when maxItems is zero', () => {
-    expect(formatAgentList([agent('a', 'user', 'first')], 0)).toEqual({ text: '', remaining: 1 })
   })
 })
 


### PR DESCRIPTION
A code-quality scan (0 Sonar findings, ~98% coverage, 0 type escape hatches in source) surfaced three exported functions with no production caller, alive only through their own tests.

- **`mcp.ts` `loadConfig` and `configPaths`.** Production loads user and project MCP config separately, through `loadConfigFrom(userConfigPaths(...))` and `loadConfigFrom(projectConfigPaths(...))`: user config unconditionally, project config only once the project is trusted. `loadConfig` wrapped a single merged read that nothing calls, and its test asserted a "user then project, project wins" ordering the real code never performs, so it read as coverage for behavior that does not exist. `configPaths` existed only to feed `loadConfig`.
- **`subagent/agents.ts` `formatAgentList`.** No production caller.

A function kept alive only by its own test is worse than plain dead code: it looks exercised. `userConfigPaths` and `projectConfigPaths` stay, along with the test that pins the actual separated, trust-gated model.

726 tests, coverage unchanged at 97.9% (removing dead-but-tested code and its tests does not drop real coverage).