### PR TITLE
Correct docs that this session's changes made false

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ One `pi install` and everything below loads on the next start. `pi list` shows w
 | Hooks | `.claude/settings.json` hooks on pi lifecycle events | `hooks.ts` |
 | Output styles | `.claude/output-styles` + active `outputStyle`, `/output-style` switcher | `output-styles.ts` |
 | CLAUDE.md `@imports` | resolves `@path` imports pi's native loader skips | `context-imports.ts` |
-| MCP servers | `~/.claude.json`, `~/.pi/agent/mcp.json`, `.mcp.json`, `.pi/mcp.json` (later wins); stdio, HTTP, SSE | `mcp.ts` |
+| MCP servers | user `~/.claude.json`, `~/.pi/agent/mcp.json` (loaded on session start); project `.mcp.json`, `.pi/mcp.json` (only once the project is approved); stdio, HTTP, SSE | `mcp.ts` |
+| Project trust | prompts before loading project config (MCP servers, hooks, agents) that pi would otherwise trust silently | `project-approval.ts` |
 | Subagents / Task | `~/.claude/agents` and `~/.pi/agent/agents`, plus project `.claude/agents` and `.pi/agents`; background runs | `subagent/` |
 | Plan mode | `plan_mode_complete` tool, exact tool snapshot/restore | `plan-mode/` |
 | Todo list | persistent overlay, status machine, compaction-safe | `todo.ts` |
@@ -53,6 +54,8 @@ One `pi install` and everything below loads on the next start. `pi list` shows w
 | Notifications | vendored example | `notify.ts` |
 
 `CLAUDE.md` itself needs no extension: pi loads `CLAUDE.md` / `AGENTS.md` context files natively (global + walking cwd to root). `context-imports.ts` only adds the `@import` resolution pi's loader lacks, appending the imported files without re-injecting the base.
+
+`output-guard.ts` and `web-transport.ts` are shared internals (context-budget truncation, DNS-pinned fetch) with no feature of their own; the tools above use them.
 
 Vendored bases (`question`, `notify`, `status-line`) come from pi's MIT example extensions (see [LICENSE](LICENSE)).
 

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -1,16 +1,20 @@
 /**
  * MCP Adapter Extension
  *
- * Connects MCP (Model Context Protocol) servers from mcp.json and registers
- * their tools in pi as `<server>_<tool>`. Async factory connects eagerly at
- * startup (per-server timeout, failures skip with a notice); stdio and HTTP
- * (streamable with SSE fallback) transports; /mcp shows status.
+ * Connects MCP (Model Context Protocol) servers and registers their tools in pi
+ * as `<server>_<tool>`. Connects on `session_start`, not from the factory (pi runs
+ * the factory for invocations that never start a session); per-server timeout,
+ * failures skip with a notice; stdio and HTTP (streamable with SSE fallback)
+ * transports; /mcp shows status.
  *
- * Reads Claude Code's MCP config too. Merge order (later wins): ~/.claude.json,
- * ~/.pi/agent/mcp.json, .mcp.json, then .pi/mcp.json. User config connects at
- * startup; project config (.mcp.json / .pi/mcp.json) can run arbitrary commands,
- * so it connects only once the project is trusted.
- * Values support ${VAR} environment interpolation.
+ * Reads Claude Code's MCP config too. User config (~/.claude.json,
+ * ~/.pi/agent/mcp.json) is the user's own and loads on the first session. Project
+ * config (.mcp.json, .pi/mcp.json) can run arbitrary commands on connect, so it
+ * loads only once the project is approved (see project-approval). The two scopes
+ * are loaded separately, not merged; user config connects first, so a project
+ * server cannot take the name of a user server that connected.
+ * Values support ${VAR} interpolation, and a stdio server receives only the SDK's
+ * default environment plus its own `env` block, not the whole process environment.
  */
 
 import * as fs from 'node:fs'


### PR DESCRIPTION
Polish pass: the code is at zero findings and ~98% coverage, so this closes the gap between the docs and what the code now does. A doc that misdescribes the code is worse than a missing one.

Three statements had become false through this session's own changes:

- **README, MCP row** claimed the four config files merge, "later wins". The merged read was removed when the dead `loadConfig` went; user and project config load separately (user unconditionally on session start, project only once approved), and are not merged.
- **`mcp.ts` header** claimed the "async factory connects eagerly at startup". Connection moved to `session_start`, because pi runs the factory for invocations that never start a session.
- **`mcp.ts` header** repeated the false "merge order, later wins".

Corrected, plus:
- The `project-approval` trust prompt is now in the feature table — a user-facing behavior that was undocumented.
- The `mcp.ts` header notes the SDK-default-env restriction and the approval gate, and states the user-connects-first ordering precisely (without overclaiming the failed-server edge that SECURITY.md documents).
- A line reconciles `output-guard.ts` and `web-transport.ts` as shared internals, since the README says each feature is an extension and those two are not features.

No code change. 730 tests.