### PR TITLE
Match Claude Code hook matcher semantics

### DIFF
--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -22,9 +22,11 @@
  *
  * Config is merged from ~/.claude/settings.json (always) plus the project's
  * .claude/settings.json and settings.local.json (only when the project is
- * trusted, since hooks execute arbitrary shell). Claude tool matchers are
- * PascalCase (`Bash`); pi tool names are lowercase (`bash`), so matchers are
- * applied case-insensitively.
+ * trusted, since hooks execute arbitrary shell). Matchers follow Claude's rule:
+ * `*`/empty match all, plain names are exact (with `|`/`,` list separators), and
+ * anything with other regex characters is an unanchored regex. Claude matchers
+ * are PascalCase (`Bash`); pi tool names are lowercase (`bash`), so comparison
+ * is case-insensitive and folds `-` to `_`.
  *
  * Docs: https://code.claude.com/docs/en/hooks.md
  */
@@ -86,12 +88,32 @@ export function loadHooks(files: string[]): HooksConfig {
   return config
 }
 
-function matcherApplies(matcher: string | undefined, name: string): boolean {
+/** Claude's rule: a matcher of only letters, digits, `_`, `-`, spaces, `,` and `|`
+ * is a list of exact names; anything else is an unanchored regex. */
+const EXACT_MATCHER = /^[\w\- ,|]*$/
+
+/** Claude names are PascalCase and keep dashes (`Bash`, `mcp__brave-search__x`);
+ * pi names are lowercase with underscores, so comparison folds both. */
+function foldName(name: string): string {
+  return name.toLowerCase().replaceAll('-', '_')
+}
+
+function exactListApplies(matcher: string, names: readonly string[]): boolean {
+  const tokens = matcher
+    .split(/[|,]/)
+    .map((token) => foldName(token.trim()))
+    .filter(Boolean)
+  return names.some((name) => tokens.includes(foldName(name)))
+}
+
+function matcherApplies(matcher: string | undefined, names: readonly string[]): boolean {
   if (!matcher || matcher === '*') return true
+  if (EXACT_MATCHER.test(matcher)) return exactListApplies(matcher, names)
   try {
-    return new RegExp(`^(?:${matcher})$`, 'i').test(name)
+    const regex = new RegExp(matcher, 'i')
+    return names.some((name) => regex.test(name))
   } catch {
-    return matcher.toLowerCase() === name.toLowerCase()
+    return exactListApplies(matcher, names)
   }
 }
 
@@ -101,11 +123,13 @@ function isRunnableHook(hook: HookCommand): boolean {
   return typeof hook.command === 'string' && (hook.type === undefined || hook.type === 'command')
 }
 
-/** Command specs whose matcher applies to the given tool/source name. */
-export function matchingCommands(matchers: HookMatcher[] | undefined, name: string): HookCommand[] {
+/** Command specs whose matcher applies to any of the given tool/source names.
+ * Multiple candidates let one event offer both the pi name and its Claude alias. */
+export function matchingCommands(matchers: HookMatcher[] | undefined, names: string | readonly string[]): HookCommand[] {
+  const candidates = typeof names === 'string' ? [names] : names
   const result: HookCommand[] = []
   for (const entry of matchers ?? []) {
-    if (matcherApplies(entry.matcher, name)) result.push(...(entry.hooks ?? []).filter(isRunnableHook))
+    if (matcherApplies(entry.matcher, candidates)) result.push(...(entry.hooks ?? []).filter(isRunnableHook))
   }
   return result
 }

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -37,6 +37,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
+import { isMcpToolAliases, MCP_TOOLS_CHANNEL } from './internal/mcp-alias.js'
 import { isProjectApproved } from './internal/project-approval.js'
 
 const DEFAULT_TIMEOUT_S = 60
@@ -232,10 +233,13 @@ function timeoutMs(command: HookCommand): number {
   return seconds * 1000
 }
 
-/** Run PreToolUse hooks for a tool; the first blocking verdict wins. */
-export async function runPreToolUse(config: HooksConfig, toolName: string, toolInput: unknown, runner: HookRunner): Promise<HookDecision> {
-  for (const command of matchingCommands(config.PreToolUse, toolName)) {
-    const result = await runner(command.command, { hook_event_name: 'PreToolUse', tool_name: toolName, tool_input: toolInput }, timeoutMs(command))
+/** Run PreToolUse hooks for a tool; the first blocking verdict wins. For MCP tools the
+ * matcher sees both the pi name and the Claude alias, and the payload reports the alias,
+ * which is the name a Claude-written hook script expects in tool_name. */
+export async function runPreToolUse(config: HooksConfig, toolName: string, toolInput: unknown, runner: HookRunner, claudeName?: string): Promise<HookDecision> {
+  const names = claudeName ? [toolName, claudeName] : [toolName]
+  for (const command of matchingCommands(config.PreToolUse, names)) {
+    const result = await runner(command.command, { hook_event_name: 'PreToolUse', tool_name: claudeName ?? toolName, tool_input: toolInput }, timeoutMs(command))
     // A killed hook never reached its verdict, and SIGKILL leaves a null exit code that
     // would otherwise read as a clean allow. Fail closed instead.
     if (result.timedOut) return { block: true, reason: `Hook timed out after ${timeoutMs(command)}ms: ${command.command}` }
@@ -301,6 +305,14 @@ export default function hooksExtension(pi: ExtensionAPI) {
   // contract does, so remember it from tool_call keyed by the call id.
   const pendingInputs = new Map<string, unknown>()
   const runner: HookRunner = (command, payload, ms) => runHookCommand(command, payload, ms, projectDir)
+  // Claude matchers name MCP tools mcp__<server>__<tool>; pi-code registers them as
+  // <server>_<tool>. The mcp extension publishes the mapping on pi's shared bus.
+  const mcpAliases = new Map<string, string>()
+  pi.events.on(MCP_TOOLS_CHANNEL, (data) => {
+    if (!isMcpToolAliases(data)) return
+    mcpAliases.clear()
+    for (const entry of data) mcpAliases.set(entry.pi, entry.claude)
+  })
 
   pi.on('session_start', async (event, ctx) => {
     const trusted = await isProjectApproved(ctx)
@@ -319,7 +331,7 @@ export default function hooksExtension(pi: ExtensionAPI) {
       const oldest = pendingInputs.keys().next().value
       if (oldest !== undefined) pendingInputs.delete(oldest)
     }
-    const decision = await runPreToolUse(config, event.toolName, event.input, runner)
+    const decision = await runPreToolUse(config, event.toolName, event.input, runner, mcpAliases.get(event.toolName))
     if (!decision.block) return undefined
     // pi still emits tool_execution_end (isError) for a blocked call, which also
     // cleans up; deleting here just avoids relying on that host detail.
@@ -331,7 +343,9 @@ export default function hooksExtension(pi: ExtensionAPI) {
     const toolInput = pendingInputs.get(event.toolCallId)
     pendingInputs.delete(event.toolCallId)
     if (event.isError) return
-    await runNotifyHooks(matchingCommands(config.PostToolUse, event.toolName), { hook_event_name: 'PostToolUse', tool_name: event.toolName, tool_input: toolInput, tool_response: event.result }, runner)
+    const alias = mcpAliases.get(event.toolName)
+    const names = alias ? [event.toolName, alias] : [event.toolName]
+    await runNotifyHooks(matchingCommands(config.PostToolUse, names), { hook_event_name: 'PostToolUse', tool_name: alias ?? event.toolName, tool_input: toolInput, tool_response: event.result }, runner)
   })
 
   pi.on('input', async (event, ctx) => {

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -281,6 +281,19 @@ export async function runUserPromptSubmit(config: HooksConfig, prompt: string, r
 /** Bound on remembered tool inputs, in case a blocked or aborted call never ends. */
 const MAX_PENDING_INPUTS = 100
 
+/** pi's lifecycle vocabularies differ from Claude's documented ones. The matcher is
+ * offered both spellings so existing configs keep firing either way, and the payload
+ * reports the Claude value, which is what a Claude-written hook script parses. */
+const SESSION_START_SOURCE: Record<string, string> = { startup: 'startup', new: 'clear', resume: 'resume', fork: 'fork' }
+const PRECOMPACT_TRIGGER: Record<string, string> = { manual: 'manual', threshold: 'auto', overflow: 'auto' }
+const SESSION_END_REASON: Record<string, string> = { quit: 'prompt_input_exit', new: 'clear', resume: 'resume', reload: 'other', fork: 'other' }
+
+/** The raw pi value plus its Claude spelling, deduplicated, for matcher candidates. */
+function claudeSpelling(map: Record<string, string>, raw: string): { names: string[]; value: string } {
+  const value = map[raw] ?? raw
+  return { names: value === raw ? [raw] : [raw, value], value }
+}
+
 export default function hooksExtension(pi: ExtensionAPI) {
   let config: HooksConfig = {}
   let projectDir = ''
@@ -293,10 +306,11 @@ export default function hooksExtension(pi: ExtensionAPI) {
     const trusted = await isProjectApproved(ctx)
     projectDir = ctx.cwd
     config = loadHooks(hookFiles(ctx.cwd, os.homedir(), trusted))
-    // Only fire SessionStart hooks on a genuine session begin, matched by source (Claude uses
-    // "startup"/"resume"/...). "reload" and "fork" re-fire in-process and would double-run hooks.
-    if (event.reason === 'reload' || event.reason === 'fork') return
-    await runNotifyHooks(matchingCommands(config.SessionStart, event.reason), { hook_event_name: 'SessionStart', source: event.reason }, runner)
+    // "reload" re-fires in-process with the same conversation and would double-run hooks;
+    // a fork is a genuine session begin, which Claude reports as source "fork".
+    if (event.reason === 'reload') return
+    const source = claudeSpelling(SESSION_START_SOURCE, event.reason)
+    await runNotifyHooks(matchingCommands(config.SessionStart, source.names), { hook_event_name: 'SessionStart', source: source.value }, runner)
   })
 
   pi.on('tool_call', async (event) => {
@@ -343,10 +357,12 @@ export default function hooksExtension(pi: ExtensionAPI) {
   })
 
   pi.on('session_before_compact', async (event) => {
-    await runNotifyHooks(matchingCommands(config.PreCompact, event.reason), { hook_event_name: 'PreCompact', trigger: event.reason }, runner)
+    const trigger = claudeSpelling(PRECOMPACT_TRIGGER, event.reason)
+    await runNotifyHooks(matchingCommands(config.PreCompact, trigger.names), { hook_event_name: 'PreCompact', trigger: trigger.value }, runner)
   })
 
   pi.on('session_shutdown', async (event) => {
-    await runNotifyHooks(matchingCommands(config.SessionEnd, event.reason), { hook_event_name: 'SessionEnd', reason: event.reason }, runner)
+    const reason = claudeSpelling(SESSION_END_REASON, event.reason)
+    await runNotifyHooks(matchingCommands(config.SessionEnd, reason.names), { hook_event_name: 'SessionEnd', reason: reason.value }, runner)
   })
 }

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -129,8 +129,15 @@ function isRunnableHook(hook: HookCommand): boolean {
 export function matchingCommands(matchers: HookMatcher[] | undefined, names: string | readonly string[]): HookCommand[] {
   const candidates = typeof names === 'string' ? [names] : names
   const result: HookCommand[] = []
+  const seen = new Set<string>()
   for (const entry of matchers ?? []) {
-    if (matcherApplies(entry.matcher, candidates)) result.push(...(entry.hooks ?? []).filter(isRunnableHook))
+    if (!matcherApplies(entry.matcher, candidates)) continue
+    for (const hook of (entry.hooks ?? []).filter(isRunnableHook)) {
+      // Claude runs a handler defined in more than one settings file once.
+      if (seen.has(hook.command)) continue
+      seen.add(hook.command)
+      result.push(hook)
+    }
   }
   return result
 }

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -100,11 +100,13 @@ function foldName(name: string): string {
 }
 
 function exactListApplies(matcher: string, names: readonly string[]): boolean {
-  const tokens = matcher
-    .split(/[|,]/)
-    .map((token) => foldName(token.trim()))
-    .filter(Boolean)
-  return names.some((name) => tokens.includes(foldName(name)))
+  const tokens = new Set(
+    matcher
+      .split(/[|,]/)
+      .map((token) => foldName(token.trim()))
+      .filter(Boolean),
+  )
+  return names.some((name) => tokens.has(foldName(name)))
 }
 
 function matcherApplies(matcher: string | undefined, names: readonly string[]): boolean {

--- a/extensions/internal/mcp-alias.ts
+++ b/extensions/internal/mcp-alias.ts
@@ -1,0 +1,21 @@
+/**
+ * Channel and payload for the MCP tool-name registry the mcp extension publishes on
+ * pi's shared extension event bus. Claude Code names MCP tools `mcp__<server>__<tool>`
+ * (original names, dashes preserved); pi-code registers them as `<server>_<tool>` with
+ * dashes folded to underscores. Hook matchers written for Claude need the mapping, and
+ * pi loads every extension without a shared module cache, so cross-extension state must
+ * ride the bus rather than a module singleton.
+ */
+
+export const MCP_TOOLS_CHANNEL = 'pi-code:mcp-tools'
+
+export interface McpToolAlias {
+  /** Tool name as registered in pi, e.g. `github_create_issue`. */
+  pi: string
+  /** Claude Code's name for the same tool, e.g. `mcp__github__create_issue`. */
+  claude: string
+}
+
+export function isMcpToolAliases(data: unknown): data is McpToolAlias[] {
+  return Array.isArray(data) && data.every((entry) => typeof (entry as McpToolAlias)?.pi === 'string' && typeof (entry as McpToolAlias)?.claude === 'string')
+}

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -29,6 +29,7 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js' // 
 import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { Type } from 'typebox'
+import { MCP_TOOLS_CHANNEL, type McpToolAlias } from './internal/mcp-alias.js'
 import { capForContext } from './internal/output-guard.js'
 import { isProjectApproved } from './internal/project-approval.js'
 
@@ -261,6 +262,8 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   const clients = new Map<string, Client>()
   const status = new Map<string, { state: string; tools: number }>()
   const registered = new Set<string>()
+  // Original server/tool names per registered pi name, for Claude-style hook matchers.
+  const aliases: McpToolAlias[] = []
 
   async function connectServers(servers: Record<string, ServerConfig>): Promise<void> {
     for (const [name, config] of Object.entries(servers)) {
@@ -283,6 +286,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
             continue
           }
           registered.add(toolName)
+          aliases.push({ pi: toolName, claude: `mcp__${name}__${tool.name}` })
           count++
           pi.registerTool({
             name: toolName,
@@ -327,6 +331,8 @@ export default async function mcpExtension(pi: ExtensionAPI) {
       projectConnected = true
       await connectServers(loadConfigFrom(projectConfigPaths(ctx.cwd)))
     }
+
+    pi.events.emit(MCP_TOOLS_CHANNEL, [...aliases])
 
     const connected = [...status.values()].filter((s) => s.state === 'connected')
     const failed = [...status.entries()].filter(([, s]) => s.state !== 'connected')

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -387,7 +387,7 @@ describe('matchingCommands edge shapes', () => {
     expect(matchingCommands([hook], 'bash')).toEqual([])
   })
 
-  it('anchors the matcher so a partial tool-name match does not fire', () => {
+  it('does not partial-match an exact-name matcher', () => {
     const hook = { matcher: 'Bash', hooks: [{ command: 'guard' }] }
     expect(matchingCommands([hook], 'bashful')).toEqual([])
     expect(matchingCommands([hook], 'rebash')).toEqual([])

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -386,6 +386,15 @@ describe('matchingCommands edge shapes', () => {
     expect(matchingCommands([{ matcher: 'Bash' } as never], 'bash')).toEqual([])
   })
 
+  it('runs a handler defined identically in more than one settings file once', () => {
+    // Claude: "If you define the same handler in more than one settings file, it runs once."
+    const entries = [
+      { matcher: 'Bash', hooks: [{ command: 'guard.sh' }] },
+      { matcher: '*', hooks: [{ command: 'guard.sh' }, { command: 'other.sh' }] },
+    ]
+    expect(matchingCommands(entries, 'bash')).toEqual([{ command: 'guard.sh' }, { command: 'other.sh' }])
+  })
+
   it('falls back to case-insensitive literal equality when the matcher is an invalid regex', () => {
     const hook = { matcher: 'Bash(', hooks: [{ command: 'lit' }] }
     expect(matchingCommands([hook], 'bash(')).toEqual([{ command: 'lit' }])

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -140,7 +140,11 @@ type Handler = (event: Record<string, unknown>, ctx?: Record<string, unknown>) =
 /** Register the extension against a stub API and expose its three lifecycle handlers. */
 const setupExtension = () => {
   const handlers = new Map<string, Handler>()
-  hooksExtension({ on: (name: string, fn: Handler) => handlers.set(name, fn) } as never)
+  const busHandlers = new Map<string, (data: unknown) => void>()
+  hooksExtension({
+    on: (name: string, fn: Handler) => handlers.set(name, fn),
+    events: { on: (channel: string, fn: (data: unknown) => void) => busHandlers.set(channel, fn), emit: () => {} },
+  } as never)
   const handler = (name: string): Handler => {
     const found = handlers.get(name)
     if (!found) throw new Error(`hooks extension did not register ${name}`)
@@ -158,6 +162,7 @@ const setupExtension = () => {
     agentEnd: () => handler('agent_end')({ messages: [] }),
     beforeCompact: (reason: string) => handler('session_before_compact')({ reason }),
     shutdown: (reason: string) => handler('session_shutdown')({ reason }),
+    emitMcpTools: (entries: unknown) => busHandlers.get('pi-code:mcp-tools')?.(entries),
   }
 }
 
@@ -750,5 +755,45 @@ describe('hooks extension notify-style events', () => {
     const ext = await withHooks({ SessionEnd: [{ matcher: 'quit', hooks: [{ command: 'bye' }] }] })
     await ext.shutdown('quit')
     expect(commandsRun()).toEqual(['bye'])
+  })
+})
+
+describe('hooks MCP tool aliases', () => {
+  const withHooks = async (config: Record<string, unknown>) => {
+    writeSettings(hoisted.home, 'settings.json', config)
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it("fires a Claude mcp__ matcher against pi's server_tool name and reports the Claude name", async () => {
+    const ext = await withHooks({ PreToolUse: [{ matcher: 'mcp__github__.*', hooks: [{ command: 'guard' }] }] })
+    ext.emitMcpTools([{ pi: 'github_create_issue', claude: 'mcp__github__create_issue' }])
+    await ext.toolCall('github_create_issue', { title: 't' })
+    expect(commandsRun()).toEqual(['guard'])
+    expect(JSON.parse(recordFor('guard').stdin)).toEqual({ hook_event_name: 'PreToolUse', tool_name: 'mcp__github__create_issue', tool_input: { title: 't' } })
+  })
+
+  it('does not fire the mcp__ matcher when no alias was published', async () => {
+    const ext = await withHooks({ PreToolUse: [{ matcher: 'mcp__github__.*', hooks: [{ command: 'guard' }] }] })
+    await ext.toolCall('github_create_issue', {})
+    expect(commandsRun()).toEqual([])
+  })
+
+  it('reports the Claude name in PostToolUse payloads for aliased tools', async () => {
+    const ext = await withHooks({ PostToolUse: [{ matcher: 'mcp__github__.*', hooks: [{ command: 'post' }] }] })
+    ext.emitMcpTools([{ pi: 'github_create_issue', claude: 'mcp__github__create_issue' }])
+    await ext.toolCall('github_create_issue', { title: 't' })
+    await ext.toolEnd('github_create_issue', false, { result: 'ok' })
+    expect(commandsRun()).toEqual(['post'])
+    expect(JSON.parse(recordFor('post').stdin)).toEqual({ hook_event_name: 'PostToolUse', tool_name: 'mcp__github__create_issue', tool_input: { title: 't' }, tool_response: 'ok' })
+  })
+
+  it('ignores a malformed alias payload from the bus', async () => {
+    const ext = await withHooks({ PreToolUse: [{ matcher: 'mcp__github__.*', hooks: [{ command: 'guard' }] }] })
+    ext.emitMcpTools([{ pi: 'github_create_issue' }])
+    ext.emitMcpTools('junk')
+    await ext.toolCall('github_create_issue', {})
+    expect(commandsRun()).toEqual([])
   })
 })

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -458,13 +458,27 @@ describe('hooks extension session_start', () => {
     expect(commandsRun()).toEqual([])
   })
 
-  it.each(['reload', 'fork'])('skips SessionStart hooks on a %s but still loads the config', async (reason) => {
-    writeSettings(hoisted.home, 'settings.json', { ...homeConfig, SessionStart: [{ matcher: reason, hooks: [{ command: 'home-session' }] }] })
+  it('skips SessionStart hooks on a reload but still loads the config', async () => {
+    writeSettings(hoisted.home, 'settings.json', { ...homeConfig, SessionStart: [{ matcher: 'reload', hooks: [{ command: 'home-session' }] }] })
     const ext = setupExtension()
-    await ext.sessionStart(reason, { cwd: tempDir('hooks-proj-') })
+    await ext.sessionStart('reload', { cwd: tempDir('hooks-proj-') })
     expect(commandsRun()).toEqual([])
     await ext.toolCall('bash', {})
     expect(commandsRun()).toEqual(['home-pre'])
+  })
+
+  it('fires SessionStart hooks on a fork with source fork, as Claude does', async () => {
+    writeSettings(hoisted.home, 'settings.json', { SessionStart: [{ matcher: 'fork', hooks: [{ command: 'home-session' }] }] })
+    await setupExtension().sessionStart('fork', { cwd: tempDir('hooks-proj-') })
+    expect(commandsRun()).toEqual(['home-session'])
+    expect(JSON.parse(recordFor('home-session').stdin)).toEqual({ hook_event_name: 'SessionStart', source: 'fork' })
+  })
+
+  it("maps pi's new-session start onto Claude's clear source", async () => {
+    writeSettings(hoisted.home, 'settings.json', { SessionStart: [{ matcher: 'clear', hooks: [{ command: 'home-session' }] }] })
+    await setupExtension().sessionStart('new', { cwd: tempDir('hooks-proj-') })
+    expect(commandsRun()).toEqual(['home-session'])
+    expect(JSON.parse(recordFor('home-session').stdin)).toEqual({ hook_event_name: 'SessionStart', source: 'clear' })
   })
 
   it('exposes CLAUDE_PROJECT_DIR to hook commands', async () => {
@@ -718,10 +732,23 @@ describe('hooks extension notify-style events', () => {
     expect(commandsRun()).toEqual([])
   })
 
-  it('runs SessionEnd hooks with the shutdown reason', async () => {
-    const ext = await withHooks({ SessionEnd: [{ hooks: [{ command: 'bye' }] }] })
+  it("maps pi's threshold/overflow compaction onto Claude's auto trigger", async () => {
+    const ext = await withHooks({ PreCompact: [{ matcher: 'auto', hooks: [{ command: 'pc' }] }] })
+    await ext.beforeCompact('threshold')
+    expect(commandsRun()).toEqual(['pc'])
+    expect(JSON.parse(recordFor('pc').stdin)).toEqual({ hook_event_name: 'PreCompact', trigger: 'auto' })
+  })
+
+  it("runs SessionEnd hooks with the Claude spelling of pi's shutdown reason", async () => {
+    const ext = await withHooks({ SessionEnd: [{ matcher: 'prompt_input_exit', hooks: [{ command: 'bye' }] }] })
     await ext.shutdown('quit')
     expect(commandsRun()).toEqual(['bye'])
-    expect(JSON.parse(recordFor('bye').stdin)).toEqual({ hook_event_name: 'SessionEnd', reason: 'quit' })
+    expect(JSON.parse(recordFor('bye').stdin)).toEqual({ hook_event_name: 'SessionEnd', reason: 'prompt_input_exit' })
+  })
+
+  it("still fires a SessionEnd matcher written against pi's raw reason", async () => {
+    const ext = await withHooks({ SessionEnd: [{ matcher: 'quit', hooks: [{ command: 'bye' }] }] })
+    await ext.shutdown('quit')
+    expect(commandsRun()).toEqual(['bye'])
   })
 })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -54,6 +54,32 @@ describe('matchingCommands', () => {
     expect(matchingCommands([hook], 'read')).toEqual([])
   })
 
+  it('treats a comma-separated matcher as a list of exact names, like Claude', () => {
+    const hook = { matcher: 'Edit, Write', hooks: [{ command: 'fmt' }] }
+    expect(matchingCommands([hook], 'edit')).toEqual([{ command: 'fmt' }])
+    expect(matchingCommands([hook], 'write')).toEqual([{ command: 'fmt' }])
+    expect(matchingCommands([hook], 'read')).toEqual([])
+  })
+
+  it('applies a matcher with regex characters unanchored, like Claude', () => {
+    // Claude documents `Edit.*` as matching NotebookEdit: the regex tests anywhere in the name.
+    const hook = { matcher: 'Edit.*', hooks: [{ command: 'fmt' }] }
+    expect(matchingCommands([hook], 'notebookedit')).toEqual([{ command: 'fmt' }])
+    expect(matchingCommands([hook], 'read')).toEqual([])
+  })
+
+  it('treats dashes and underscores alike when matching exact names', () => {
+    const hook = { matcher: 'mcp__brave-search__web_search', hooks: [{ command: 'x' }] }
+    expect(matchingCommands([hook], 'mcp__brave_search__web-search')).toEqual([{ command: 'x' }])
+    expect(matchingCommands([hook], 'mcp__brave_search__other')).toEqual([])
+  })
+
+  it('matches when any candidate name satisfies the matcher', () => {
+    const hook = { matcher: 'mcp__github__create_issue', hooks: [{ command: 'x' }] }
+    expect(matchingCommands([hook], ['github_create_issue', 'mcp__github__create_issue'])).toEqual([{ command: 'x' }])
+    expect(matchingCommands([hook], ['github_create_issue'])).toEqual([])
+  })
+
   it('matches a SessionStart matcher against the session source, not an empty string', () => {
     const hook = { matcher: 'startup', hooks: [{ command: 'setup.sh' }] }
     expect(matchingCommands([hook], 'startup')).toEqual([{ command: 'setup.sh' }])

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -136,6 +136,7 @@ interface Harness {
   tools: RegisteredTool[]
   notifications: Notification[]
   warnings: string[]
+  emitted: Array<{ channel: string; data: unknown }>
   home: string
   cwd: string
   sessionStart: (trusted?: boolean | undefined, approve?: boolean) => Promise<void>
@@ -161,6 +162,7 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
   const tools: RegisteredTool[] = []
   const notifications: Notification[] = []
   const warnings: string[] = []
+  const emitted: Array<{ channel: string; data: unknown }> = []
   const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<void>>()
   const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>()
 
@@ -184,12 +186,14 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
     on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<void>) => handlers.set(name, fn),
     registerCommand: (name: string, opts2: { handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, opts2),
     registerTool: (tool: RegisteredTool) => tools.push(tool),
+    events: { emit: (channel: string, data: unknown) => emitted.push({ channel, data }), on: () => () => {} },
   } as never)
 
   return {
     tools,
     notifications,
     warnings,
+    emitted,
     home,
     cwd,
     sessionStart: async (trusted?: boolean, approve = true) => {
@@ -962,5 +966,17 @@ describe('mcp session_shutdown', () => {
 
     await expect(shutting).resolves.toBeUndefined()
     expect(closed).toEqual(['quick'])
+  })
+})
+
+describe('MCP tool alias publication', () => {
+  it('publishes pi-to-Claude tool name aliases on the shared bus with original names', async () => {
+    withTools([{ name: 'web-search' }])
+    const harness = await setup({ user: { 'brave-search': { command: 'srv' } } })
+    await harness.sessionStart()
+    expect(harness.emitted).toContainEqual({
+      channel: 'pi-code:mcp-tools',
+      data: [{ pi: 'brave_search_web_search', claude: 'mcp__brave-search__web-search' }],
+    })
   })
 })


### PR DESCRIPTION
Brings hook matching in line with the documented Claude Code semantics, in four areas. Each change ships with tests that fail against the previous behavior.

## Matchers that could never fire

- **`mcp__server__tool` matchers now fire** (hooks.ts, mcp.ts, internal/mcp-alias.ts). Claude names MCP tools `mcp__<server>__<tool>` with original dashes; pi-code registers `<server>_<tool>` with dashes folded, so a matcher like `mcp__github__.*` never matched any tool. The mcp extension now publishes the name mapping on pi's shared extension event bus (extensions load without a shared module cache, so a registry singleton cannot work), hook matching checks both names, and hook payloads report the Claude name in `tool_name`, which is what a Claude-written hook script parses.
- **`PreCompact` matcher `auto` now fires** (hooks.ts). Claude documents triggers `manual`/`auto`; pi reports `threshold`/`overflow`, which an `auto` matcher never matched. The same held for `SessionStart` `clear` (pi: `new`) and every `SessionEnd` reason. Each event now offers the matcher both spellings and reports the Claude value in the payload; matchers written against pi's raw values keep working.

## Matcher interpretation

- **Exact-or-regex rule matches Claude's documented table** (hooks.ts). A matcher of only letters, digits, `_`, `-`, spaces, `,` and `|` is a list of exact names (`Edit, Write` matched nothing before); anything else is an unanchored regex (`Edit.*` now matches `notebookedit`, as Claude documents). Comparison stays case-insensitive and folds `-` to `_`, bridging Claude spellings onto pi's lowercase underscored names. *Behavior change: regexes are no longer anchored, matching Claude rather than the previous stricter reading.*

## Duplicate and fork handling

- **A handler defined in more than one settings file runs once per firing** (hooks.ts), per Claude's documented dedupe; the concatenated user and project configs previously ran it twice.
- **A forked session now fires `SessionStart` with `source: "fork"`** (hooks.ts) instead of being suppressed, matching current Claude behavior; `reload` stays suppressed since it re-fires in-process.

Verified with the full gate (biome, strict tsc, 861 tests) and `scripts/e2e-full.sh` against pi 0.84.0; the one failing e2e step (context-imports codeword, a two-question model turn) was reproduced as a model-phrasing flake by a direct probe that shows the imported codeword reaching the model in 30s, and is unrelated to the files this PR touches.