### PR TITLE
Resolve agent model tier aliases against available models

### DIFF
--- a/extensions/subagent/README.md
+++ b/extensions/subagent/README.md
@@ -114,11 +114,15 @@ Claude Code fields map onto pi where a sensible seam exists: `tools` and
 `--exclude-tools`; `effort` becomes the `:thinking` suffix on a pinned model, or
 `--thinking` when no model is pinned;
 `permissionMode: plan` selects a read-only toolset unless `tools` is set. Model
-aliases (`sonnet`, `opus`, `haiku`, `inherit`) run on the session's default
-model. `skills` names skills to preload: their bodies are inlined into the child's
+aliases (`sonnet`, `opus`, `haiku`) resolve against the models this machine is
+authenticated for, falling back to the session's default model when that tier is
+unavailable; `inherit` is the session model by definition. `skills` names skills to preload: their bodies are inlined into the child's
 prompt, since a child pi process does not inherit the parent's skill discovery, and
 a name that resolves to nothing is reported in the prompt rather than dropped.
-Fields with no pi equivalent are ignored: `memory`, `mcpServers`, `maxTurns`.
+Fields with no pi seam are ignored, each verified against pi's CLI rather than
+assumed: `maxTurns` (no turn-limit flag), `mcpServers` (a child reads MCP config
+from files, and writing config into the workspace to fake it would be worse than
+the gap), and `memory` (pi-code's memory is per project, not per agent).
 
 **Locations:**
 - `~/.claude/agents/*.md`, `~/.pi/agent/agents/*.md` - User-level (always loaded; `~/.pi` wins a name conflict)

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -54,6 +54,24 @@ function parseModelField(raw: unknown): string | undefined {
   return model && !CLAUDE_MODEL_ALIASES.has(model.toLowerCase()) ? model : undefined
 }
 
+/** The tier alias an agent asked for, kept so it can be resolved against the models
+ * this user is actually authenticated for. `inherit` is not a tier: it means the
+ * session model, which is also the fallback when a tier is unavailable. */
+function parseModelAlias(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined
+  const alias = raw.trim().toLowerCase()
+  return alias !== 'inherit' && CLAUDE_MODEL_ALIASES.has(alias) ? alias : undefined
+}
+
+/** Resolve a Claude tier alias to a concrete model id the user can actually run.
+ * Returning undefined leaves the child on the session model, which is what the
+ * unresolvable case degraded to before and still does. */
+export function resolveModelAlias(alias: string | undefined, available: ReadonlyArray<{ id: string; provider?: string }>): string | undefined {
+  if (!alias || alias === 'inherit') return undefined
+  const needle = alias.toLowerCase()
+  return available.find((model) => model.id.toLowerCase().includes(needle))?.id
+}
+
 /** pi's extended thinking levels; Claude's effort values are a subset, so they map 1:1. */
 const THINKING_LEVELS = new Set(['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
 
@@ -139,6 +157,7 @@ function parseAgentFile(content: string, source: AgentSource, filePath: string):
     disallowedTools,
     model: parseModelField(frontmatter.model),
     effort: parseEffortField(frontmatter.effort),
+    modelAlias: parseModelAlias(frontmatter.model),
     skills: parseSkillsField(frontmatter.skills),
     systemPrompt: body,
     source,
@@ -155,6 +174,8 @@ export interface AgentConfig {
   disallowedTools?: string[]
   model?: string
   effort?: string
+  /** Claude tier alias (`sonnet`/`opus`/`haiku`) when the file named one. */
+  modelAlias?: string
   /** Skill names to inline into the child's prompt, per Claude's `skills` field. */
   skills?: string[]
   systemPrompt: string

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -27,7 +27,7 @@ import { capForContext } from '../internal/output-guard.js'
 import { isProjectApproved, isProjectApprovedSilently } from '../internal/project-approval.js'
 import { SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
 import { skillDirs } from '../skills.js'
-import { type AgentConfig, type AgentScope, discoverAgents, withPreloadedSkills } from './agents.js'
+import { type AgentConfig, type AgentScope, discoverAgents, resolveModelAlias, withPreloadedSkills } from './agents.js'
 import { activeBackgroundRuns, backgroundStatusText, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
 
 const MAX_PARALLEL_TASKS = 8
@@ -262,6 +262,8 @@ interface RunAgentOptions {
   onPhase?: SubagentPhaseSink
   /** Skill directories to preload from, resolved where project trust is known. */
   skillRoots?: string[]
+  /** Models this user can actually run, for resolving a tier alias. */
+  availableModels?: ReadonlyArray<{ id: string }>
 }
 
 /** Publishes a child run's start/stop for the hooks extension's SubagentStart/Stop. */
@@ -297,7 +299,7 @@ async function runSingleAgentInner(options: RunAgentOptions): Promise<SingleResu
     }
   }
 
-  const args = agentInvocationArgs(agent)
+  const args = agentInvocationArgs(agent, resolveModelAlias(agent.modelAlias, options.availableModels ?? []))
 
   let tmpPromptDir: string | null = null
   let tmpPromptPath: string | null = null
@@ -527,6 +529,7 @@ interface ModeContext {
   makeDetails: MakeDetails
   onPhase?: SubagentPhaseSink
   skillRoots: string[]
+  availableModels: ReadonlyArray<{ id: string }>
 }
 
 async function checkProjectAgentGate(params: SubagentParamsStatic, agents: AgentConfig[], ctx: ExtensionContext, projectAgentsDir: string | null, gateMode: SubagentMode, makeDetails: MakeDetails): Promise<ToolResult | null> {
@@ -560,11 +563,13 @@ async function checkProjectAgentGate(params: SubagentParamsStatic, agents: Agent
 }
 
 /** CLI args shared by foreground and background children, from the agent's config. */
-function agentInvocationArgs(agent: AgentConfig): string[] {
+function agentInvocationArgs(agent: AgentConfig, aliasModel?: string): string[] {
   const args: string[] = ['--mode', 'json', '-p', '--no-session']
-  // pi reads a thinking level from the model pattern's :suffix when a model is pinned,
-  // and from --thinking otherwise, so effort survives either way.
-  if (agent.model) args.push('--model', agent.effort ? `${agent.model}:${agent.effort}` : agent.model)
+  // A concrete model wins; otherwise a Claude tier alias resolved against the models
+  // this user can actually run. pi reads a thinking level from the model pattern's
+  // :suffix when a model is pinned, and from --thinking otherwise.
+  const model = agent.model ?? aliasModel
+  if (model) args.push('--model', agent.effort ? `${model}:${agent.effort}` : model)
   else if (agent.effort) args.push('--thinking', agent.effort)
   if (agent.tools && agent.tools.length > 0) args.push('--tools', agent.tools.join(','))
   if (agent.disallowedTools && agent.disallowedTools.length > 0) args.push('--exclude-tools', agent.disallowedTools.join(','))
@@ -592,7 +597,7 @@ function removeTmpPrompt(tmpPrompt: { dir: string; filePath: string } | undefine
   }
 }
 
-async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConfig[], defaultCwd: string, pi: ExtensionAPI, makeDetails: MakeDetails, skillRoots: string[]): Promise<ToolResult> {
+async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConfig[], defaultCwd: string, pi: ExtensionAPI, makeDetails: MakeDetails, skillRoots: string[], availableModels: ReadonlyArray<{ id: string }>): Promise<ToolResult> {
   const task = params.task
   const agentName = params.agent
   if (!task || !agentName) {
@@ -612,7 +617,7 @@ async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConf
   if (activeBackgroundRuns() >= MAX_BACKGROUND_RUNS) {
     return backgroundCapResult(makeDetails)
   }
-  const args = agentInvocationArgs(agent)
+  const args = agentInvocationArgs(agent, resolveModelAlias(agent.modelAlias, availableModels))
   let tmpPrompt: { dir: string; filePath: string } | undefined
   const promptWithSkills = withPreloadedSkills(agent.systemPrompt, agent.skills, skillRoots)
   if (promptWithSkills.trim()) {
@@ -675,6 +680,7 @@ async function runChainMode(chain: ChainStepParam[], mode: ModeContext): Promise
       makeDetails: makeDetails('chain'),
       onPhase: mode.onPhase,
       skillRoots: mode.skillRoots,
+      availableModels: mode.availableModels,
     })
     results.push(result)
 
@@ -791,6 +797,7 @@ async function runSingleMode(agentName: string, task: string, cwd: string | unde
     makeDetails: makeDetails('single'),
     onPhase: mode.onPhase,
     skillRoots: mode.skillRoots,
+    availableModels: mode.availableModels,
   })
   const isError = result.exitCode !== 0 || result.stopReason === 'error' || result.stopReason === 'aborted'
   if (isError) {
@@ -1185,10 +1192,13 @@ export default function subagentExtension(pi: ExtensionAPI) {
       // Project skills only preload once the project is approved, matching the
       // gate the skills extension applies to discovery itself.
       const skillRoots = skillDirs(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
+      // Tier aliases resolve against what this user is authenticated for; an
+      // unavailable tier still falls back to the session model.
+      const availableModels = ctx.modelRegistry?.getAvailable?.() ?? []
 
-      if (params.background) return runBackgroundMode(params, agents, ctx.cwd, pi, makeDetails, skillRoots)
+      if (params.background) return runBackgroundMode(params, agents, ctx.cwd, pi, makeDetails, skillRoots, availableModels)
 
-      const mode: ModeContext = { agents, defaultCwd: ctx.cwd, signal, onUpdate, makeDetails, skillRoots, onPhase: (phase, agentType, agentId) => pi.events.emit(SUBAGENT_CHANNEL, { phase, agentType, agentId }) }
+      const mode: ModeContext = { agents, defaultCwd: ctx.cwd, signal, onUpdate, makeDetails, skillRoots, availableModels, onPhase: (phase, agentType, agentId) => pi.events.emit(SUBAGENT_CHANNEL, { phase, agentType, agentId }) }
 
       if (params.chain?.length) return runChainMode(params.chain, mode)
       if (params.tasks?.length) return runParallelMode(params.tasks, mode)

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { discoverAgents, withPreloadedSkills } from '../extensions/subagent/agents.ts'
+import { discoverAgents, resolveModelAlias, withPreloadedSkills } from '../extensions/subagent/agents.ts'
 
 /**
  * Covers extensions/subagent/agents.ts and extensions/subagent/background.ts.
@@ -705,5 +705,27 @@ describe('resumeBackgroundRun', () => {
     const id = startBackgroundRun('scout', 'first', invocation, () => {}) as string
     expect(resumeBackgroundRun(id, 'again', () => {})).toBe('still-running')
     expect(resumeBackgroundRun('bg-nope', 'again', () => {})).toBe('unknown')
+  })
+})
+
+describe('resolveModelAlias', () => {
+  const available = [
+    { id: 'claude-sonnet-4-5', provider: 'anthropic' },
+    { id: 'claude-opus-4-1', provider: 'anthropic' },
+    { id: 'gpt-oss:20b', provider: 'ollama' },
+  ]
+
+  it('resolves a Claude tier alias to an authenticated model id', () => {
+    expect(resolveModelAlias('sonnet', available)).toBe('claude-sonnet-4-5')
+    expect(resolveModelAlias('Opus', available)).toBe('claude-opus-4-1')
+  })
+
+  it('returns undefined when the tier is not available, so the session model is used', () => {
+    expect(resolveModelAlias('haiku', available)).toBeUndefined()
+    expect(resolveModelAlias('sonnet', [{ id: 'gpt-oss:20b', provider: 'ollama' }])).toBeUndefined()
+  })
+
+  it('treats inherit as the session model rather than a tier to look up', () => {
+    expect(resolveModelAlias('inherit', available)).toBeUndefined()
   })
 })


### PR DESCRIPTION
A `sonnet`/`opus`/`haiku` alias in an agent file was dropped outright: pi's resolver would partial-match it against an authenticated Anthropic provider, but for every other setup the child exited at boot on an unresolvable `--model`, so running on the session model was the safe degradation.

The model registry knows which models this machine is actually authenticated for, which turns that guess into a lookup.

- **An alias resolves to a concrete id when the tier is available** (subagent/agents.ts, subagent/index.ts), using `modelRegistry.getAvailable()`.
- **It still falls back to the session model when the tier is not available**, which is exactly the previous behavior, so no setup that works today changes.
- `inherit` remains the session model by definition rather than a tier to look up.

The subagent README also records what was *verified* about the fields that stay unmapped, rather than asserting it: pi's CLI has no turn-limit flag, so `maxTurns` has no seam; a child reads MCP config from files, and writing config into the workspace to fake `mcpServers` would be worse than the gap; pi-code's memory is per project, not per agent.

Verified with the full gate: 975 tests.