### PR TITLE
Release 0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-code",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-code",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-code",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, and subagents",
   "keywords": [
     "pi-package"


### PR DESCRIPTION
Patch bump. No runtime change; internal quality and documentation.

- Removed dead exports that were kept alive only by their own tests (`loadConfig`/`configPaths` in `mcp.ts`, `formatAgentList` in `subagent/agents.ts`).
- Added a consistency test so the project-trust trigger cannot drift out of sync with the project config the trust-gated extensions consume.
- Corrected documentation this cycle's changes had made false: the MCP config model (loaded separately per scope, not merged) and its connection lifecycle (on session start, not from the factory). Documented the `project-approval` trust prompt.