### PR TITLE
Extract the bearer token resolution

### DIFF
--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -172,6 +172,14 @@ export function loadUserScope(home: string, cwd: string): Record<string, ServerC
 
 /** Claude reports a config entry that has a url but no type as an error; pi-code
  * still connects (streamable HTTP with SSE fallback) but says the entry is wrong. */
+/** An inline bearerToken (interpolated) wins over bearerTokenEnv, which names an
+ * environment variable read as-is. */
+export function resolveBearerToken(config: { bearerToken?: string; bearerTokenEnv?: string }): string | undefined {
+  if (config.bearerToken) return interpolateEnv(config.bearerToken)
+  if (config.bearerTokenEnv) return process.env[config.bearerTokenEnv]
+  return undefined
+}
+
 /** A server cwd expands ${VAR} then a leading ~, or stays unset. */
 export function expandCwd(cwd: string | undefined): string | undefined {
   if (!cwd) return undefined
@@ -267,7 +275,7 @@ async function connect(name: string, config: ServerConfig): Promise<Client> {
   }
   const headers: Record<string, string> = {}
   for (const [key, value] of Object.entries(config.headers ?? {})) headers[key] = interpolateEnv(value)
-  const token = config.bearerToken ? interpolateEnv(config.bearerToken) : config.bearerTokenEnv ? process.env[config.bearerTokenEnv] : undefined
+  const token = resolveBearerToken(config)
   if (token) headers.Authorization = `Bearer ${token}`
   const url = new URL(interpolateEnv(config.url))
   if (config.type === 'sse') {

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -121,7 +121,7 @@ vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
 }))
 
 const mcpExtension = (await import('../extensions/mcp.ts')).default
-const { splitByPolicy, expandCwd } = await import('../extensions/mcp.ts')
+const { splitByPolicy, expandCwd, resolveBearerToken } = await import('../extensions/mcp.ts')
 
 interface RegisteredTool {
   name: string
@@ -1083,5 +1083,18 @@ describe('policy split and cwd expansion helpers', () => {
     expect(expandCwd(undefined)).toBeUndefined()
     expect(expandCwd('~/proj')).toBe(`${hoisted.home}/proj`)
     unsetEnv('CWD_ROOT')
+  })
+})
+
+describe('resolveBearerToken', () => {
+  it('prefers an interpolated inline token, falls back to the named env var, else undefined', () => {
+    setEnv('TOK_INLINE', 'inline-secret')
+    setEnv('TOK_NAMED', 'named-secret')
+    expect(resolveBearerToken({ bearerToken: '${TOK_INLINE}' })).toBe('inline-secret')
+    expect(resolveBearerToken({ bearerTokenEnv: 'TOK_NAMED' })).toBe('named-secret')
+    expect(resolveBearerToken({ bearerToken: 'literal', bearerTokenEnv: 'TOK_NAMED' })).toBe('literal')
+    expect(resolveBearerToken({})).toBeUndefined()
+    unsetEnv('TOK_INLINE')
+    unsetEnv('TOK_NAMED')
   })
 })


### PR DESCRIPTION
The last Sonar finding open on main: a nested ternary choosing between an inline `bearerToken` and the variable named by `bearerTokenEnv`. It is now a named function with a test pinning the precedence between the two forms, the `${VAR}` interpolation of the inline one, and the unset case.