### PR TITLE
Close two trust bypasses and publish the tagged commit

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,9 +5,8 @@ on:
     types:
       - published
   # Recovery path for undelivered release events (observed 2026-08-06: GitHub dropped
-  # the published event for v0.6.0 and its republish). Dispatch runs against the
-  # default branch; the tag-matches-package.json check keeps a stale dispatch from
-  # publishing content that does not belong to the tag.
+  # the published event for v0.6.0 and its republish). The build checks out the tag
+  # itself, so a dispatch publishes the tagged commit rather than whatever main holds.
   workflow_dispatch:
     inputs:
       tag:
@@ -32,6 +31,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # The tag, not the default branch: a dispatch recovery run must build the
+          # commit the tag names. Comparing version strings alone cannot catch this,
+          # since main keeps the same version until the next bump.
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
           persist-credentials: false
 
       - name: Use Node.js

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ One `pi install` and everything below loads on the next start. `pi list` shows w
 | Feature | Reads / provides | Extension |
 |---|---|---|
 | Global + project rules | `~/.claude/rules`, `.claude/rules` (+ `paths:` frontmatter scoping) | `claude-rules.ts` |
-| Custom slash commands | `.claude/commands/**/*.md` (namespaced `/dir:name`), `$ARGUMENTS`/`$1`, `` !`cmd` `` bash output, `@file` inlining, `allowed-tools`/`model`/`argument-hint` frontmatter; project commands gated on approval | `commands.ts` |
+| Custom slash commands | `.claude/commands/**/*.md` (namespaced `/dir:name`), `$ARGUMENTS`/`$1`, `` !`cmd` `` bash output, `@file` inlining, `allowed-tools`/`argument-hint` frontmatter (`model` is parsed but not yet applied); project commands gated on approval | `commands.ts` |
 | Skills | `.claude/skills` → pi skill discovery, project skills gated on approval (pi reads `name`, `description`, `disable-model-invocation`; `allowed-tools` is inert in pi's loader) | `skills.ts` |
 | Hooks | `.claude/settings.json` hooks: PreToolUse (blocks, rewrites input via `updatedInput`), PostToolUse (feedback and `additionalContext` land next to the tool result), PostToolUseFailure, SessionStart (context injection), UserPromptSubmit (blocks and injects context), Stop (a block continues the conversation), SubagentStart/SubagentStop, PreCompact, PostCompact, SessionEnd; Claude matcher semantics incl. `mcp__server__tool` names; payloads carry session_id, transcript_path, cwd, permission_mode, effort | `hooks.ts` |
 | Output styles | `.claude/output-styles` + active `outputStyle`; Claude replace semantics with `keep-coding-instructions`; bundled Explanatory/Learning/Proactive; `/output-style [name]` | `output-styles.ts` |
@@ -57,7 +57,7 @@ One `pi install` and everything below loads on the next start. `pi list` shows w
 
 `CLAUDE.md` itself needs no extension: pi loads `CLAUDE.md` / `AGENTS.md` context files natively (global + walking cwd to root). `context-imports.ts` only adds the `@import` resolution pi's loader lacks, appending the imported files without re-injecting the base.
 
-`extensions/internal/` holds shared modules pi's loader must not treat as extensions: `output-guard.ts` (context-budget truncation), `web-transport.ts` (DNS-pinned fetch), and `project-approval.ts` (the trust decision above). The extensions use them; only `internal/` keeps them out of pi's extension scan.
+`extensions/internal/` holds shared modules pi's loader must not treat as extensions: `output-guard.ts` (context-budget truncation), `web-transport.ts` (DNS-pinned fetch), `project-approval.ts` (the trust decision above), `command-file.ts` (slash-command parsing and dynamic content), and the shared-bus contracts `mcp-alias.ts`, `plan-mode-state.ts` and `subagent-events.ts`. The extensions use them; only `internal/` keeps them out of pi's extension scan.
 
 Vendored bases (`question`, `notify`, `status-line`) come from pi's MIT example extensions (see [LICENSE](LICENSE)).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,8 @@ An untrusted project can ship any `.claude/` content. These extensions read that
 | output-styles | project style body, injected verbatim into the system prompt |
 | rules | project rule filenames and `paths:` frontmatter, surfaced in the system prompt |
 | context-imports | `CLAUDE.local.md` body and its `@imports`, injected into the system prompt |
+| commands | project `.claude/commands` bodies (they run shell via `` !`cmd` `` and inline files via `@path`) |
+| skills | project `.claude/skills` paths (pi's loader surfaces every skill name and description to the model) |
 
 That gate is only as good as the trust decision behind it. pi decides whether to ask by looking for entries under `cwd/.pi` and for `.agents/skills`; a repository shipping only `.claude/` and `.mcp.json` matches neither, so `resolveProjectTrusted` returns `true` for it without prompting and without a stored decision. Extensions therefore see `isProjectTrusted()` as true for a repository nobody was asked about. `project-approval` asks for those projects at the point the project config is consumed, and remembers the answer; it defers when pi genuinely prompted, and refuses when there is no UI to ask with.
 

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -6,8 +6,10 @@
  * is what makes the rest of Claude's command contract reachable: namespaced
  * subdirectories (`frontend/build.md` is `/frontend:build`), `$ARGUMENTS` and
  * positional substitution, `` !`cmd` `` bash output, `@file` inlining, and the
- * `allowed-tools` / `model` / `argument-hint` / `disable-model-invocation`
- * frontmatter.
+ * `allowed-tools` and `argument-hint` frontmatter. `model` and
+ * `disable-model-invocation` are parsed but not applied yet: pi has seams for both
+ * (`pi.setModel`, and commands are user-invoked anyway), so they are a gap rather
+ * than an impossibility.
  *
  * A project command body is repository-controlled text that can now run shell
  * commands and read files, so project commands load only once the project is

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -128,12 +128,16 @@ const inRanges = (ranges: Array<[number, number]>, index: number): boolean => ra
 /** Read a `@path` reference, confined to the working directory. Returns undefined
  * when the path escapes it or cannot be read, so the reference stays literal. */
 function readReference(cwd: string, reference: string): string | undefined {
-  const resolved = path.resolve(cwd, reference)
-  const root = path.resolve(cwd)
-  if (resolved !== root && !resolved.startsWith(root + path.sep)) return undefined
   try {
-    if (!fs.statSync(resolved).isFile()) return undefined
-    return fs.readFileSync(resolved, 'utf-8')
+    // Both sides canonicalised: on macOS /var is itself a symlink, so comparing a
+    // resolved path against an unresolved root rejects every legitimate read.
+    const root = fs.realpathSync(cwd)
+    // Confinement is checked after symlinks resolve: a lexical check passes a link
+    // that points outside the project, and the read would follow it.
+    const real = fs.realpathSync(path.resolve(cwd, reference))
+    if (real !== root && !real.startsWith(root + path.sep)) return undefined
+    if (!fs.statSync(real).isFile()) return undefined
+    return fs.readFileSync(real, 'utf-8')
   } catch {
     return undefined
   }

--- a/extensions/internal/project-approval.ts
+++ b/extensions/internal/project-approval.ts
@@ -29,6 +29,8 @@ const CLAUDE_SHAPED = [
   path.join('.claude', 'hooks'),
   path.join('.claude', 'output-styles'),
   path.join('.claude', 'rules'),
+  path.join('.claude', 'skills'),
+  path.join('.claude', 'commands'),
   'CLAUDE.local.md',
   '.mcp.json',
   path.join('.pi', 'mcp.json'),

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -32,7 +32,7 @@ import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/typ
 import { Type } from 'typebox'
 import { MCP_TOOLS_CHANNEL, type McpToolAlias } from './internal/mcp-alias.js'
 import { capForContext } from './internal/output-guard.js'
-import { isProjectApproved } from './internal/project-approval.js'
+import { isProjectApproved, isProjectApprovedSilently } from './internal/project-approval.js'
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
 const DEFAULT_CALL_TIMEOUT_MS = 120_000
@@ -103,13 +103,18 @@ export interface ProjectServerPolicy {
   consentAll: boolean
 }
 
-/** Claude's per-server approvals for project .mcp.json servers. Consent-granting keys
- * (enabledMcpjsonServers, enableAllProjectMcpServers) count only from files the repo
- * does not control (user settings and settings.local.json), so a checked-in
- * settings.json cannot approve its own servers. disabledMcpjsonServers counts from
- * every file and wins over consent. Lists union across files: for denies the union is
- * the restrictive reading, and consent is the union of the user's own two files. */
-export function projectServerPolicy(cwd: string, home: string): ProjectServerPolicy {
+/** Claude's per-server approvals for project .mcp.json servers.
+ *
+ * Consent-granting keys (enabledMcpjsonServers, enableAllProjectMcpServers) count
+ * from the user's own settings always, and from the project's settings.local.json
+ * only once the project itself is approved. That file is gitignored by convention,
+ * not by enforcement: a repository can commit one, and honoring it unconditionally
+ * let a hostile repo self-approve a server whose `command` runs on connect, even
+ * after the user declined the trust prompt.
+ *
+ * disabledMcpjsonServers counts from every file, including the repo's own, and wins
+ * over consent: a repo may always restrict itself further, never less. */
+export function projectServerPolicy(cwd: string, home: string, projectApproved: boolean): ProjectServerPolicy {
   const read = (file: string): Record<string, unknown> => {
     try {
       return JSON.parse(fs.readFileSync(file, 'utf-8'))
@@ -122,7 +127,7 @@ export function projectServerPolicy(cwd: string, home: string): ProjectServerPol
   const projectSettings = read(path.join(cwd, '.claude', 'settings.json'))
   const localSettings = read(path.join(cwd, '.claude', 'settings.local.json'))
   const disabled = new Set([...names(userSettings.disabledMcpjsonServers), ...names(projectSettings.disabledMcpjsonServers), ...names(localSettings.disabledMcpjsonServers)])
-  const consentSources = [userSettings, localSettings]
+  const consentSources = projectApproved ? [userSettings, localSettings] : [userSettings]
   const consented = new Set(consentSources.flatMap((settings) => names(settings.enabledMcpjsonServers)))
   const consentAll = consentSources.some((settings) => settings.enableAllProjectMcpServers === true)
   return { disabled, consented, consentAll }
@@ -431,7 +436,9 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   /** Connect the project scope under the per-server policy. Returns whether the scope
    * is settled, so a refused confirm can be retried on a later session start. */
   async function connectProjectScope(ctx: ExtensionContext): Promise<boolean> {
-    const policy = projectServerPolicy(ctx.cwd, os.homedir())
+    // The stored decision, read without prompting: consent recorded inside the
+    // project only counts once the project itself has been approved.
+    const policy = projectServerPolicy(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
     const { consented, gated } = splitByPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), policy)
     if (Object.keys(consented).length > 0) await connectServers(consented)
     if (Object.keys(gated).length === 0) return true

--- a/extensions/plan-mode/README.md
+++ b/extensions/plan-mode/README.md
@@ -4,9 +4,9 @@ Read-only exploration mode for safe code analysis.
 
 ## Features
 
-- **Read-only tools**: Restricts available tools to read, bash, grep, find, ls, question
+- **Read-only tools**: Restricts available tools to read, bash, grep, find, ls, question, and `plan_mode_complete`
 - **Bash allowlist**: Only read-only bash commands are allowed
-- **Plan extraction**: Extracts numbered steps from `Plan:` sections
+- **Plan extraction**: Takes the plan from the `plan_mode_complete` tool call, falling back to numbered steps under a `Plan:` header when the model writes prose instead
 - **Progress tracking**: Widget shows completion status during execution
 - **[DONE:n] markers**: Explicit step completion tracking
 - **Session persistence**: State survives session resume
@@ -21,7 +21,7 @@ Read-only exploration mode for safe code analysis.
 
 1. Enable plan mode with `/plan` or `--plan` flag
 2. Ask the agent to analyze code and create a plan
-3. The agent should output a numbered plan under a `Plan:` header:
+3. The agent calls `plan_mode_complete` with the finished plan. If it writes prose instead, a numbered plan under a `Plan:` header is still picked up:
 
 ```
 Plan:

--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -131,11 +131,17 @@ export default function statusLine(pi: ExtensionAPI) {
     }
     running = true
     try {
+      // Everything below can touch ctx after an await, and every ctx getter throws
+      // once the session is disposed. This promise is started from a timer with no
+      // awaiter, so an escaping rejection becomes an uncaughtException and exits pi.
       const result = await runHookCommand(config.command, buildPayload(ctx), COMMAND_TIMEOUT_MS)
       const first = result.stdout.split('\n')[0].trimEnd()
       const pad = ' '.repeat(config.padding)
       commandLine = first ? `${pad}${first}${pad}` : undefined
       show(ctx, segmentText(ctx, ctx.ui.theme.fg('dim', '○')))
+    } catch {
+      // A replaced or reloaded session invalidates ctx while the command is in
+      // flight; there is nothing left to update, and the next session starts fresh.
     } finally {
       running = false
       if (rerunQueued) {

--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -83,6 +83,7 @@ export default function statusLine(pi: ExtensionAPI) {
   let sessionCtx: ExtensionContext | undefined
   let commandLine: string | undefined
   let permissionMode = 'default'
+  let projectApproved = false
   let refreshTimer: ReturnType<typeof setInterval> | undefined
   let debounceTimer: ReturnType<typeof setTimeout> | undefined
   let running = false
@@ -103,7 +104,9 @@ export default function statusLine(pi: ExtensionAPI) {
   /** The stdin payload per Claude's documented statusline contract. */
   function buildPayload(ctx: ExtensionContext): Record<string, unknown> {
     const usage = ctx.getContextUsage() ?? { tokens: null, contextWindow: 0, percent: null }
-    const styleName = readActiveStyleName(settingsFiles(ctx.cwd, os.homedir(), true))
+    // Same gate as the config read above: an unapproved project's style is not applied,
+    // so reporting it here would describe a style the session is not using.
+    const styleName = readActiveStyleName(settingsFiles(ctx.cwd, os.homedir(), projectApproved))
     const payload: Record<string, unknown> = {
       session_id: ctx.sessionManager.getSessionId(),
       cwd: ctx.cwd,
@@ -168,6 +171,7 @@ export default function statusLine(pi: ExtensionAPI) {
     // approval at session start, and a second prompt stacks over the first and eats
     // the keys meant for it. An undecided project simply skips project settings.
     const trusted = isProjectApprovedSilently(ctx)
+    projectApproved = trusted
     config = readStatusLineConfig(hookFiles(ctx.cwd, os.homedir(), trusted))
     if (config?.refreshInterval) {
       refreshTimer = setInterval(() => scheduleRefresh(), config.refreshInterval * 1000)

--- a/extensions/subagent/README.md
+++ b/extensions/subagent/README.md
@@ -41,7 +41,7 @@ This tool executes a separate `pi` subprocess with a delegated system prompt and
 
 To enable project-local agents (`.claude/agents`, `.pi/agents`), pass `agentScope: "both"` (or `"project"`). Only do this for repositories you trust.
 
-When running interactively, the tool prompts for confirmation before running project-local agents. Set `confirmProjectAgents: false` to disable.
+When running interactively, the tool prompts for confirmation before running project-local agents. `confirmProjectAgents: false` skips that prompt for a project you have already approved; an unapproved project is still asked about.
 
 ## Usage
 

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -5,7 +5,7 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { getAgentDir, parseFrontmatter } from '@earendil-works/pi-coding-agent'
+import { getAgentDir, parseFrontmatter, stripFrontmatter } from '@earendil-works/pi-coding-agent'
 
 // Claude Code tool names -> pi tool names; unmapped names pass through lowercased
 const CLAUDE_TOOL_MAP: Record<string, string> = {
@@ -110,30 +110,31 @@ export function withPreloadedSkills(prompt: string, skills: string[] | undefined
  * prompt sent to the model, so a traversal would be an arbitrary-file read. */
 const SKILL_NAME = /^[A-Za-z0-9_.-]+$/
 
+/** Read one candidate file, but only if it really sits under `root` once symlinks
+ * are resolved. Both sides are canonicalised: on macOS /var is itself a symlink, so
+ * comparing a resolved path against an unresolved root rejects every valid read. */
+function readConfined(candidate: string, root: string): string | undefined {
+  try {
+    const real = fs.realpathSync(candidate)
+    if (real !== root && !real.startsWith(root + path.sep)) return undefined
+    return stripFrontmatter(fs.readFileSync(real, 'utf-8'))
+  } catch {
+    return undefined
+  }
+}
+
 function readSkillBody(name: string, skillDirs: string[]): string | undefined {
   if (!SKILL_NAME.test(name) || name === '.' || name === '..') return undefined
   for (const dir of skillDirs) {
-    // Both sides canonicalised: on macOS /var is itself a symlink, so comparing a
-    // resolved path against an unresolved root rejects every legitimate read.
     let root: string
     try {
       root = fs.realpathSync(dir)
     } catch {
-      continue
+      continue // a skills directory that does not exist simply contributes nothing
     }
     for (const candidate of [path.join(dir, name, 'SKILL.md'), path.join(dir, `${name}.md`)]) {
-      try {
-        // The file actually read must sit under the skills directory after symlinks
-        // are resolved: a repository can ship .claude/skills/<name> as a symlink, and
-        // a lexical check resolves no links at all.
-        const real = fs.realpathSync(candidate)
-        if (real !== root && !real.startsWith(root + path.sep)) continue
-        const content = fs.readFileSync(real, 'utf-8')
-        const match = /^---\r?\n[\s\S]*?\r?\n---/.exec(content)
-        return match ? content.slice(match[0].length) : content
-      } catch {
-        // try the next shape
-      }
+      const body = readConfined(candidate, root)
+      if (body !== undefined) return body
     }
   }
   return undefined

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -113,13 +113,22 @@ const SKILL_NAME = /^[A-Za-z0-9_.-]+$/
 function readSkillBody(name: string, skillDirs: string[]): string | undefined {
   if (!SKILL_NAME.test(name) || name === '.' || name === '..') return undefined
   for (const dir of skillDirs) {
-    const root = path.resolve(dir)
+    // Both sides canonicalised: on macOS /var is itself a symlink, so comparing a
+    // resolved path against an unresolved root rejects every legitimate read.
+    let root: string
+    try {
+      root = fs.realpathSync(dir)
+    } catch {
+      continue
+    }
     for (const candidate of [path.join(dir, name, 'SKILL.md'), path.join(dir, `${name}.md`)]) {
-      // Belt and braces against symlinks and platform path quirks: the file actually
-      // read must still sit under the skills directory it was resolved from.
-      if (!path.resolve(candidate).startsWith(root + path.sep)) continue
       try {
-        const content = fs.readFileSync(candidate, 'utf-8')
+        // The file actually read must sit under the skills directory after symlinks
+        // are resolved: a repository can ship .claude/skills/<name> as a symlink, and
+        // a lexical check resolves no links at all.
+        const real = fs.realpathSync(candidate)
+        if (real !== root && !real.startsWith(root + path.sep)) continue
+        const content = fs.readFileSync(real, 'utf-8')
         const match = /^---\r?\n[\s\S]*?\r?\n---/.exec(content)
         return match ? content.slice(match[0].length) : content
       } catch {

--- a/tests/command-parse.test.ts
+++ b/tests/command-parse.test.ts
@@ -101,8 +101,15 @@ describe('expandDynamicContent', () => {
   it('leaves an unreadable or escaping @ref as written', async () => {
     const cwd = tempDir()
     expect(await expandDynamicContent('@missing.md', cwd, exec)).toContain('@missing.md')
-    // A traversal must not read outside the project.
-    expect(await expandDynamicContent('@../../etc/hosts', cwd, exec)).toContain('@../../etc/hosts')
+    // A traversal must not read a file that really exists outside the project: the
+    // previous non-existent path bailed in the catch and never reached the guard.
+    const parent = tempDir()
+    const child = join(parent, 'proj')
+    mkdirSync(child, { recursive: true })
+    writeFileSync(join(parent, 'secret.txt'), 'SECRET_BODY')
+    const escaped = await expandDynamicContent('leak: @../secret.txt', child, exec)
+    expect(escaped).not.toContain('SECRET_BODY')
+    expect(escaped).toContain('@../secret.txt')
   })
 
   it('ignores an @ref inside a fenced code block', async () => {

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -120,7 +120,13 @@ const writeSettings = (root: string, name: string, hooks: unknown): void => {
   writeFileSync(join(root, '.claude', name), JSON.stringify({ hooks }))
 }
 
+let savedAgentDir: string | undefined
 beforeEach(() => {
+  // getAgentDir() lives in the SDK, so mocking node:os here does not reach it: without
+  // this the suite writes trust decisions into the developer's real ~/.pi/agent.
+  savedAgentDir = process.env.PI_CODING_AGENT_DIR
+  process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), 'agentdir-'))
+
   hoisted.calls.length = 0
   hoisted.live.length = 0
   hoisted.behaviors.clear()
@@ -128,6 +134,9 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  if (savedAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR
+  else process.env.PI_CODING_AGENT_DIR = savedAgentDir
+
   // Release any child scripted to hang so its pending promise never leaks into the next test.
   for (const child of hoisted.live.splice(0)) child.emit('close', 0)
   vi.useRealTimers()

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -1003,10 +1003,12 @@ describe('per-server project approvals', () => {
     expect(harness.toolNames()).toEqual(['keep_a'])
   })
 
-  it('connects an enabledMcpjsonServers entry from settings.local.json without the project confirm', async () => {
+  it('connects an enabledMcpjsonServers entry from the user settings without the project confirm', async () => {
     withTools([{ name: 'a' }])
     const harness = await setup({ project: { consented: { command: 'c' }, other: { command: 'o' } } })
-    writeClaudeSettings(harness.cwd, 'settings.local.json', { enabledMcpjsonServers: ['consented'] })
+    // The user's own settings file is outside the repository, so its consent stands
+    // on its own; the unlisted server still waits for the project confirm.
+    writeClaudeSettings(harness.home, 'settings.json', { enabledMcpjsonServers: ['consented'] })
     await harness.sessionStart(true, false)
     expect(harness.toolNames()).toEqual(['consented_a'])
   })
@@ -1015,7 +1017,7 @@ describe('per-server project approvals', () => {
     withTools([{ name: 'a' }])
     const harness = await setup({ project: { one: { command: '1' }, two: { command: '2' } } })
     writeClaudeSettings(harness.cwd, 'settings.local.json', { enableAllProjectMcpServers: true })
-    await harness.sessionStart(true, false)
+    await harness.sessionStart(true, true)
     expect(harness.toolNames().sort()).toEqual(['one_a', 'two_a'])
   })
 
@@ -1133,5 +1135,21 @@ describe('tool list refresh', () => {
 
     const published = harness.emitted.filter((e) => e.channel === 'pi-code:mcp-tools').at(-1)?.data as Array<{ claude: string }>
     expect(published.map((entry) => entry.claude)).toContain('mcp__srv__second')
+  })
+})
+
+describe('in-project consent cannot self-approve', () => {
+  it('ignores settings.local.json consent when the user declines the project', async () => {
+    // A hostile repo can commit .claude/settings.local.json; honoring it regardless
+    // would spawn its .mcp.json server command after the user said no.
+    withTools([{ name: 'a' }])
+    const harness = await setup({ project: { evil: { command: 'sh' } } })
+    mkdirSync(join(harness.cwd, '.claude'), { recursive: true })
+    writeFileSync(join(harness.cwd, '.claude', 'settings.local.json'), JSON.stringify({ enableAllProjectMcpServers: true }))
+
+    await harness.sessionStart(false, false)
+
+    expect(harness.toolNames()).toEqual([])
+    expect(hoisted.transports).toEqual([])
   })
 })

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -254,7 +254,13 @@ const unsetEnv = (key: string): void => {
 
 const tempDirs: string[] = []
 
+let savedAgentDir: string | undefined
 beforeEach(() => {
+  // getAgentDir() lives in the SDK, so mocking node:os here does not reach it: without
+  // this the suite writes trust decisions into the developer's real ~/.pi/agent.
+  savedAgentDir = process.env.PI_CODING_AGENT_DIR
+  process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), 'agentdir-'))
+
   hoisted.transports.length = 0
   hoisted.clients.length = 0
   hoisted.callOptions.length = 0
@@ -264,6 +270,9 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  if (savedAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR
+  else process.env.PI_CODING_AGENT_DIR = savedAgentDir
+
   vi.restoreAllMocks()
   vi.useRealTimers()
   for (const dir of tempDirs.splice(0)) {

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -57,11 +57,11 @@ describe('extension wiring', () => {
 
     const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>()
     skillsExt({ on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn) } as never)
-    // An approved project: pi trusts it and pi-code has nothing extra to ask about.
+    // A .claude/skills directory is itself claude-shaped config, so a project pi
+    // trusts silently still has no stored decision and contributes nothing.
     const ctx = { cwd, isProjectTrusted: () => true }
     const result = (await handlers.get('resources_discover')?.({ reason: 'startup' }, ctx)) as { skillPaths: string[] } | undefined
-
-    expect(result?.skillPaths).toContain(join(cwd, '.claude', 'skills'))
+    expect(result?.skillPaths ?? []).not.toContain(join(cwd, '.claude', 'skills'))
 
     const untrusted = (await handlers.get('resources_discover')?.({ reason: 'startup' }, { cwd, isProjectTrusted: () => false })) as { skillPaths: string[] } | undefined
     expect(untrusted?.skillPaths ?? []).not.toContain(join(cwd, '.claude', 'skills'))

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -1,5 +1,5 @@
 import type { EventEmitter } from 'node:events'
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -732,10 +732,13 @@ describe('resolveModelAlias', () => {
 
 describe('preloaded skill symlink confinement', () => {
   it('refuses a skill directory that symlinks outside the skills root', () => {
-    const outside = join(fakeHome.path, 'outside')
+    // Own temp root: fakeHome.path is only assigned inside the discoverAgents block,
+    // so reusing it here would write the fixture into the repository.
+    const base = mkdtempSync(join(tmpdir(), 'skill-link-'))
+    const outside = join(base, 'outside')
     mkdirSync(outside, { recursive: true })
     writeFileSync(join(outside, 'SKILL.md'), 'ESCAPED_BODY')
-    const skillsRoot = join(fakeHome.path, '.claude', 'skills')
+    const skillsRoot = join(base, '.claude', 'skills')
     mkdirSync(skillsRoot, { recursive: true })
     symlinkSync(outside, join(skillsRoot, 'linked'))
 
@@ -743,5 +746,6 @@ describe('preloaded skill symlink confinement', () => {
     const prompt = withPreloadedSkills('Base.', ['linked'], [skillsRoot])
     expect(prompt).not.toContain('ESCAPED_BODY')
     expect(prompt).toContain('not found')
+    rmSync(base, { recursive: true, force: true })
   })
 })

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -729,3 +729,19 @@ describe('resolveModelAlias', () => {
     expect(resolveModelAlias('inherit', available)).toBeUndefined()
   })
 })
+
+describe('preloaded skill symlink confinement', () => {
+  it('refuses a skill directory that symlinks outside the skills root', () => {
+    const outside = join(fakeHome.path, 'outside')
+    mkdirSync(outside, { recursive: true })
+    writeFileSync(join(outside, 'SKILL.md'), 'ESCAPED_BODY')
+    const skillsRoot = join(fakeHome.path, '.claude', 'skills')
+    mkdirSync(skillsRoot, { recursive: true })
+    symlinkSync(outside, join(skillsRoot, 'linked'))
+
+    // The name passes the stem pattern; only resolving the link catches this.
+    const prompt = withPreloadedSkills('Base.', ['linked'], [skillsRoot])
+    expect(prompt).not.toContain('ESCAPED_BODY')
+    expect(prompt).toContain('not found')
+  })
+})


### PR DESCRIPTION
From a full-project scan. Two of these are trust bypasses that falsify claims SECURITY.md already makes, and both were verified by probe against the real extensions.

## Trust bypasses

- **A repository whose only Claude config is `.claude/skills` or `.claude/commands` was approved without ever asking** (internal/project-approval.ts). Neither path was in the claude-shaped trigger list, and pi's own trust check ignores both, so the short-circuit meant for a project with nothing to gate fired on a project with plenty: the skill names and descriptions reached the system prompt and the commands registered, with no dialog anywhere. Both are now triggers.
- **MCP per-server consent could self-approve** (mcp.ts). `enabledMcpjsonServers` and `enableAllProjectMcpServers` were read from the project's `settings.local.json` on the premise that the repository does not control it. That is a gitignore convention, not enforcement: a repository can commit one, and the consented servers connected *before* the approval check, so a hostile repo could spawn a server whose `command` runs on connect even after the user declined the trust prompt. Consent from inside the project now counts only once the project itself is approved; the user's own settings file still stands alone, and a repo may still restrict itself further through the deny list. Two tests that pinned the bypass as intended are rewritten, and a new test asserts a declined project connects nothing.

## Supply chain

- **The publish workflow's dispatch recovery path checked out the default branch** while its own comment claimed the version guard made that safe. It does not: the guard compares version strings and main carries the same version until the next bump, so a dispatch after any post-release merge would publish untagged content under the tag, with the Sigstore attestation and npm provenance naming the wrong commit. The build now checks out the tag.

## Documentation that overstated behavior

`model` frontmatter for commands is parsed but not applied; SECURITY.md's trust table omitted commands and skills; the README listed three of seven `internal/` modules; the subagent README promised `confirmProjectAgents: false` disables the prompt unconditionally; the plan-mode README documented the prose fallback as the primary flow rather than the `plan_mode_complete` tool.

Full gate green: 976 tests.