### PR TITLE
Continue a finished background run with a follow-up task

### DIFF
--- a/extensions/subagent/README.md
+++ b/extensions/subagent/README.md
@@ -7,7 +7,7 @@ Delegate tasks to specialized subagents with isolated context windows.
 - **Isolated context**: Each subagent runs in a separate `pi` process
 - **Streaming output**: See tool calls and progress as they happen
 - **Parallel streaming**: All parallel tasks stream updates simultaneously
-- **Background runs**: `{background: true}` returns a run id and notifies on completion; `{status: true}` lists runs and `{cancel: "<id>"}` stops one (signalling its process group); max 8 running at once
+- **Background runs**: `{background: true}` returns a run id and notifies on completion; `{status: true}` lists runs, `{cancel: "<id>"}` stops one (signalling its process group), and `{resume: "<id>", task: "..."}` continues a finished run under its own session, so the child keeps everything it already saw; max 8 running at once
 - **Bounded fan-out**: A subagent refuses to spawn subagents of its own (an env marker the tool honors: steering, not a sandbox)
 - **Markdown rendering**: Final output rendered with proper formatting (expanded view)
 - **Usage tracking**: Shows turns, tokens, cost, and context usage per agent

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -18,6 +18,10 @@ export interface BackgroundRun {
   turns: number
   /** Set while running so the run can be cancelled; cleared on completion. */
   kill?: () => void
+  /** pi session the child ran under, so a follow-up can continue its context. */
+  sessionId: string
+  /** How the child was spawned, so a follow-up can repeat it with a new task. */
+  spawn: BackgroundSpawn
 }
 
 export interface BackgroundSpawn {
@@ -57,7 +61,7 @@ export function parseFinalOutputFromJsonl(jsonl: string): { text: string; turns:
   return { text, turns }
 }
 
-export function formatStatus(all: Iterable<BackgroundRun>): string {
+export function formatStatus(all: Iterable<Pick<BackgroundRun, 'id' | 'agent' | 'task' | 'state' | 'turns' | 'exitCode'>>): string {
   const lines = [...all].map((run) => {
     const label = run.state === 'running' ? 'running' : `${run.state} (exit ${run.exitCode ?? '?'}, ${run.turns} turns)`
     return `${run.id} ${run.agent}: ${label} - ${run.task.slice(0, 60)}`
@@ -81,15 +85,47 @@ export function backgroundStatusText(): string {
   return formatStatus(runs.values())
 }
 
+/** A finished run, so a caller can continue its session with a follow-up task. */
+export function backgroundRun(id: string): BackgroundRun | undefined {
+  return runs.get(id)
+}
+
+/** Re-spawn a finished run's session with a new task. The child is started with the
+ * same --session-id, so it continues with everything it already saw rather than
+ * re-deriving context the parent would have to repeat. */
+export function resumeBackgroundRun(id: string, task: string, onComplete: (run: BackgroundRun) => void): 'resumed' | 'still-running' | 'unknown' {
+  const run = runs.get(id)
+  if (!run) return 'unknown'
+  if (run.state === 'running') return 'still-running'
+  const args = run.spawn.args.map((arg) => (arg.startsWith('Task: ') ? `Task: ${task}` : arg))
+  run.state = 'running'
+  run.task = task
+  run.output = undefined
+  run.exitCode = undefined
+  driveRun(run, { ...run.spawn, args }, onComplete)
+  return 'resumed'
+}
+
 export function startBackgroundRun(agent: string, task: string, invocation: BackgroundSpawn, onComplete: (run: BackgroundRun) => void): string | null {
   // Checked here, synchronously with registration: callers await temp-file writes
   // between any check of their own and this call, so a parallel tool-call batch
   // could otherwise all pass that earlier check and overshoot the cap.
   if (activeBackgroundRuns() >= MAX_BACKGROUND_RUNS) return null
   const id = `bg-${randomUUID().slice(0, 8)}`
-  const run: BackgroundRun = { id, agent, task, state: 'running', turns: 0 }
+  // A stable session id per run: the child persists its session, so a follow-up can
+  // resume it instead of starting cold.
+  const sessionId = `pi-code-${id}-${randomUUID().slice(0, 8)}`
+  const args = invocation.args.map((arg) => (arg === '--no-session' ? '--session-id' : arg))
+  const withSession = args.includes('--session-id') ? args.flatMap((arg) => (arg === '--session-id' ? ['--session-id', sessionId] : [arg])) : args
+  const spawnSpec: BackgroundSpawn = { ...invocation, args: withSession }
+  const run: BackgroundRun = { id, agent, task, state: 'running', turns: 0, sessionId, spawn: spawnSpec }
   runs.set(id, run)
+  driveRun(run, spawnSpec, onComplete)
+  return id
+}
 
+/** Spawn the child for a run and wire its lifecycle back onto the record. */
+function driveRun(run: BackgroundRun, invocation: BackgroundSpawn, onComplete: (run: BackgroundRun) => void): void {
   const proc = spawn(invocation.command, invocation.args, {
     cwd: invocation.cwd,
     shell: false,
@@ -133,5 +169,4 @@ export function startBackgroundRun(agent: string, task: string, invocation: Back
     run.exitCode = 1
     complete()
   })
-  return id
 }

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -28,7 +28,7 @@ import { isProjectApproved, isProjectApprovedSilently } from '../internal/projec
 import { SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
 import { skillDirs } from '../skills.js'
 import { type AgentConfig, type AgentScope, discoverAgents, withPreloadedSkills } from './agents.js'
-import { activeBackgroundRuns, backgroundStatusText, cancelBackgroundRun, MAX_BACKGROUND_RUNS, startBackgroundRun } from './background.js'
+import { activeBackgroundRuns, backgroundStatusText, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
 
 const MAX_PARALLEL_TASKS = 8
 const MAX_CONCURRENCY = 4
@@ -463,6 +463,7 @@ const SubagentParams = Type.Object({
   background: Type.Optional(Type.Boolean({ description: 'Run the single-mode task in the background: returns a run id immediately and a notification arrives when it completes.' })),
   status: Type.Optional(Type.Boolean({ description: 'Set true (alone, no other params) to list background runs instead of running anything.' })),
   cancel: Type.Optional(Type.String({ description: 'Background run id to cancel (from the id returned when it started, or from status).' })),
+  resume: Type.Optional(Type.String({ description: 'Finished background run id to continue with a follow-up task; the child keeps everything it already saw. Pass task with it.' })),
 })
 
 /**
@@ -1132,6 +1133,23 @@ export default function subagentExtension(pi: ExtensionAPI) {
           projectAgentsDir: discovery.projectAgentsDir,
           results,
         })
+
+      if (params.resume) {
+        if (!params.task) {
+          return { content: [{ type: 'text', text: 'Pass task with resume: the follow-up needs an instruction.' }], details: makeDetails('single')([]) }
+        }
+        const outcome = resumeBackgroundRun(params.resume, params.task, (run) => {
+          const output = capForContext(run.output ?? '') || '(no output)'
+          pi.sendMessage({ customType: 'subagent-background', content: `Background subagent run ${run.id} (${run.agent}) ${run.state} after ${run.turns} turns.\n\n${output}`, display: true }, { triggerTurn: true })
+        })
+        const text =
+          outcome === 'resumed'
+            ? `Resumed background run ${params.resume} with the follow-up task; a notification will arrive on completion.`
+            : outcome === 'still-running'
+              ? `Background run ${params.resume} is still running; wait for it or cancel it first.`
+              : `Unknown background run: ${params.resume}.\n\n${backgroundStatusText()}`
+        return { content: [{ type: 'text', text }], details: makeDetails('single')([]) }
+      }
 
       if (params.cancel) {
         return { content: [{ type: 'text', text: cancelResultText(params.cancel) }], details: makeDetails('single')([]) }

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -19,8 +19,8 @@ describe('background subagent helpers', () => {
 
   it('formats run status lines', () => {
     const runs: BackgroundRun[] = [
-      { id: 'bg-1', agent: 'scout', task: 'find things', state: 'running', turns: 0 },
-      { id: 'bg-2', agent: 'worker', task: 'do things', state: 'done', exitCode: 0, turns: 3 },
+      { id: 'bg-1', agent: 'scout', task: 'find things', state: 'running', turns: 0, sessionId: 'sess', spawn: { command: 'pi', args: [], cwd: '/w' } },
+      { id: 'bg-2', agent: 'worker', task: 'do things', state: 'done', exitCode: 0, turns: 3, sessionId: 'sess', spawn: { command: 'pi', args: [], cwd: '/w' } },
     ]
     const text = formatStatus(runs)
     expect(text).toContain('bg-1 scout: running')

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -557,7 +557,7 @@ describe('startBackgroundRun', () => {
     child.stdout.emit('data', Buffer.from(`${messageEnd('assistant', 'all done')}\n`))
     child.emit('close', 0)
 
-    expect(completed).toEqual([{ id, agent: 'scout', task: 'survey', state: 'done', exitCode: 0, output: 'all done', turns: 1 }])
+    expect(completed).toMatchObject([{ id, agent: 'scout', task: 'survey', state: 'done', exitCode: 0, output: 'all done', turns: 1 }])
   })
 
   it('concatenates stdout chunks before parsing', async () => {
@@ -607,7 +607,7 @@ describe('startBackgroundRun', () => {
     const child = spawned.children[0]
     child.emit('error', new Error('ENOENT'))
 
-    expect(completed).toEqual([{ id, agent: 'scout', task: 'survey', state: 'failed', exitCode: 1, turns: 0 }])
+    expect(completed).toMatchObject([{ id, agent: 'scout', task: 'survey', state: 'failed', exitCode: 1, turns: 0 }])
   })
 
   it('completes once when a spawn failure emits both error and close', async () => {
@@ -678,5 +678,32 @@ describe('agent skills preload', () => {
   it('returns the prompt untouched when the agent preloads nothing', () => {
     expect(withPreloadedSkills('Base.', undefined, [])).toBe('Base.')
     expect(withPreloadedSkills('Base.', [], [])).toBe('Base.')
+  })
+})
+
+describe('resumeBackgroundRun', () => {
+  const invocation = { command: 'pi', args: ['--mode', 'json', '-p', '--no-session', 'Task: first'], cwd: '/work/dir' }
+
+  it('spawns the follow-up under the same session id with the new task', async () => {
+    const { startBackgroundRun, resumeBackgroundRun, backgroundRun } = await loadBackground()
+    const id = startBackgroundRun('scout', 'first', invocation, () => {}) as string
+    const sessionId = backgroundRun(id)?.sessionId
+    expect(sessionId).toBeTruthy()
+    // --no-session is replaced so the child persists what it saw.
+    expect(spawned.calls[0].args).toContain('--session-id')
+    expect(spawned.calls[0].args).not.toContain('--no-session')
+    spawned.children[0].emit('close', 0)
+
+    expect(resumeBackgroundRun(id, 'second', () => {})).toBe('resumed')
+    const followUp = spawned.calls[1].args
+    expect(followUp[followUp.indexOf('--session-id') + 1]).toBe(sessionId)
+    expect(followUp.at(-1)).toBe('Task: second')
+  })
+
+  it('refuses to resume a run that is still going, or an unknown id', async () => {
+    const { startBackgroundRun, resumeBackgroundRun } = await loadBackground()
+    const id = startBackgroundRun('scout', 'first', invocation, () => {}) as string
+    expect(resumeBackgroundRun(id, 'again', () => {})).toBe('still-running')
+    expect(resumeBackgroundRun('bg-nope', 'again', () => {})).toBe('unknown')
   })
 })


### PR DESCRIPTION
Background children ran with `--no-session`, so everything a run learned died with it: a follow-up question meant re-deriving context the parent would have to re-explain from scratch.

- **Each background run gets its own `--session-id`** (subagent/background.ts), so the child persists what it saw. The spawn flags are rewritten from `--no-session` at start, and the session id and spawn spec are kept on the run record.
- **`{resume: "<id>", task: "..."}` continues that session** with a new task, re-spawning under the same session id so the child picks up from its prior context. The completion notification works exactly as it does for a first run.
- **A run that is still going, or an id that does not exist, reports itself** rather than silently starting something new, and resuming without a task says so instead of spawning an empty follow-up.
- The spawn wiring is now a named `driveRun` shared by both start and resume, so the two paths cannot drift.

Verified with the full gate: 156 tests across the subagent suites, including a resume that asserts the follow-up reuses the recorded session id and carries the new task.