### PR TITLE
Add npm discovery keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,21 @@
   "version": "0.4.0",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, and subagents",
   "keywords": [
-    "pi-package"
+    "pi",
+    "pi-package",
+    "pi-coding-agent",
+    "pi-extension",
+    "extension",
+    "claude",
+    "claude-code",
+    "coding-agent",
+    "ai",
+    "mcp",
+    "hooks",
+    "skills",
+    "subagents",
+    "memory",
+    "todo"
   ],
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Changes

`package.json` `keywords` extended from the single `pi-package` entry to cover the package identity, the compatibility surface, and the features it provides:

- Package identity: `pi`, `pi-package`, `pi-coding-agent`, `pi-extension`, `extension`
- Compatibility: `claude`, `claude-code`, `coding-agent`, `ai`
- Features: `mcp`, `hooks`, `skills`, `subagents`, `memory`, `todo`

No other file records keywords: `package-lock.json`'s root package entry does not carry the field, and nothing else in the tree references the list.

Keywords are registry metadata, so this takes effect on the next npm publish.

## Verification

`npm run check` (biome, tsc, vitest with coverage) green locally.