### PR TITLE
Extend hook events and MCP config parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ One `pi install` and everything below loads on the next start. `pi list` shows w
 | Global + project rules | `~/.claude/rules`, `.claude/rules` (+ `paths:` frontmatter scoping) | `claude-rules.ts` |
 | Custom slash commands | `.claude/commands/*.md` → pi prompt templates | `commands.ts` |
 | Skills | `.claude/skills` → pi skill discovery (pi reads `name`, `description`, `disable-model-invocation`; `allowed-tools` is inert in pi's loader) | `skills.ts` |
-| Hooks | `.claude/settings.json` hooks on pi lifecycle events | `hooks.ts` |
+| Hooks | `.claude/settings.json` hooks: PreToolUse, PostToolUse, SessionStart, UserPromptSubmit (blocks and injects context), Stop, PreCompact, SessionEnd | `hooks.ts` |
 | Output styles | `.claude/output-styles` + active `outputStyle`, `/output-style` switcher | `output-styles.ts` |
 | CLAUDE.md `@imports` | resolves `@path` imports pi's native loader skips; loads `CLAUDE.local.md` (approval-gated) | `context-imports.ts` |
 | MCP servers | user `~/.claude.json`, `~/.pi/agent/mcp.json` (loaded on session start); project `.mcp.json`, `.pi/mcp.json` (only once the project is approved); stdio, HTTP, SSE | `mcp.ts` |

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -3,9 +3,17 @@
  *
  * Runs Claude Code's `.claude/settings.json` hooks on pi's lifecycle events, so
  * a project's existing hooks work under pi:
- * - PreToolUse  -> pi `tool_call` (can block the tool)
- * - PostToolUse -> pi `tool_execution_end` (fire-and-forget)
- * - SessionStart-> pi `session_start` (fire-and-forget)
+ * - PreToolUse      -> pi `tool_call` (can block the tool)
+ * - PostToolUse     -> pi `tool_execution_end` (fire-and-forget)
+ * - SessionStart    -> pi `session_start` (fire-and-forget)
+ * - UserPromptSubmit-> pi `input` (can block the prompt via `handled`, or inject
+ *                      additional context by transforming the submitted text)
+ * - Stop            -> pi `agent_end` (fire-and-forget; cannot prevent stopping)
+ * - PreCompact      -> pi `session_before_compact` (fire-and-forget)
+ * - SessionEnd      -> pi `session_shutdown` (fire-and-forget)
+ *
+ * Claude's SubagentStop has no pi lifecycle seam (the subagent tool spawns child pi
+ * processes, and pi emits no subagent-completion event), so it is not bridged.
  *
  * Hook commands run via `sh -c` with the event JSON on stdin. A PreToolUse
  * hook blocks the tool by exiting 2 (stderr becomes the reason) or by printing
@@ -102,7 +110,7 @@ export function matchingCommands(matchers: HookMatcher[] | undefined, name: stri
   return result
 }
 
-function tryParseJson(text: string): { hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string }; decision?: string; reason?: string; continue?: boolean; stopReason?: string } | undefined {
+function tryParseJson(text: string): { hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string; additionalContext?: string }; decision?: string; reason?: string; continue?: boolean; stopReason?: string } | undefined {
   try {
     return JSON.parse(text)
   } catch {
@@ -217,6 +225,35 @@ async function runNotifyHooks(commands: HookCommand[], payload: unknown, runner:
   await Promise.all(commands.map((command) => runner(command.command, payload, timeoutMs(command))))
 }
 
+export interface PromptDecision {
+  block: boolean
+  reason?: string
+  context: string
+}
+
+/** Additional context a UserPromptSubmit hook contributes: an explicit
+ * hookSpecificOutput.additionalContext, or the raw stdout of a plain exit-0 hook. */
+function promptContext(stdout: string): string {
+  const parsed = tryParseJson(stdout)
+  if (parsed) return parsed.hookSpecificOutput?.additionalContext ?? ''
+  return stdout.trim()
+}
+
+/** Run UserPromptSubmit hooks: the first blocking verdict wins; otherwise their
+ * additional context is concatenated for injection ahead of the prompt. */
+export async function runUserPromptSubmit(config: HooksConfig, prompt: string, runner: HookRunner): Promise<PromptDecision> {
+  const contexts: string[] = []
+  for (const command of matchingCommands(config.UserPromptSubmit, 'UserPromptSubmit')) {
+    const result = await runner(command.command, { hook_event_name: 'UserPromptSubmit', prompt }, timeoutMs(command))
+    if (result.timedOut) return { block: true, reason: `Hook timed out after ${timeoutMs(command)}ms: ${command.command}`, context: '' }
+    const decision = interpretHookResult(result.code, result.stdout, result.stderr)
+    if (decision.block) return { block: true, reason: decision.reason, context: '' }
+    const context = promptContext(result.stdout)
+    if (context) contexts.push(context)
+  }
+  return { block: false, context: contexts.join('\n') }
+}
+
 /** Bound on remembered tool inputs, in case a blocked or aborted call never ends. */
 const MAX_PENDING_INPUTS = 100
 
@@ -257,5 +294,35 @@ export default function hooksExtension(pi: ExtensionAPI) {
     pendingInputs.delete(event.toolCallId)
     if (event.isError) return
     await runNotifyHooks(matchingCommands(config.PostToolUse, event.toolName), { hook_event_name: 'PostToolUse', tool_name: event.toolName, tool_input: toolInput, tool_response: event.result }, runner)
+  })
+
+  pi.on('input', async (event, ctx) => {
+    // Only genuine user input; extension-injected messages (plan-mode, subagent) are not
+    // prompts the user submitted.
+    if (event.source === 'extension') return { action: 'continue' }
+    const decision = await runUserPromptSubmit(config, event.text, runner)
+    if (decision.block) {
+      // pi's input result has no reason channel, so surface why before consuming it.
+      ctx.ui.notify(decision.reason ?? 'Prompt blocked by hook', 'error')
+      return { action: 'handled' }
+    }
+    // Claude injects a UserPromptSubmit hook's context ahead of the prompt; transform is
+    // pi's seam for rewriting the submitted text.
+    if (decision.context) return { action: 'transform', text: `${decision.context}\n\n${event.text}` }
+    return { action: 'continue' }
+  })
+
+  // Notify-style Claude events with a matching pi lifecycle seam. None can block: pi's
+  // agent_end, session_before_compact and session_shutdown are fire-and-forget here.
+  pi.on('agent_end', async () => {
+    await runNotifyHooks(matchingCommands(config.Stop, 'Stop'), { hook_event_name: 'Stop' }, runner)
+  })
+
+  pi.on('session_before_compact', async (event) => {
+    await runNotifyHooks(matchingCommands(config.PreCompact, event.reason), { hook_event_name: 'PreCompact', trigger: event.reason }, runner)
+  })
+
+  pi.on('session_shutdown', async (event) => {
+    await runNotifyHooks(matchingCommands(config.SessionEnd, event.reason), { hook_event_name: 'SessionEnd', reason: event.reason }, runner)
   })
 }

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -7,14 +7,15 @@
  * failures skip with a notice; stdio and HTTP (streamable with SSE fallback)
  * transports; /mcp shows status.
  *
- * Reads Claude Code's MCP config too. User config (~/.claude.json,
- * ~/.pi/agent/mcp.json) is the user's own and loads on the first session. Project
- * config (.mcp.json, .pi/mcp.json) can run arbitrary commands on connect, so it
- * loads only once the project is approved (see project-approval). The two scopes
- * are loaded separately, not merged; user config connects first, so a project
- * server cannot take the name of a user server that connected.
- * Values support ${VAR} interpolation, and a stdio server receives only the SDK's
- * default environment plus its own `env` block, not the whole process environment.
+ * Reads Claude Code's MCP config too. User config (~/.claude.json top-level plus its
+ * per-project `projects[cwd].mcpServers` local scope, and ~/.pi/agent/mcp.json) is the
+ * user's own and loads on the first session. Project config (.mcp.json, .pi/mcp.json)
+ * can run arbitrary commands on connect, so it loads only once the project is approved
+ * (see project-approval). The two scopes are loaded separately, not merged; user config
+ * connects first, so a project server cannot take the name of a user server that connected.
+ * Values support ${VAR} / ${VAR:-default} interpolation, connect and per-call timeouts
+ * honor MCP_TIMEOUT / MCP_TOOL_TIMEOUT, and a stdio server receives only the SDK's default
+ * environment plus its own `env` block, not the whole process environment.
  */
 
 import * as fs from 'node:fs'
@@ -31,8 +32,20 @@ import { Type } from 'typebox'
 import { capForContext } from './internal/output-guard.js'
 import { isProjectApproved } from './internal/project-approval.js'
 
-const CONNECT_TIMEOUT_MS = 10_000
-const CALL_TIMEOUT_MS = 120_000
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
+const DEFAULT_CALL_TIMEOUT_MS = 120_000
+
+/** A positive-integer env override, or the default when unset or unparseable. */
+function envTimeout(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined) return fallback
+  const value = Number.parseInt(raw, 10)
+  return Number.isInteger(value) && value > 0 ? value : fallback
+}
+
+// Claude honors MCP_TIMEOUT (connect) and MCP_TOOL_TIMEOUT (per-call), both in ms.
+const connectTimeoutMs = (): number => envTimeout('MCP_TIMEOUT', DEFAULT_CONNECT_TIMEOUT_MS)
+const callTimeoutMs = (): number => envTimeout('MCP_TOOL_TIMEOUT', DEFAULT_CALL_TIMEOUT_MS)
 // Tool names an MCP server must never take over. formatToolName always emits
 // `<server>_<tool>`, so only names containing an underscore are actually reachable:
 // pi's own built-ins (read, bash, edit, ...) cannot be produced and are not listed.
@@ -87,6 +100,23 @@ export function loadConfigFrom(files: string[]): Record<string, ServerConfig> {
     } catch {
       // missing or invalid file: skip silently, /mcp reports what loaded
     }
+  }
+  return servers
+}
+
+/**
+ * All user-owned servers for this session: the global user servers plus Claude's "local"
+ * scope, the per-project user servers under `projects[cwd].mcpServers` in ~/.claude.json.
+ * Both are the user's own config, so neither needs project trust; local wins on a name
+ * clash (Claude's precedence is local over user).
+ */
+export function loadUserScope(home: string, cwd: string): Record<string, ServerConfig> {
+  const servers = loadConfigFrom(userConfigPaths(home))
+  try {
+    const claudeJson = JSON.parse(fs.readFileSync(path.join(home, '.claude.json'), 'utf-8'))
+    Object.assign(servers, claudeJson.projects?.[cwd]?.mcpServers ?? {})
+  } catch {
+    // missing or invalid ~/.claude.json: the top-level user servers already loaded
   }
   return servers
 }
@@ -204,7 +234,7 @@ async function connect(name: string, config: ServerConfig): Promise<Client> {
 async function connectWithTimeout(client: Client, transport: Parameters<Client['connect']>[0], label: string): Promise<void> {
   const connecting = client.connect(transport)
   try {
-    await withTimeout(connecting, CONNECT_TIMEOUT_MS, label)
+    await withTimeout(connecting, connectTimeoutMs(), label)
   } catch (error) {
     // Only a timeout can orphan a still-opening transport; a connect rejection means the
     // SDK already tore it down, so closing again would be redundant.
@@ -244,7 +274,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
       try {
         const client = await connect(name, config)
         clients.set(name, client)
-        const tools = await withTimeout(listAllTools(client), CONNECT_TIMEOUT_MS, `list tools ${name}`)
+        const tools = await withTimeout(listAllTools(client), connectTimeoutMs(), `list tools ${name}`)
         let count = 0
         for (const tool of tools) {
           const toolName = formatToolName(name, tool.name)
@@ -262,7 +292,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
             async execute(_id, params) {
               // Pass the timeout to the SDK too: its own default request timeout is 60s and
               // would otherwise reject first, so the outer race at CALL_TIMEOUT_MS was dead.
-              const result = await withTimeout(client.callTool({ name: tool.name, arguments: params as Record<string, unknown> }, undefined, { timeout: CALL_TIMEOUT_MS }), CALL_TIMEOUT_MS, toolName)
+              const result = await withTimeout(client.callTool({ name: tool.name, arguments: params as Record<string, unknown> }, undefined, { timeout: callTimeoutMs() }), callTimeoutMs(), toolName)
               const content = mapContent(result.content as McpContentBlock[], result.structuredContent)
               const details: { error?: string } = {}
               if (result.isError) {
@@ -289,7 +319,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // the factory: pi runs the factory for invocations that never start a session.
     if (!userConnected) {
       userConnected = true
-      await connectServers(loadConfigFrom(userConfigPaths(os.homedir())))
+      await connectServers(loadUserScope(os.homedir(), ctx.cwd))
     }
     // A project .mcp.json can run arbitrary commands on connect, so only honor it once the project is trusted.
     // isProjectTrusted alone is true for a repo pi never asked about; see project-approval.

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -146,11 +146,18 @@ const setupExtension = () => {
     if (!found) throw new Error(`hooks extension did not register ${name}`)
     return found
   }
+  const notes: Array<{ msg: string; level: string }> = []
+  const defaultCtx = { ui: { notify: (msg: string, level: string) => notes.push({ msg, level }) } }
   return {
     registered: [...handlers.keys()],
+    notes,
     sessionStart: (reason: string, ctx: Record<string, unknown>) => handler('session_start')({ reason }, ctx),
     toolCall: (toolName: string, input: unknown, toolCallId = 't1') => handler('tool_call')({ toolName, input, toolCallId }),
     toolEnd: (toolName: string, isError = false, end: { toolCallId?: string; result?: unknown } = {}) => handler('tool_execution_end')({ toolName, isError, toolCallId: end.toolCallId ?? 't1', result: end.result }),
+    input: (text: string, source = 'interactive') => handler('input')({ text, source }, defaultCtx),
+    agentEnd: () => handler('agent_end')({ messages: [] }),
+    beforeCompact: (reason: string) => handler('session_before_compact')({ reason }),
+    shutdown: (reason: string) => handler('session_shutdown')({ reason }),
   }
 }
 
@@ -427,8 +434,8 @@ describe('loadHooks malformed config shapes', () => {
 })
 
 describe('hooks extension registration', () => {
-  it('subscribes to the three lifecycle events it bridges', () => {
-    expect(setupExtension().registered).toEqual(['session_start', 'tool_call', 'tool_execution_end'])
+  it('subscribes to the lifecycle events it bridges', () => {
+    expect(setupExtension().registered).toEqual(['session_start', 'tool_call', 'tool_execution_end', 'input', 'agent_end', 'session_before_compact', 'session_shutdown'])
   })
 })
 
@@ -640,5 +647,81 @@ describe('hooks extension tool_execution_end', () => {
     expect(commandsRun()).toEqual(['post-a', 'post-b'])
     for (const child of hoisted.live) child.emit('close', 0)
     await expect(pending).resolves.toBeUndefined()
+  })
+})
+
+describe('hooks extension UserPromptSubmit', () => {
+  const withPromptHooks = async (hooks: Array<{ command: string }>) => {
+    writeSettings(hoisted.home, 'settings.json', { UserPromptSubmit: [{ hooks }] })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('continues an ordinary prompt, passing it in the payload', async () => {
+    const ext = await withPromptHooks([{ command: 'audit' }])
+    expect(await ext.input('ship it')).toEqual({ action: 'continue' })
+    expect(JSON.parse(recordFor('audit').stdin)).toEqual({ hook_event_name: 'UserPromptSubmit', prompt: 'ship it' })
+  })
+
+  it('does not run on extension-injected input', async () => {
+    const ext = await withPromptHooks([{ command: 'audit' }])
+    expect(await ext.input('injected', 'extension')).toEqual({ action: 'continue' })
+    expect(commandsRun()).toEqual([])
+  })
+
+  it('injects a hook additionalContext ahead of the prompt via transform', async () => {
+    const ext = await withPromptHooks([{ command: 'ctx' }])
+    script('ctx', { stdout: [JSON.stringify({ hookSpecificOutput: { additionalContext: 'repo is frozen' } })] })
+    expect(await ext.input('deploy')).toEqual({ action: 'transform', text: 'repo is frozen\n\ndeploy' })
+  })
+
+  it('injects plain stdout as context', async () => {
+    const ext = await withPromptHooks([{ command: 'ctx' }])
+    script('ctx', { stdout: ['remember the changelog'] })
+    expect(await ext.input('deploy')).toEqual({ action: 'transform', text: 'remember the changelog\n\ndeploy' })
+  })
+
+  it('blocks a prompt a hook denies and surfaces the reason', async () => {
+    const ext = await withPromptHooks([{ command: 'guard' }])
+    script('guard', { stderr: ['no secrets in prompts'], code: 2 })
+    expect(await ext.input('here is my api key')).toEqual({ action: 'handled' })
+    expect(ext.notes.at(-1)).toEqual({ msg: 'no secrets in prompts', level: 'error' })
+  })
+})
+
+describe('hooks extension notify-style events', () => {
+  const withHooks = async (config: Record<string, unknown>) => {
+    writeSettings(hoisted.home, 'settings.json', config)
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('runs Stop hooks on agent end', async () => {
+    const ext = await withHooks({ Stop: [{ hooks: [{ command: 'stopped' }] }] })
+    await ext.agentEnd()
+    expect(commandsRun()).toEqual(['stopped'])
+    expect(JSON.parse(recordFor('stopped').stdin)).toEqual({ hook_event_name: 'Stop' })
+  })
+
+  it('runs PreCompact hooks matching the compaction trigger', async () => {
+    const ext = await withHooks({ PreCompact: [{ matcher: 'manual', hooks: [{ command: 'pc' }] }] })
+    await ext.beforeCompact('manual')
+    expect(commandsRun()).toEqual(['pc'])
+    expect(JSON.parse(recordFor('pc').stdin)).toEqual({ hook_event_name: 'PreCompact', trigger: 'manual' })
+  })
+
+  it('does not run PreCompact hooks whose matcher misses the trigger', async () => {
+    const ext = await withHooks({ PreCompact: [{ matcher: 'manual', hooks: [{ command: 'pc' }] }] })
+    await ext.beforeCompact('threshold')
+    expect(commandsRun()).toEqual([])
+  })
+
+  it('runs SessionEnd hooks with the shutdown reason', async () => {
+    const ext = await withHooks({ SessionEnd: [{ hooks: [{ command: 'bye' }] }] })
+    await ext.shutdown('quit')
+    expect(commandsRun()).toEqual(['bye'])
+    expect(JSON.parse(recordFor('bye').stdin)).toEqual({ hook_event_name: 'SessionEnd', reason: 'quit' })
   })
 })

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -719,6 +719,19 @@ describe('mcp tool execution', () => {
     await assertion
   })
 
+  it('honors MCP_TOOL_TIMEOUT for the per-call budget', async () => {
+    setEnv('MCP_TOOL_TIMEOUT', '5000')
+    hoisted.control.callTool = () => new Promise<CallResult>(() => {})
+    const harness = await registerOne()
+    vi.useFakeTimers()
+
+    const pending = harness.tools[0].execute('call-1', {})
+    const assertion = expect(pending).rejects.toThrow('timed out after 5000ms')
+    await vi.advanceTimersByTimeAsync(5_000)
+    await assertion
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 5000 })
+  })
+
   it('passes the call timeout to the SDK so its shorter default cannot fire first', async () => {
     hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
     const harness = await registerOne()
@@ -773,6 +786,19 @@ describe('mcp failure reporting', () => {
     await booting
 
     expect(await statusLinesOf(harness)).toEqual(['hung: failed: connect hung timed out after 10000ms (0 tools)'])
+  })
+
+  it('honors MCP_TIMEOUT for the connect budget', async () => {
+    setEnv('MCP_TIMEOUT', '2000')
+    hoisted.control.connect = () => new Promise<void>(() => {})
+    vi.useFakeTimers()
+
+    const harness = await setup({ user: { hung: { command: 'sleep' } } })
+    const booting = harness.sessionStart()
+    await vi.advanceTimersByTimeAsync(2_000)
+    await booting
+
+    expect(await statusLinesOf(harness)).toEqual(['hung: failed: connect hung timed out after 2000ms (0 tools)'])
   })
 
   it('closes a client whose connect exceeded the budget so it cannot orphan', async () => {

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -1,10 +1,33 @@
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { formatToolName, interpolateEnv, loadConfigFrom, mapContent, normalizeSchema, projectConfigPaths, userConfigPaths } from '../extensions/mcp.ts'
+import { formatToolName, interpolateEnv, loadConfigFrom, loadUserScope, mapContent, normalizeSchema, projectConfigPaths, userConfigPaths } from '../extensions/mcp.ts'
+
+describe('loadUserScope', () => {
+  it('merges local-scope per-project servers over the global user servers', () => {
+    const home = mkdtempSync(join(tmpdir(), 'mcp-home-'))
+    const cwd = '/work/project'
+    writeFileSync(
+      join(home, '.claude.json'),
+      JSON.stringify({
+        mcpServers: { global: { command: 'g' }, shared: { command: 'user-shared' } },
+        projects: { '/work/project': { mcpServers: { local: { command: 'l' }, shared: { command: 'local-shared' } } } },
+      }),
+    )
+    const servers = loadUserScope(home, cwd)
+    expect(Object.keys(servers).sort()).toEqual(['global', 'local', 'shared'])
+    expect((servers.shared as { command: string }).command).toBe('local-shared')
+  })
+
+  it('returns the global user servers when the project has no local scope', () => {
+    const home = mkdtempSync(join(tmpdir(), 'mcp-home-'))
+    writeFileSync(join(home, '.claude.json'), JSON.stringify({ mcpServers: { g: { command: 'g' } } }))
+    expect(Object.keys(loadUserScope(home, '/some/other'))).toEqual(['g'])
+  })
+})
 
 describe('mcp adapter helpers', () => {
   // biome-ignore lint/suspicious/noTemplateCurlyInString: the title documents the ${VAR} syntax interpolateEnv parses


### PR DESCRIPTION
Two config-parity features from the backlog, each red-first, gate green at 846 tests.

## Hook events

Bridges four more Claude hook events onto real pi lifecycle seams:
- **UserPromptSubmit** → pi `input`: can block the prompt (surfacing the reason, then consuming it) and inject a hook's `additionalContext` by transforming the submitted text.
- **Stop** → `agent_end`, **PreCompact** → `session_before_compact`, **SessionEnd** → `session_shutdown`: fire-and-forget (none of those pi events can be cancelled, a documented limitation).
- **SubagentStop** has no pi lifecycle seam and is documented as unbridged.

## MCP config fidelity

- **Local scope**: per-project user servers under `projects[cwd].mcpServers` in ~/.claude.json, merged over the global user servers (local wins a name clash), gated like other user config.
- **MCP_TIMEOUT / MCP_TOOL_TIMEOUT** env vars now override the connect and per-call timeouts (defaults 10s/120s).

Per-server .mcp.json approval settings (enabledMcpjsonServers etc.) remain all-or-nothing; OAuth is still out (needs a browser flow).