### PR TITLE
Honor Claude's statusLine command contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ One `pi install` and everything below loads on the next start. `pi list` shows w
 | Persistent memory | per-project memories, index injected each session | `memory.ts` |
 | WebSearch / WebFetch | key-free DuckDuckGo search, SSRF-guarded fetch | `web.ts` |
 | AskUserQuestion | one question with `header`, single- or `multiSelect` options, plus free-text; no multi-question batching | `question.ts` |
-| Statusline | turn state + session cost | `status-line.ts` |
+| Statusline | Claude `statusLine` command contract (stdin JSON, `padding`, `refreshInterval`); built-in turn state + session cost fallback | `status-line.ts` |
 | Notifications | vendored example | `notify.ts` |
 
 `CLAUDE.md` itself needs no extension: pi loads `CLAUDE.md` / `AGENTS.md` context files natively (global + walking cwd to root). `context-imports.ts` only adds the `@import` resolution pi's loader lacks, appending the imported files without re-injecting the base.

--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -1,15 +1,35 @@
 /**
  * Status Line Extension
  *
- * Adds a Claude Code style status segment to pi's footer: turn state plus
- * running session cost. Cost is summed from per-message usage on the current
- * branch, so it stays correct across /tree navigation and forks.
+ * Honors Claude Code's `statusLine` settings contract: a configured command runs
+ * with the session JSON on stdin (model, workspace, cost, context_window, effort,
+ * output_style, session ids) and its first stdout line becomes the footer segment,
+ * padded per `padding`. It re-runs, debounced 300ms as Claude does, at session
+ * start, after turns, after compaction, on plan-mode changes (the permission-mode
+ * analogue, off the shared bus), and on the optional `refreshInterval` timer
+ * (minimum 1s). A project-defined command is arbitrary shell, so project settings
+ * count only once the project is approved, like hooks.
  *
- * pi's built-in footer already shows path, branch, context, and model;
- * this extension only adds what is missing instead of replacing the footer.
+ * Without a configured statusLine, the built-in segment shows turn state plus
+ * running session cost, summed from per-message usage on the current branch so it
+ * stays correct across /tree navigation and forks. The built-in segment is also
+ * the fallback while a configured command produces no output. Multi-line output
+ * is truncated to its first line: the segment is one footer row in pi.
+ *
+ * Docs: https://code.claude.com/docs/en/statusline.md
  */
 
+import * as fs from 'node:fs'
+import * as os from 'node:os'
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
+
+import { hookFiles, runHookCommand } from './hooks.js'
+import { isPlanModeState, PLAN_MODE_CHANNEL } from './internal/plan-mode-state.js'
+import { isProjectApproved } from './internal/project-approval.js'
+import { readActiveStyleName, settingsFiles } from './output-styles.js'
+
+const COMMAND_TIMEOUT_MS = 5_000
+const DEBOUNCE_MS = 300
 
 interface UsageEntry {
   type: string
@@ -28,34 +48,153 @@ function formatCost(cost: number): string {
   return cost >= 0.01 ? `$${cost.toFixed(2)}` : `$${cost.toFixed(4)}`
 }
 
+export interface StatusLineConfig {
+  command: string
+  padding: number
+  refreshInterval: number | undefined
+}
+
+/** The `statusLine` recorded in settings, last file winning. Claude's shape is
+ * `{type: "command", command, padding?, refreshInterval?}`; entries without a
+ * command string are ignored, and refreshInterval has a documented minimum of 1. */
+export function readStatusLineConfig(files: string[]): StatusLineConfig | undefined {
+  let found: StatusLineConfig | undefined
+  for (const file of files) {
+    try {
+      const settings = JSON.parse(fs.readFileSync(file, 'utf-8'))
+      const entry = settings.statusLine
+      if (!entry || typeof entry.command !== 'string') continue
+      if (entry.type !== undefined && entry.type !== 'command') continue
+      found = {
+        command: entry.command,
+        padding: typeof entry.padding === 'number' && entry.padding > 0 ? entry.padding : 0,
+        refreshInterval: typeof entry.refreshInterval === 'number' && entry.refreshInterval >= 1 ? entry.refreshInterval : undefined,
+      }
+    } catch {
+      // missing or invalid file: skip
+    }
+  }
+  return found
+}
+
 export default function statusLine(pi: ExtensionAPI) {
   let turnCount = 0
+  let config: StatusLineConfig | undefined
+  let sessionCtx: ExtensionContext | undefined
+  let commandLine: string | undefined
+  let permissionMode = 'default'
+  let refreshTimer: ReturnType<typeof setInterval> | undefined
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined
+  let running = false
+  let rerunQueued = false
 
-  function showIdle(ctx: ExtensionContext, symbol: string): void {
+  function segmentText(ctx: ExtensionContext, symbol: string): string {
     const theme = ctx.ui.theme
     const cost = sessionCost(ctx)
     const costText = cost > 0 ? theme.fg('muted', ` ${formatCost(cost)}`) : ''
     const turnText = turnCount > 0 ? theme.fg('dim', ` turn ${turnCount}`) : theme.fg('dim', ' ready')
-    ctx.ui.setStatus('pi-code-status', symbol + turnText + costText)
+    return symbol + turnText + costText
   }
 
+  function show(ctx: ExtensionContext, builtIn: string): void {
+    ctx.ui.setStatus('pi-code-status', commandLine ?? builtIn)
+  }
+
+  /** The stdin payload per Claude's documented statusline contract. */
+  function buildPayload(ctx: ExtensionContext): Record<string, unknown> {
+    const usage = ctx.getContextUsage() ?? { tokens: null, contextWindow: 0, percent: null }
+    const styleName = readActiveStyleName(settingsFiles(ctx.cwd, os.homedir(), true))
+    const payload: Record<string, unknown> = {
+      session_id: ctx.sessionManager.getSessionId(),
+      cwd: ctx.cwd,
+      workspace: { current_dir: ctx.cwd, project_dir: ctx.cwd },
+      model: { id: (ctx.model as { id?: string } | undefined)?.id ?? '' },
+      cost: { total_cost_usd: sessionCost(ctx) },
+      context_window: { context_window_size: usage.contextWindow, used_percentage: usage.percent, total_input_tokens: usage.tokens },
+      permission_mode: permissionMode,
+    }
+    const transcript = ctx.sessionManager.getSessionFile()
+    if (transcript) payload.transcript_path = transcript
+    if (ctx.thinkingLevel) payload.effort = { level: ctx.thinkingLevel }
+    if (styleName) payload.output_style = { name: styleName }
+    return payload
+  }
+
+  async function runCommand(ctx: ExtensionContext): Promise<void> {
+    if (!config) return
+    if (running) {
+      rerunQueued = true
+      return
+    }
+    running = true
+    try {
+      const result = await runHookCommand(config.command, buildPayload(ctx), COMMAND_TIMEOUT_MS)
+      const first = result.stdout.split('\n')[0].trimEnd()
+      const pad = ' '.repeat(config.padding)
+      commandLine = first ? `${pad}${first}${pad}` : undefined
+      show(ctx, segmentText(ctx, ctx.ui.theme.fg('dim', '○')))
+    } finally {
+      running = false
+      if (rerunQueued) {
+        rerunQueued = false
+        void runCommand(ctx)
+      }
+    }
+  }
+
+  /** Claude debounces statusline updates at 300ms so rapid triggers batch. */
+  function scheduleRefresh(): void {
+    if (!config || !sessionCtx) return
+    const ctx = sessionCtx
+    clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      void runCommand(ctx)
+    }, DEBOUNCE_MS)
+  }
+
+  pi.events.on(PLAN_MODE_CHANNEL, (data) => {
+    if (!isPlanModeState(data)) return
+    permissionMode = data.active ? 'plan' : 'default'
+    scheduleRefresh()
+  })
+
   pi.on('session_start', async (_event, ctx) => {
-    // One instance serves every session, so a fresh session must not inherit the count.
+    // One instance serves every session, so a fresh session must not inherit state.
     turnCount = 0
-    showIdle(ctx, ctx.ui.theme.fg('dim', '○'))
+    commandLine = undefined
+    sessionCtx = ctx
+    clearInterval(refreshTimer)
+    const trusted = await isProjectApproved(ctx)
+    config = readStatusLineConfig(hookFiles(ctx.cwd, os.homedir(), trusted))
+    if (config?.refreshInterval) {
+      refreshTimer = setInterval(() => scheduleRefresh(), config.refreshInterval * 1000)
+    }
+    show(ctx, segmentText(ctx, ctx.ui.theme.fg('dim', '○')))
+    scheduleRefresh()
   })
 
   pi.on('turn_start', async (_event, ctx) => {
     turnCount++
     const theme = ctx.ui.theme
-    ctx.ui.setStatus('pi-code-status', theme.fg('accent', '●') + theme.fg('dim', ` turn ${turnCount}...`))
+    show(ctx, theme.fg('accent', '●') + theme.fg('dim', ` turn ${turnCount}...`))
   })
 
   pi.on('turn_end', async (_event, ctx) => {
-    showIdle(ctx, ctx.ui.theme.fg('success', '✓'))
+    show(ctx, segmentText(ctx, ctx.ui.theme.fg('success', '✓')))
+    scheduleRefresh()
   })
 
   pi.on('agent_end', async (_event, ctx) => {
-    showIdle(ctx, ctx.ui.theme.fg('success', '✓'))
+    show(ctx, segmentText(ctx, ctx.ui.theme.fg('success', '✓')))
+    scheduleRefresh()
+  })
+
+  pi.on('session_compact', async (_event, _ctx) => {
+    scheduleRefresh()
+  })
+
+  pi.on('session_shutdown', async () => {
+    clearInterval(refreshTimer)
+    clearTimeout(debounceTimer)
   })
 }

--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -8,7 +8,7 @@
  * start, after turns, after compaction, on plan-mode changes (the permission-mode
  * analogue, off the shared bus), and on the optional `refreshInterval` timer
  * (minimum 1s). A project-defined command is arbitrary shell, so project settings
- * count only once the project is approved, like hooks.
+ * count only once the project is already approved, read without prompting.
  *
  * Without a configured statusLine, the built-in segment shows turn state plus
  * running session cost, summed from per-message usage on the current branch so it
@@ -25,7 +25,7 @@ import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-a
 
 import { hookFiles, runHookCommand } from './hooks.js'
 import { isPlanModeState, PLAN_MODE_CHANNEL } from './internal/plan-mode-state.js'
-import { isProjectApproved } from './internal/project-approval.js'
+import { isProjectApprovedSilently } from './internal/project-approval.js'
 import { readActiveStyleName, settingsFiles } from './output-styles.js'
 
 const COMMAND_TIMEOUT_MS = 5_000
@@ -164,7 +164,10 @@ export default function statusLine(pi: ExtensionAPI) {
     commandLine = undefined
     sessionCtx = ctx
     clearInterval(refreshTimer)
-    const trusted = await isProjectApproved(ctx)
+    // Reading config must never open a trust dialog: several extensions resolve
+    // approval at session start, and a second prompt stacks over the first and eats
+    // the keys meant for it. An undecided project simply skips project settings.
+    const trusted = isProjectApprovedSilently(ctx)
     config = readStatusLineConfig(hookFiles(ctx.cwd, os.homedir(), trusted))
     if (config?.refreshInterval) {
       refreshTimer = setInterval(() => scheduleRefresh(), config.refreshInterval * 1000)

--- a/tests/status-line-command.test.ts
+++ b/tests/status-line-command.test.ts
@@ -1,0 +1,162 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import statusLine, { readStatusLineConfig } from '../extensions/status-line.ts'
+
+const hoisted = vi.hoisted(() => ({ home: '', runs: [] as Array<{ command: string; payload: unknown }>, result: { code: 0, stdout: '', stderr: '', timedOut: false } }))
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: () => hoisted.home }
+})
+
+vi.mock('../extensions/hooks.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../extensions/hooks.js')>()
+  return {
+    ...actual,
+    runHookCommand: async (command: string, payload: unknown) => {
+      hoisted.runs.push({ command, payload })
+      return hoisted.result
+    },
+  }
+})
+
+const tempDirs: string[] = []
+const tempDir = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'sl-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+const writeSettings = (root: string, name: string, settings: Record<string, unknown>): void => {
+  mkdirSync(join(root, '.claude'), { recursive: true })
+  writeFileSync(join(root, '.claude', name), JSON.stringify(settings))
+}
+
+beforeEach(() => {
+  hoisted.home = tempDir()
+  hoisted.runs.length = 0
+  hoisted.result = { code: 0, stdout: '', stderr: '', timedOut: false }
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('readStatusLineConfig', () => {
+  it('reads the command with padding and refreshInterval, last file winning', () => {
+    const a = join(tempDir(), 'a.json')
+    const b = join(tempDir(), 'b.json')
+    writeFileSync(a, JSON.stringify({ statusLine: { type: 'command', command: 'first.sh' } }))
+    writeFileSync(b, JSON.stringify({ statusLine: { type: 'command', command: 'second.sh', padding: 2, refreshInterval: 5 } }))
+    expect(readStatusLineConfig([a, b])).toEqual({ command: 'second.sh', padding: 2, refreshInterval: 5 })
+  })
+
+  it('ignores malformed entries, sub-minimum intervals, and missing files', () => {
+    const a = join(tempDir(), 'a.json')
+    writeFileSync(a, JSON.stringify({ statusLine: { type: 'command', command: 'x.sh', refreshInterval: 0 } }))
+    expect(readStatusLineConfig([a, join(tempDir(), 'absent.json')])).toEqual({ command: 'x.sh', padding: 0, refreshInterval: undefined })
+    const bad = join(tempDir(), 'bad.json')
+    writeFileSync(bad, JSON.stringify({ statusLine: { type: 'command' } }))
+    expect(readStatusLineConfig([bad])).toBeUndefined()
+  })
+})
+
+type Handler = (event: Record<string, unknown>, ctx?: unknown) => Promise<void>
+
+const setup = (cwd: string) => {
+  const handlers = new Map<string, Handler>()
+  const busHandlers = new Map<string, (data: unknown) => void>()
+  statusLine({
+    on: (name: string, fn: Handler) => handlers.set(name, fn),
+    events: { on: (channel: string, fn: (data: unknown) => void) => busHandlers.set(channel, fn), emit: () => {} },
+  } as never)
+  const status: Array<string | undefined> = []
+  const ctx = {
+    cwd,
+    hasUI: true,
+    isProjectTrusted: () => true,
+    thinkingLevel: 'high',
+    model: { id: 'gpt-oss:20b' },
+    getContextUsage: () => ({ tokens: 1000, contextWindow: 131072, percent: 0.8 }),
+    ui: { theme: { fg: (_c: string, t: string) => t }, setStatus: (_k: string, text: string | undefined) => status.push(text), notify: () => {}, confirm: async () => true },
+    sessionManager: { getBranch: () => [], getSessionId: () => 'sess-9', getSessionFile: () => '/tmp/sess-9.jsonl' },
+  }
+  return { handlers, busHandlers, status, ctx }
+}
+
+describe('statusLine command contract', () => {
+  it('runs the configured command with the session payload and shows its first line, padded', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh', padding: 1 } })
+    hoisted.result = { code: 0, stdout: 'CTX 42% | $0.10\nsecond row\n', stderr: '', timedOut: false }
+    const { handlers, status, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(hoisted.runs).toHaveLength(1)
+    expect(hoisted.runs[0].command).toBe('seg.sh')
+    const payload = hoisted.runs[0].payload as Record<string, unknown>
+    expect(payload.session_id).toBe('sess-9')
+    expect(payload.cwd).toBe(cwd)
+    expect((payload.model as { id: string }).id).toBe('gpt-oss:20b')
+    expect((payload.context_window as { used_percentage: number }).used_percentage).toBe(0.8)
+    expect(status.at(-1)).toBe(' CTX 42% | $0.10 ')
+  })
+
+  it('keeps the built-in segment when the command prints nothing', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 1, stdout: '', stderr: 'boom', timedOut: false }
+    const { handlers, status, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(status.some((s) => s?.includes('ready'))).toBe(true)
+  })
+
+  it('ignores a project-defined command when the project is not approved', async () => {
+    const cwd = tempDir()
+    writeSettings(cwd, 'settings.json', { statusLine: { type: 'command', command: 'evil.sh' } })
+    const { handlers, ctx } = setup(cwd)
+    const untrusted = { ...ctx, isProjectTrusted: () => false }
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, untrusted)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(hoisted.runs).toHaveLength(0)
+  })
+
+  it('re-runs on the refreshInterval timer', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh', refreshInterval: 2 } })
+    hoisted.result = { code: 0, stdout: 'tick', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    const initial = hoisted.runs.length
+    await vi.advanceTimersByTimeAsync(4500)
+    expect(hoisted.runs.length).toBeGreaterThan(initial)
+    await handlers.get('session_shutdown')?.({}, ctx)
+  })
+
+  it('re-runs when the plan-mode state changes on the bus', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'seg', stderr: '', timedOut: false }
+    const { handlers, busHandlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    const initial = hoisted.runs.length
+    busHandlers.get('pi-code:plan-mode')?.({ active: true })
+    await vi.advanceTimersByTimeAsync(400)
+    expect(hoisted.runs.length).toBe(initial + 1)
+  })
+})

--- a/tests/status-line.test.ts
+++ b/tests/status-line.test.ts
@@ -1,16 +1,35 @@
-import { describe, expect, it } from 'vitest'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
 
 import statusLine from '../extensions/status-line.ts'
+
+// The extension reads statusLine settings from the home dir at session start; point
+// it at an empty temp home so the developer's real config never reaches the tests.
+const hoisted = vi.hoisted(() => ({ home: '' }))
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: () => hoisted.home }
+})
+hoisted.home = mkdtempSync(join(tmpdir(), 'sl-home-'))
 
 const theme = { fg: (_color: string, text: string) => text }
 
 function setup() {
   const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<void>>()
-  statusLine({ on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<void>) => handlers.set(name, fn) } as never)
+  statusLine({
+    on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<void>) => handlers.set(name, fn),
+    events: { on: () => () => {}, emit: () => {} },
+  } as never)
   const status: string[] = []
   const makeCtx = (branch: unknown[] = []) => ({
-    ui: { theme, setStatus: (_key: string, text: string) => status.push(text) },
-    sessionManager: { getBranch: () => branch },
+    cwd: mkdtempSync(join(tmpdir(), 'sl-cwd-')),
+    isProjectTrusted: () => true,
+    ui: { theme, setStatus: (_key: string, text: string) => status.push(text), confirm: async () => true, notify: () => {} },
+    sessionManager: { getBranch: () => branch, getSessionId: () => 's', getSessionFile: () => undefined },
+    getContextUsage: () => ({ tokens: 0, contextWindow: 0, percent: 0 }),
   })
   return { handlers, status, makeCtx }
 }


### PR DESCRIPTION
Implements Claude Code's `statusLine` settings contract, the last of the audited high-value parity gaps. Each behavior ships with a test that fails against the previous code.

- **A configured `statusLine` command drives the footer segment** (status-line.ts). The command runs with the documented session JSON on stdin (`session_id`, `cwd`, `workspace`, `model`, `cost`, `context_window`, `permission_mode`, `effort`, `output_style`, `transcript_path`) and its first stdout line becomes the segment. Previously the segment was fixed and the settings key was ignored entirely.
- **`padding` and `refreshInterval` are honored** (status-line.ts). Padding pads both sides of the rendered line; `refreshInterval` re-runs the command on a timer, with Claude's documented 1s minimum, and the timer is cleared at shutdown.
- **Updates follow Claude's documented triggers, debounced 300ms**: session start, turn end, agent end, after compaction, and on plan-mode changes (the permission-mode analogue, read off the shared bus). A run that arrives while one is in flight is queued rather than dropped.
- **Config reads never open a trust dialog** (status-line.ts, using the silent approval helper). Project settings count only when the project is already approved. *This one matters beyond configuration:* the prompting variant, used briefly during development, let a second "Trust this project?" dialog stack over the first at session start when several extensions resolved approval concurrently, and the second dialog swallowed the keys meant for the first. The e2e caught it as every dialog-driven step failing while pure model turns passed.
- The built-in turn/cost segment remains the default when no command is configured, and the fallback whenever a configured command prints nothing.

Verified with the full gate (13 status-line tests across two suites) and `scripts/e2e-full.sh`: 28 passed, 0 dialog or feature failures. The one red step in that run, the `/hello` prompt-template turn, was reproduced in isolation as a model instruction-following flake (the marker returns in 2s on a clean probe) and is unrelated to these files.