### PR TITLE
Truncate an over-long question header instead of rejecting the call

### DIFF
--- a/extensions/question.ts
+++ b/extensions/question.ts
@@ -34,7 +34,7 @@ const OptionSchema = Type.Object({
 
 const SingleQuestion = Type.Object({
   question: Type.String({ description: 'The question to ask the user' }),
-  header: Type.Optional(Type.String({ description: 'Short label for the question, shown above it (max 12 characters)', maxLength: 12 })),
+  header: Type.Optional(Type.String({ description: 'Short label for the question, shown above it, kept to 12 characters' })),
   options: Type.Array(OptionSchema, { description: 'Options for the user to choose from (1-4)', minItems: 1, maxItems: 4 }),
   multiSelect: Type.Optional(Type.Boolean({ description: 'Allow selecting several options (space toggles, enter confirms)' })),
 })
@@ -45,7 +45,7 @@ const SingleQuestion = Type.Object({
 export const QuestionParams = Type.Object({
   question: Type.Optional(Type.String({ description: 'The question to ask. Required, unless asking several via questions.' })),
   options: Type.Optional(Type.Array(OptionSchema, { description: 'The 1-4 choices for this question, each {label, description?}. Required with question.', minItems: 1, maxItems: 4 })),
-  header: Type.Optional(Type.String({ description: 'Optional short label shown above the question (max 12 characters)', maxLength: 12 })),
+  header: Type.Optional(Type.String({ description: 'Optional short label shown above the question, kept to 12 characters' })),
   multiSelect: Type.Optional(Type.Boolean({ description: 'Optional: allow selecting several options (space toggles, enter confirms)' })),
   questions: Type.Optional(Type.Array(SingleQuestion, { description: 'Only to ask 2-4 questions in one call: each entry takes the same fields as above. Leave unset for a single question.', minItems: 1, maxItems: 4 })),
 })
@@ -60,9 +60,15 @@ export interface QuestionSpec {
 /** Normalize either accepted shape into the list of questions to ask. */
 export function questionList(params: Partial<QuestionSpec> & { questions?: QuestionSpec[] }): QuestionSpec[] {
   if (params.questions && params.questions.length > 0) return params.questions
-  if (typeof params.question === 'string') return [{ question: params.question, header: params.header, options: params.options ?? [], multiSelect: params.multiSelect }]
+  if (typeof params.question === 'string') return [{ question: params.question, header: shortHeader(params.header), options: params.options ?? [], multiSelect: params.multiSelect }]
   return []
 }
+
+/** Claude keeps a header short for the label slot. Truncating is the forgiving read:
+ * rejecting the call costs a turn while the model recovers from a validation error,
+ * which is a poor trade for a display detail. */
+export const HEADER_MAX = 12
+export const shortHeader = (header: string | undefined): string | undefined => (header === undefined ? undefined : header.slice(0, HEADER_MAX))
 
 function checkbox(checked: boolean | undefined): string {
   if (checked === undefined) return ''
@@ -320,7 +326,7 @@ async function askOne(params: QuestionSpec, ctx: ExtensionContext): Promise<{ co
     function render(width: number): string[] {
       if (cachedLines && cachedWidth === width) return cachedLines
       cachedWidth = width
-      cachedLines = buildQuestionLines({ width, question: params.question, header: params.header, options: allOptions, optionIndex, editMode, multiSelect, checked, editor, theme })
+      cachedLines = buildQuestionLines({ width, question: params.question, header: shortHeader(params.header), options: allOptions, optionIndex, editMode, multiSelect, checked, editor, theme })
       return cachedLines
     }
 
@@ -337,7 +343,7 @@ async function askOne(params: QuestionSpec, ctx: ExtensionContext): Promise<{ co
   // Build simple options list for details; header/multiSelect appear only when set,
   // so single-select details are unchanged.
   const simpleOptions = params.options.map((o) => o.label)
-  const base = { question: params.question, options: simpleOptions, ...(params.header ? { header: params.header } : {}), ...(multiSelect ? { multiSelect: true } : {}) }
+  const base = { question: params.question, options: simpleOptions, ...(params.header ? { header: shortHeader(params.header) } : {}), ...(multiSelect ? { multiSelect: true } : {}) }
 
   if (!result) {
     return {

--- a/tests/question.test.ts
+++ b/tests/question.test.ts
@@ -1,7 +1,7 @@
 import type { Text } from '@earendil-works/pi-tui'
 import { describe, expect, it } from 'vitest'
 
-import questionExtension, { QuestionParams } from '../extensions/question.ts'
+import questionExtension, { QuestionParams, shortHeader } from '../extensions/question.ts'
 
 interface Option {
   label: string
@@ -96,10 +96,13 @@ const openOverlayWith = (tool: QuestionTool, params: Record<string, unknown>) =>
 
 describe('question schema caps', () => {
   it("bounds options and header to Claude's AskUserQuestion limits", () => {
-    const schema = QuestionParams as unknown as { properties: { options: { minItems: number; maxItems: number }; header: { maxLength: number } } }
+    const schema = QuestionParams as unknown as { properties: { options: { minItems: number; maxItems: number } } }
     expect(schema.properties.options.maxItems).toBe(4)
     expect(schema.properties.options.minItems).toBe(1)
-    expect(schema.properties.header.maxLength).toBe(12)
+    // The header cap is a display detail, so it truncates rather than failing the
+    // call: a rejected call costs a turn while the model recovers.
+    expect(shortHeader('a very long header indeed')).toBe('a very long ')
+    expect(shortHeader(undefined)).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
The 12-character header cap was enforced as a schema `maxLength`, so a longer header failed validation: the model got a tool error and spent a turn recovering before it could ask the user anything.

A display detail should not cost a turn. The header is now truncated where it is rendered and in the result details, and the schema states the limit without enforcing it. Found by watching a real model hit the error while it was trying to ask a question.