### PR TITLE
Fix deferred subagent robustness items

### DIFF
--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -47,9 +47,10 @@ export function parseFinalOutputFromJsonl(jsonl: string): { text: string; turns:
     }
     if (event.type !== 'message_end' || event.message?.role !== 'assistant') continue
     turns++
-    for (const part of event.message.content ?? []) {
-      if (part.type === 'text' && part.text) text = part.text
-    }
+    // The complete text of the last assistant message, matching getFinalOutput on the
+    // foreground path so a multi-part message reads the same in both.
+    const parts = (event.message.content ?? []).filter((p) => p.type === 'text' && p.text).map((p) => p.text as string)
+    if (parts.length > 0) text = parts.join('\n')
   }
   return { text, turns }
 }

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -160,9 +160,10 @@ export function getFinalOutput(messages: Message[]): string {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i]
     if (msg.role === 'assistant') {
-      for (const part of msg.content) {
-        if (part.type === 'text') return part.text
-      }
+      // The complete text of the last assistant message: a message can carry more than one
+      // text part, and taking only the first diverged from the background parser.
+      const parts = msg.content.filter((part) => part.type === 'text').map((part) => part.text)
+      if (parts.length > 0) return parts.join('\n')
     }
   }
   return ''

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -638,7 +638,7 @@ async function runChainMode(chain: ChainStepParam[], mode: ModeContext): Promise
         details: makeDetails('chain')(results),
       }
     }
-    previousOutput = getFinalOutput(result.messages)
+    previousOutput = capForContext(getFinalOutput(result.messages))
   }
   return {
     content: [{ type: 'text', text: capForContext(getFinalOutput(results.at(-1)?.messages ?? [])) || '(no output)' }],

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -347,10 +347,11 @@ const loadBackground = async (): Promise<typeof import('../extensions/subagent/b
 }
 
 describe('parseFinalOutputFromJsonl', () => {
-  it('keeps the last text part when one assistant message has several', async () => {
+  it('joins every text part when one assistant message has several', async () => {
     const { parseFinalOutputFromJsonl } = await loadBackground()
 
-    expect(parseFinalOutputFromJsonl(messageEnd('assistant', 'draft', 'polished'))).toEqual({ text: 'polished', turns: 1 })
+    // The whole final message, matching getFinalOutput on the foreground path.
+    expect(parseFinalOutputFromJsonl(messageEnd('assistant', 'draft', 'polished'))).toEqual({ text: 'draft\npolished', turns: 1 })
   })
 
   it('counts an assistant turn even when the message carries no content', async () => {

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -790,6 +790,21 @@ describe('chain mode', () => {
     expect(text(result)).toBe('done')
   })
 
+  it('bounds a large previous-step output before it rides the next step argv', async () => {
+    // Without a cap the whole prior report becomes one argv string and the OS spawn fails.
+    const huge = 'z'.repeat(200_000)
+    const chain = [
+      { agent: 'scout', task: 'a' },
+      { agent: 'scout', task: 'use: {previous}' },
+    ]
+    script('a', { stdout: [say(huge)] })
+    const result = await execute('c1', { chain }, undefined, undefined, trustedCtx)
+
+    const secondArg = piArgs(spawnCalls[1]).at(-1) as string
+    expect(secondArg.length).toBeLessThan(60_000)
+    expect(secondArg.startsWith('Task: use: zzz')).toBe(true)
+  })
+
   it('passes previous output containing $-patterns through verbatim', async () => {
     // String.replaceAll with a string replacement interprets $$, $&, $` and $'; a shell
     // snippet or awk line in the previous step's report must reach the next step intact.

--- a/tests/subagent-render.test.ts
+++ b/tests/subagent-render.test.ts
@@ -137,9 +137,10 @@ describe('formatUsageStats', () => {
 })
 
 describe('getFinalOutput', () => {
-  it('returns the first text part of the last assistant message', () => {
+  it('joins every text part of the last assistant message', () => {
+    // The whole final message, not just the first part; this matches the background parser.
     const messages = [assistant(textPart('early')), user('ignored'), assistant(toolCallPart('bash', {}), textPart('first'), textPart('second'))]
-    expect(getFinalOutput(messages)).toBe('first')
+    expect(getFinalOutput(messages)).toBe('first\nsecond')
   })
 
   it('falls back to an earlier assistant message when the last one has no text part', () => {


### PR DESCRIPTION
Two robustness fixes deferred from the gap-scan PR (#31), each red-first, gate green at 833 tests.

- **Bound the chain `{previous}` handoff.** The previous step's full output was substituted into the next child's argv, which the OS caps (~128KB on Linux); a verbose step overflowed it and the spawn failed as an unexplained `(no output)`. Cap the handoff with the shared output guard.
- **Unify final-output extraction.** `getFinalOutput` (foreground) returned the first text part of the last assistant message while the background JSONL parser kept the last; a multi-part message read differently per path. Both now join every text part of that message.

Packaging was checked as part of this pass: the published tarball includes `extensions/internal/` and every extension, so the loader contract holds for the shipped artifact.