### PR TITLE
Fix memory paths on Windows

### DIFF
--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -18,7 +18,10 @@ import { capForContext } from './internal/output-guard.js'
 const INDEX_FILE = 'MEMORY.md'
 
 export function projectSlug(cwd: string): string {
-  return cwd.replace(/[/\\]/g, '-').replace(/^-+/, '-')
+  return cwd
+    .replace(/^([A-Za-z]):(?=[/\\])/, '$1')
+    .replace(/[/\\]/g, '-')
+    .replace(/^-+/, '-')
 }
 
 export function memoryDir(cwd: string): string {

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { memoryDir, projectSlug, removeIndexLine, slugifyName, upsertIndexLine } from '../extensions/memory.ts'
@@ -5,7 +6,8 @@ import { memoryDir, projectSlug, removeIndexLine, slugifyName, upsertIndexLine }
 describe('memory helpers', () => {
   it('slugs project paths into directory names', () => {
     expect(projectSlug('/Users/alex/Documents/pi-code')).toBe('-Users-alex-Documents-pi-code')
-    expect(memoryDir('/tmp/x')).toContain('.pi/agent/memory/-tmp-x')
+    expect(projectSlug('C:\\Users\\alex\\Documents\\pi-code')).toBe('C-Users-alex-Documents-pi-code')
+    expect(memoryDir('/tmp/x')).toContain(path.join('.pi', 'agent', 'memory', '-tmp-x'))
   })
 
   it('slugifies memory names', () => {


### PR DESCRIPTION
## Summary

- normalize Windows drive prefixes before deriving the per-project memory directory slug
- add a Windows path regression test
- make the existing memory directory assertion platform-neutral

## Problem

On Windows, a working directory such as `C:\Users\alex\project` was converted to `C:-Users-alex-project`. The colon is not valid in a Windows directory component, so saving a memory failed when creating the project memory directory.

The fix removes the colon only from a leading Windows drive prefix before applying the existing separator replacement. This preserves the existing behavior for POSIX paths.

## Testing

- `npx @biomejs/biome check extensions/memory.ts tests/memory.test.ts`
- `npm run type:check`
- `npx vitest run tests/memory.test.ts tests/memory-actions.test.ts` (12 tests passed)
