### PR TITLE
Guard the trust trigger against drifting from what extensions consume

### DIFF
--- a/tests/project-approval.test.ts
+++ b/tests/project-approval.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { hasTrustRequiringProjectResources } from '@earendil-works/pi-coding-agent'
 import { describe, expect, it, vi } from 'vitest'
 
+import { projectConfigPaths } from '../extensions/mcp.ts'
 import { hasClaudeShapedConfig, isProjectApproved } from '../extensions/project-approval.ts'
 
 const tempDir = (): string => mkdtempSync(join(tmpdir(), 'pa-'))
@@ -96,5 +97,26 @@ describe('isProjectApproved', () => {
   it('refuses when there is no UI to ask with', async () => {
     // pi never consulted defaultProjectTrust here, so there is no preference to defer to.
     expect(await isProjectApproved(ctx({ hasUI: false }), deps())).toBe(false)
+  })
+})
+
+describe('the trust trigger stays in sync with what the trust-gated extensions consume', () => {
+  // The approval prompt only fires when hasClaudeShapedConfig sees project config. If a new
+  // project source is added to an extension but not to that list, a repository shipping only
+  // the new source would be trusted without a prompt, which is the auto-trust bug PR #12 fixed.
+  // These derive the expected project sources from the extensions themselves so the list cannot
+  // silently drift.
+
+  it.each(projectConfigPaths('/x').map((abs) => abs.slice('/x/'.length)))('treats a project with only %s as claude-shaped (mcp project config runs commands on connect)', (rel) => {
+    const cwd = tempDir()
+    mkdirSync(join(cwd, rel, '..'), { recursive: true })
+    writeFileSync(join(cwd, rel), '{}')
+    expect(hasClaudeShapedConfig(cwd)).toBe(true)
+  })
+
+  it.each([join('.claude', 'agents'), join('.pi', 'agents')])('treats a project with only a %s directory as claude-shaped (project agents ship their own prompt and tools)', (dir) => {
+    const cwd = tempDir()
+    mkdirSync(join(cwd, dir), { recursive: true })
+    expect(hasClaudeShapedConfig(cwd)).toBe(true)
   })
 })


### PR DESCRIPTION
Found while validating a claim from the code-quality scan. I had said the config-path overlap across `mcp.ts`, `subagent/agents.ts` and `project-approval.ts` was coincidental and not worth touching. Reading the three precisely showed otherwise.

`mcp.ts` lists MCP config files; `agents.ts` lists agent directories; those two are genuinely different and correctly not shared. But `project-approval.ts`'s `CLAUDE_SHAPED` is a hand-maintained **union** of every project source the trust-gated extensions consume, and the approval prompt only fires when it matches. If a new project source is added to an extension but not to that list, a repository shipping only the new source is trusted with **no prompt**, reintroducing the auto-trust gap PR #12 fixed. That is a latent drift hazard on the security-critical path, not a coincidence.

This adds a consistency test rather than coupling four extensions together. It derives the expected project sources from the extensions themselves: every `projectConfigPaths` entry from `mcp.ts` and each project agent directory must make `hasClaudeShapedConfig` return true. Dropping `.mcp.json` from `CLAUDE_SHAPED` fails it; adding a new mcp config path extends the guard automatically, no maintenance.

No production change: `CLAUDE_SHAPED` is currently in sync. This pins that so it stays in sync. 730 tests.