### PR TITLE
Clear the Sonar findings open on main

### DIFF
--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -21,7 +21,7 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 // SSE is deprecated in favour of Streamable HTTP, but the SDK notes servers still on
 // the old spec exist, so this stays as a fallback for the migration period.
@@ -127,6 +127,19 @@ export function projectServerPolicy(cwd: string, home: string): ProjectServerPol
   return { disabled, consented, consentAll }
 }
 
+/** Split project servers by the per-server policy: never-connect, connect without the
+ * whole-project confirm, and still gated behind it. */
+export function splitByPolicy(candidates: Record<string, ServerConfig>, policy: ProjectServerPolicy): { consented: Record<string, ServerConfig>; gated: Record<string, ServerConfig> } {
+  const consented: Record<string, ServerConfig> = {}
+  const gated: Record<string, ServerConfig> = {}
+  for (const [name, config] of Object.entries(candidates)) {
+    if (policy.disabled.has(name)) continue
+    if (policy.consentAll || policy.consented.has(name)) consented[name] = config
+    else gated[name] = config
+  }
+  return { consented, gated }
+}
+
 export function loadConfigFrom(files: string[]): Record<string, ServerConfig> {
   const servers: Record<string, ServerConfig> = {}
   for (const file of files) {
@@ -159,6 +172,12 @@ export function loadUserScope(home: string, cwd: string): Record<string, ServerC
 
 /** Claude reports a config entry that has a url but no type as an error; pi-code
  * still connects (streamable HTTP with SSE fallback) but says the entry is wrong. */
+/** A server cwd expands ${VAR} then a leading ~, or stays unset. */
+export function expandCwd(cwd: string | undefined): string | undefined {
+  if (!cwd) return undefined
+  return interpolateEnv(cwd).replace(/^~(?=\/|$)/, os.homedir())
+}
+
 export function warnOnTypelessUrl(name: string, config: ServerConfig): void {
   if ('url' in config && config.type === undefined) {
     console.warn(`pi-code-mcp: server ${name} declares a url with no "type"; add "type": "http" or "sse"`)
@@ -240,7 +259,7 @@ async function connect(name: string, config: ServerConfig): Promise<Client> {
       command: interpolateEnv(config.command),
       args: (config.args ?? []).map((arg) => interpolateEnv(arg)),
       env,
-      cwd: config.cwd ? interpolateEnv(config.cwd).replace(/^~(?=\/|$)/, os.homedir()) : undefined,
+      cwd: expandCwd(config.cwd),
       stderr: 'ignore',
     })
     await connectWithTimeout(client, transport, `connect ${name}`)
@@ -362,6 +381,18 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     }
   }
 
+  /** Connect the project scope under the per-server policy. Returns whether the scope
+   * is settled, so a refused confirm can be retried on a later session start. */
+  async function connectProjectScope(ctx: ExtensionContext): Promise<boolean> {
+    const policy = projectServerPolicy(ctx.cwd, os.homedir())
+    const { consented, gated } = splitByPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), policy)
+    if (Object.keys(consented).length > 0) await connectServers(consented)
+    if (Object.keys(gated).length === 0) return true
+    if (!(await isProjectApproved(ctx))) return false
+    await connectServers(gated)
+    return true
+  }
+
   let userConnected = false
   let projectConnected = false
 
@@ -377,23 +408,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // connect, servers the user consented to individually connect without the
     // whole-project confirm, and the rest stay behind it. Reconnect attempts after a
     // refusal are safe: connectServers skips names that already connected.
-    if (!projectConnected) {
-      const policy = projectServerPolicy(ctx.cwd, os.homedir())
-      const candidates = loadConfigFrom(projectConfigPaths(ctx.cwd))
-      const consented: Record<string, ServerConfig> = {}
-      const gated: Record<string, ServerConfig> = {}
-      for (const [name, config] of Object.entries(candidates)) {
-        if (policy.disabled.has(name)) continue
-        if (policy.consentAll || policy.consented.has(name)) consented[name] = config
-        else gated[name] = config
-      }
-      if (Object.keys(consented).length > 0) await connectServers(consented)
-      if (Object.keys(gated).length === 0) projectConnected = true
-      else if (await isProjectApproved(ctx)) {
-        projectConnected = true
-        await connectServers(gated)
-      }
-    }
+    if (!projectConnected) projectConnected = await connectProjectScope(ctx)
 
     pi.events.emit(MCP_TOOLS_CHANNEL, [...aliases])
 

--- a/extensions/plan-mode/utils.ts
+++ b/extensions/plan-mode/utils.ts
@@ -194,8 +194,10 @@ export function cleanStepText(text: string): string {
 // Anchored to line start (m flag) so a prose line merely ending in "plan:" is not taken
 // for the header, which would slice the plan section mid-list and drop earlier steps.
 // Horizontal whitespace only ([^\S\n]): \s would include \n itself and overlap the
-// following \n, which is what backtracks super-linearly.
-const PLAN_HEADER = /^[^\S\n]*\*{0,2}Plan:\*{0,2}[^\S\n]*\n/im
+// following \n. The runs are bounded rather than unbounded: an unbounded run retried
+// from every position on a long whitespace-only line is what backtracks super-linearly,
+// and a real header carries at most a few spaces of indentation.
+const PLAN_HEADER = /^[^\S\n]{0,8}\*{0,2}Plan:\*{0,2}[^\S\n]{0,8}\n/im
 
 const isBlank = (ch: string | undefined): boolean => ch !== undefined && ch !== '\n' && ch.trim() === ''
 

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -121,6 +121,7 @@ vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
 }))
 
 const mcpExtension = (await import('../extensions/mcp.ts')).default
+const { splitByPolicy, expandCwd } = await import('../extensions/mcp.ts')
 
 interface RegisteredTool {
   name: string
@@ -1053,5 +1054,34 @@ describe('small MCP parity', () => {
     withTools([])
     const harness = await setupStarted({ user: { srv: { url: 'https://example.com/mcp' } } })
     expect(harness.warnings.some((w) => w.includes('no "type"'))).toBe(true)
+  })
+})
+
+describe('policy split and cwd expansion helpers', () => {
+  const policy = (over: Partial<{ disabled: Set<string>; consented: Set<string>; consentAll: boolean }> = {}) => ({
+    disabled: over.disabled ?? new Set<string>(),
+    consented: over.consented ?? new Set<string>(),
+    consentAll: over.consentAll ?? false,
+  })
+
+  it('drops disabled servers, separates consented from gated', () => {
+    const candidates = { a: { command: 'a' }, b: { command: 'b' }, c: { command: 'c' } }
+    const split = splitByPolicy(candidates, policy({ disabled: new Set(['a']), consented: new Set(['b']) }))
+    expect(Object.keys(split.consented)).toEqual(['b'])
+    expect(Object.keys(split.gated)).toEqual(['c'])
+  })
+
+  it('treats every surviving server as consented under consentAll', () => {
+    const split = splitByPolicy({ a: { command: 'a' }, b: { command: 'b' } }, policy({ consentAll: true, disabled: new Set(['b']) }))
+    expect(Object.keys(split.consented)).toEqual(['a'])
+    expect(split.gated).toEqual({})
+  })
+
+  it('expands a cwd through ${VAR} then a leading tilde, or leaves it unset', () => {
+    setEnv('CWD_ROOT', '/srv')
+    expect(expandCwd('${CWD_ROOT}/x')).toBe('/srv/x')
+    expect(expandCwd(undefined)).toBeUndefined()
+    expect(expandCwd('~/proj')).toBe(`${hoisted.home}/proj`)
+    unsetEnv('CWD_ROOT')
   })
 })


### PR DESCRIPTION
Three findings were open on the main branch that no pull-request gate surfaced, since a PR analysis reports on its own diff while an inherited finding stays open and invisible behind every later green gate.

- **The MCP `session_start` handler was at cognitive complexity 21** (mcp.ts). Connecting the project scope under the per-server policy is now `connectProjectScope`, returning whether the scope is settled so a refused confirm still retries on a later session start, and the policy split is a pure `splitByPolicy` that is directly tested (disabled dropped, consented separated from gated, `consentAll` covering everything that survives).
- **A nested ternary set the stdio `cwd`** (mcp.ts). Expansion is now `expandCwd`, tested for `${VAR}` expansion, a leading `~`, and the unset case.
- **The plan-header regex backtracked super-linearly** (plan-mode/utils.ts). Its whitespace runs are now bounded: an unbounded run retried from every position on a long whitespace-only line is the backtracking case, and a real header carries at most a few spaces of indentation. The existing plan-utils and plan-mode suites cover the parsing behavior unchanged.

Verified with the full gate; Sonar findings on this branch and on main should read zero after merge.