### PR TITLE
Preload an agent's skills into its child prompt

### DIFF
--- a/extensions/subagent/README.md
+++ b/extensions/subagent/README.md
@@ -115,8 +115,10 @@ Claude Code fields map onto pi where a sensible seam exists: `tools` and
 `--thinking` when no model is pinned;
 `permissionMode: plan` selects a read-only toolset unless `tools` is set. Model
 aliases (`sonnet`, `opus`, `haiku`, `inherit`) run on the session's default
-model. Fields with no pi equivalent are ignored: `skills`, `memory`,
-`mcpServers`, `maxTurns`.
+model. `skills` names skills to preload: their bodies are inlined into the child's
+prompt, since a child pi process does not inherit the parent's skill discovery, and
+a name that resolves to nothing is reported in the prompt rather than dropped.
+Fields with no pi equivalent are ignored: `memory`, `mcpServers`, `maxTurns`.
 
 **Locations:**
 - `~/.claude/agents/*.md`, `~/.pi/agent/agents/*.md` - User-level (always loaded; `~/.pi` wins a name conflict)

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -65,7 +65,9 @@ function parseEffortField(raw: unknown): string | undefined {
 
 /** Claude's `skills` frontmatter: a comma string or YAML list of skill names. */
 function parseSkillsField(raw: unknown): string[] | undefined {
-  const names = Array.isArray(raw) ? raw.map((entry) => String(entry)) : typeof raw === 'string' ? raw.split(',') : []
+  let names: string[] = []
+  if (Array.isArray(raw)) names = raw.map(String)
+  else if (typeof raw === 'string') names = raw.split(',')
   const cleaned = names.map((name) => name.trim()).filter(Boolean)
   return cleaned.length > 0 ? cleaned : undefined
 }

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -63,6 +63,43 @@ function parseEffortField(raw: unknown): string | undefined {
   return THINKING_LEVELS.has(effort) ? effort : undefined
 }
 
+/** Claude's `skills` frontmatter: a comma string or YAML list of skill names. */
+function parseSkillsField(raw: unknown): string[] | undefined {
+  const names = Array.isArray(raw) ? raw.map((entry) => String(entry)) : typeof raw === 'string' ? raw.split(',') : []
+  const cleaned = names.map((name) => name.trim()).filter(Boolean)
+  return cleaned.length > 0 ? cleaned : undefined
+}
+
+/** Inline the named skills into an agent's prompt. Claude preloads a subagent's
+ * `skills` at startup rather than letting it discover them, and a child pi process
+ * does not inherit the parent's skill discovery, so the bodies travel in the prompt.
+ * A name that resolves to nothing is reported rather than dropped: a silently missing
+ * instruction is worse than a visible gap. */
+export function withPreloadedSkills(prompt: string, skills: string[] | undefined, skillDirs: string[]): string {
+  if (!skills || skills.length === 0) return prompt
+  const sections: string[] = []
+  for (const name of skills) {
+    const body = readSkillBody(name, skillDirs)
+    sections.push(body === undefined ? `<skill name="${name}">(skill not found)</skill>` : `<skill name="${name}">\n${body.trim()}\n</skill>`)
+  }
+  return `${prompt}\n\n## Preloaded skills\n\n${sections.join('\n\n')}`
+}
+
+function readSkillBody(name: string, skillDirs: string[]): string | undefined {
+  for (const dir of skillDirs) {
+    for (const candidate of [path.join(dir, name, 'SKILL.md'), path.join(dir, `${name}.md`)]) {
+      try {
+        const content = fs.readFileSync(candidate, 'utf-8')
+        const match = /^---\r?\n[\s\S]*?\r?\n---/.exec(content)
+        return match ? content.slice(match[0].length) : content
+      } catch {
+        // try the next shape
+      }
+    }
+  }
+  return undefined
+}
+
 /** permissionMode has no pi equivalent; 'plan' means a research agent, so translate
  * the intent into a read-only toolset unless the file pins tools itself. */
 const READ_ONLY_TOOLS = ['read', 'grep', 'find', 'ls']
@@ -90,6 +127,7 @@ function parseAgentFile(content: string, source: AgentSource, filePath: string):
     disallowedTools,
     model: parseModelField(frontmatter.model),
     effort: parseEffortField(frontmatter.effort),
+    skills: parseSkillsField(frontmatter.skills),
     systemPrompt: body,
     source,
     filePath,
@@ -105,6 +143,8 @@ export interface AgentConfig {
   disallowedTools?: string[]
   model?: string
   effort?: string
+  /** Skill names to inline into the child's prompt, per Claude's `skills` field. */
+  skills?: string[]
   systemPrompt: string
   source: AgentSource
   filePath: string

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -85,9 +85,19 @@ export function withPreloadedSkills(prompt: string, skills: string[] | undefined
   return `${prompt}\n\n## Preloaded skills\n\n${sections.join('\n\n')}`
 }
 
+/** A skill name is a single directory or file stem, never a path. The name comes from
+ * agent frontmatter, which a repository can control, and the body is inlined into the
+ * prompt sent to the model, so a traversal would be an arbitrary-file read. */
+const SKILL_NAME = /^[A-Za-z0-9_.-]+$/
+
 function readSkillBody(name: string, skillDirs: string[]): string | undefined {
+  if (!SKILL_NAME.test(name) || name === '.' || name === '..') return undefined
   for (const dir of skillDirs) {
+    const root = path.resolve(dir)
     for (const candidate of [path.join(dir, name, 'SKILL.md'), path.join(dir, `${name}.md`)]) {
+      // Belt and braces against symlinks and platform path quirks: the file actually
+      // read must still sit under the skills directory it was resolved from.
+      if (!path.resolve(candidate).startsWith(root + path.sep)) continue
       try {
         const content = fs.readFileSync(candidate, 'utf-8')
         const match = /^---\r?\n[\s\S]*?\r?\n---/.exec(content)

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -26,7 +26,8 @@ import { type Static, Type } from 'typebox'
 import { capForContext } from '../internal/output-guard.js'
 import { isProjectApproved, isProjectApprovedSilently } from '../internal/project-approval.js'
 import { SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
-import { type AgentConfig, type AgentScope, discoverAgents } from './agents.js'
+import { skillDirs } from '../skills.js'
+import { type AgentConfig, type AgentScope, discoverAgents, withPreloadedSkills } from './agents.js'
 import { activeBackgroundRuns, backgroundStatusText, cancelBackgroundRun, MAX_BACKGROUND_RUNS, startBackgroundRun } from './background.js'
 
 const MAX_PARALLEL_TASKS = 8
@@ -321,8 +322,9 @@ async function runSingleAgentInner(options: RunAgentOptions): Promise<SingleResu
   }
 
   try {
-    if (agent.systemPrompt.trim()) {
-      const tmp = await writePromptToTempFile(agent.name, agent.systemPrompt)
+    const promptWithSkills = withPreloadedSkills(agent.systemPrompt, agent.skills, skillDirs(defaultCwd, os.homedir()))
+    if (promptWithSkills.trim()) {
+      const tmp = await writePromptToTempFile(agent.name, promptWithSkills)
       tmpPromptDir = tmp.dir
       tmpPromptPath = tmp.filePath
       args.push('--append-system-prompt', tmpPromptPath)
@@ -593,8 +595,9 @@ async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConf
   }
   const args = agentInvocationArgs(agent)
   let tmpPrompt: { dir: string; filePath: string } | undefined
-  if (agent.systemPrompt.trim()) {
-    tmpPrompt = await writePromptToTempFile(agent.name, agent.systemPrompt)
+  const promptWithSkills = withPreloadedSkills(agent.systemPrompt, agent.skills, skillDirs(params.cwd ?? defaultCwd, os.homedir()))
+  if (promptWithSkills.trim()) {
+    tmpPrompt = await writePromptToTempFile(agent.name, promptWithSkills)
     args.push('--append-system-prompt', tmpPrompt.filePath)
   }
   args.push(`Task: ${task}`)

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -655,6 +655,26 @@ describe('agent skills preload', () => {
     expect(prompt).toContain('not found')
   })
 
+  it('refuses a skill name that escapes the skills directory', () => {
+    // The name comes from agent frontmatter, which a repository can control; a
+    // traversal would read an arbitrary file into the prompt sent to the model.
+    const skillsRoot = join(fakeHome.path, '.claude', 'skills')
+    mkdirSync(skillsRoot, { recursive: true })
+    writeFileSync(join(fakeHome.path, '.claude', 'secret.md'), 'TOP_SECRET')
+
+    const prompt = withPreloadedSkills('Base.', ['../secret'], [skillsRoot])
+    expect(prompt).not.toContain('TOP_SECRET')
+    expect(prompt).toContain('not found')
+  })
+
+  it('refuses a skill name with a path separator', () => {
+    const skillsRoot = join(fakeHome.path, '.claude', 'skills')
+    mkdirSync(join(skillsRoot, 'nested'), { recursive: true })
+    writeFileSync(join(skillsRoot, 'nested', 'SKILL.md'), 'NESTED_BODY')
+
+    expect(withPreloadedSkills('Base.', ['nested/../nested'], [skillsRoot])).toContain('not found')
+  })
+
   it('returns the prompt untouched when the agent preloads nothing', () => {
     expect(withPreloadedSkills('Base.', undefined, [])).toBe('Base.')
     expect(withPreloadedSkills('Base.', [], [])).toBe('Base.')

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { discoverAgents } from '../extensions/subagent/agents.ts'
+import { discoverAgents, withPreloadedSkills } from '../extensions/subagent/agents.ts'
 
 /**
  * Covers extensions/subagent/agents.ts and extensions/subagent/background.ts.
@@ -634,5 +634,29 @@ describe('startBackgroundRun', () => {
     child.emit('close', 0)
 
     expect(backgroundStatusText()).toBe(`${id} scout: done (exit 0, 1 turns) - survey`)
+  })
+})
+
+describe('agent skills preload', () => {
+  it('parses a skills list and appends the named skill bodies to the prompt', () => {
+    const skillsRoot = join(fakeHome.path, '.claude', 'skills')
+    mkdirSync(join(skillsRoot, 'deploy'), { recursive: true })
+    writeFileSync(join(skillsRoot, 'deploy', 'SKILL.md'), '---\nname: deploy\ndescription: ship it\n---\nRun the deploy checklist.')
+
+    const prompt = withPreloadedSkills('Base prompt.', ['deploy'], [skillsRoot])
+    expect(prompt).toContain('Base prompt.')
+    expect(prompt).toContain('Run the deploy checklist.')
+    expect(prompt).toContain('deploy')
+  })
+
+  it('notes a skill it cannot find rather than silently dropping it', () => {
+    const prompt = withPreloadedSkills('Base.', ['ghost'], [join(fakeHome.path, '.claude', 'skills')])
+    expect(prompt).toContain('ghost')
+    expect(prompt).toContain('not found')
+  })
+
+  it('returns the prompt untouched when the agent preloads nothing', () => {
+    expect(withPreloadedSkills('Base.', undefined, [])).toBe('Base.')
+    expect(withPreloadedSkills('Base.', [], [])).toBe('Base.')
   })
 })

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -16,7 +16,10 @@ const cancelBackgroundRunMock = vi.hoisted(() => vi.fn())
 const activeBackgroundRunsMock = vi.hoisted(() => vi.fn(() => 0))
 
 vi.mock('node:child_process', async (importOriginal) => ({ ...(await importOriginal<object>()), spawn: spawnMock }))
-vi.mock('../extensions/subagent/agents.js', () => ({ discoverAgents: discoverAgentsMock }))
+vi.mock('../extensions/subagent/agents.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../extensions/subagent/agents.js')>()),
+  discoverAgents: discoverAgentsMock,
+}))
 vi.mock('../extensions/subagent/background.js', () => ({
   backgroundStatusText: backgroundStatusTextMock,
   cancelBackgroundRun: cancelBackgroundRunMock,


### PR DESCRIPTION
Claude preloads a subagent's `skills` frontmatter at startup rather than leaving the child to discover them, and this field was on the ignored list because a child `pi` process does not inherit the parent's skill discovery.

- **Named skill bodies now travel inline** in the prompt the child is spawned with, resolved from the same `.claude/skills` roots the skills extension exposes (both `name/SKILL.md` and `name.md` layouts), with frontmatter stripped.
- **A name that resolves to nothing is reported in the prompt** rather than dropped: an instruction the agent was told it has but cannot see is worse than a visible gap.
- Applies to both spawn paths, foreground and background.

Verified with the full gate: 151 tests across the two subagent suites, including the three new helper cases and a partial module mock so the existing suite exercises the real helper rather than a stub.