### PR TITLE
Carry agent effort through --thinking when no model is pinned

### DIFF
--- a/extensions/subagent/README.md
+++ b/extensions/subagent/README.md
@@ -111,7 +111,8 @@ System prompt for the agent goes here.
 
 Claude Code fields map onto pi where a sensible seam exists: `tools` and
 `disallowedTools` (comma string or YAML list) become pi's `--tools` /
-`--exclude-tools`; `effort` becomes the `:thinking` suffix on a pinned model;
+`--exclude-tools`; `effort` becomes the `:thinking` suffix on a pinned model, or
+`--thinking` when no model is pinned;
 `permissionMode: plan` selects a read-only toolset unless `tools` is set. Model
 aliases (`sonnet`, `opus`, `haiku`, `inherit`) run on the session's default
 model. Fields with no pi equivalent are ignored: `skills`, `memory`,

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -541,9 +541,10 @@ async function checkProjectAgentGate(params: SubagentParamsStatic, agents: Agent
 /** CLI args shared by foreground and background children, from the agent's config. */
 function agentInvocationArgs(agent: AgentConfig): string[] {
   const args: string[] = ['--mode', 'json', '-p', '--no-session']
-  // pi reads a thinking level from the model pattern's :suffix, so Claude's effort
-  // has a seam only when the agent pins a concrete model.
+  // pi reads a thinking level from the model pattern's :suffix when a model is pinned,
+  // and from --thinking otherwise, so effort survives either way.
   if (agent.model) args.push('--model', agent.effort ? `${agent.model}:${agent.effort}` : agent.model)
+  else if (agent.effort) args.push('--thinking', agent.effort)
   if (agent.tools && agent.tools.length > 0) args.push('--tools', agent.tools.join(','))
   if (agent.disallowedTools && agent.disallowedTools.length > 0) args.push('--exclude-tools', agent.disallowedTools.join(','))
   return args

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -512,14 +512,15 @@ describe('runSingleAgent process handling', () => {
     expect(piArgs(spawnCalls[0])).toEqual(['--mode', 'json', '-p', '--no-session', '--model', 'gpt-oss:20b:high', '--exclude-tools', 'write,edit', 'Task: inspect'])
   })
 
-  it('applies effort only when a concrete model is pinned', async () => {
-    // pi reads the thinking level from the model pattern; without a model there is no seam.
+  it('carries effort through --thinking when no model is pinned', async () => {
+    // pi reads the level from the model pattern when one is pinned, and from --thinking
+    // otherwise, so an agent that only sets effort no longer loses it.
     discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ effort: 'high' })], projectAgentsDir: null })
     script('inspect', { stdout: [say('ok')] })
 
     await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
 
-    expect(piArgs(spawnCalls[0])).toEqual(['--mode', 'json', '-p', '--no-session', 'Task: inspect'])
+    expect(piArgs(spawnCalls[0])).toEqual(['--mode', 'json', '-p', '--no-session', '--thinking', 'high', 'Task: inspect'])
   })
 
   it('omits the model and tools flags when the agent declares neither', async () => {
@@ -688,6 +689,31 @@ describe('runSingleAgent process handling', () => {
 
     await expect(pending).rejects.toThrow('Subagent was aborted')
     expect(spawnedChildren[0].kill).toHaveBeenCalledWith('SIGTERM')
+  })
+})
+
+describe('effort and skills', () => {
+  it('passes effort as --thinking when the agent pins no model', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ effort: 'high' })], projectAgentsDir: null })
+    script('inspect', { stdout: [say('done')] })
+
+    await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    const args = spawnMock.mock.calls[0][1] as string[]
+    expect(args).toContain('--thinking')
+    expect(args[args.indexOf('--thinking') + 1]).toBe('high')
+    expect(args).not.toContain('--model')
+  })
+
+  it('keeps the model:effort suffix when a model is pinned', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ model: 'gpt-oss:20b', effort: 'low' })], projectAgentsDir: null })
+    script('inspect', { stdout: [say('done')] })
+
+    await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    const args = spawnMock.mock.calls[0][1] as string[]
+    expect(args[args.indexOf('--model') + 1]).toBe('gpt-oss:20b:low')
+    expect(args).not.toContain('--thinking')
   })
 })
 


### PR DESCRIPTION
An agent whose frontmatter set `effort` without pinning a `model` lost the setting silently: the level rode the model pattern's `:thinking` suffix, which requires a model to attach to. pi's CLI also accepts `--thinking <level>`, so the level now survives either way, and an agent that only wants deeper reasoning no longer has to pin a model id it does not care about.

The test that pinned the old limitation is rewritten to assert the new behavior rather than deleted, and the subagent README's field-mapping paragraph is corrected.