### PR TITLE
Survive a failed todo call and a background run outliving its session

### DIFF
--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -629,7 +629,14 @@ async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConf
   const id = startBackgroundRun(agent.name, task, { command: invocation.command, args: invocation.args, cwd: params.cwd ?? defaultCwd }, (run) => {
     removeTmpPrompt(tmpPrompt)
     pi.events.emit(SUBAGENT_CHANNEL, { phase: 'stop', agentType: run.agent, agentId: run.id })
-    pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
+    // The run outlives the session that started it, and every pi call throws once
+    // that session is disposed; an escaping error here would reach Node as an
+    // uncaughtException and take the process down with it.
+    try {
+      pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
+    } catch {
+      // the session that asked for this run is gone; nothing left to notify
+    }
   })
   if (id === null) {
     // Lost the cap race to a parallel batch: the atomic check inside startBackgroundRun refused.
@@ -1102,7 +1109,11 @@ function renderParallelResult(results: SingleResult[], expanded: boolean, theme:
 
 export default function subagentExtension(pi: ExtensionAPI) {
   const notifyBackgroundCompletion = (run: { id: string; agent: string; state: string; turns: number; output?: string }): void => {
-    pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
+    try {
+      pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
+    } catch {
+      // same as above: the session that started the run may already be gone
+    }
   }
 
   // Claude surfaces each agent's description so the model can pick one autonomously.

--- a/extensions/todo.ts
+++ b/extensions/todo.ts
@@ -335,8 +335,11 @@ export default function todoExtension(pi: ExtensionAPI) {
       const msg = entry.message
       if (msg.role !== 'toolResult' || msg.toolName !== TOOL_NAME) continue
 
-      const details = msg.details as (Omit<TodoDetails, 'todos'> & { todos: LegacyTodo[] }) | undefined
-      if (details) {
+      const details = msg.details as (Omit<TodoDetails, 'todos'> & { todos?: LegacyTodo[] }) | undefined
+      // pi persists a failed tool call as `details: {}`, which is truthy: a rejected
+      // or blocked todo call would otherwise throw here and break replay for the rest
+      // of the session, losing the list on every resume, fork and compaction.
+      if (Array.isArray(details?.todos)) {
         replayTodos = details.todos.map(normalizeTodo)
         replayNextId = details.nextId
       }

--- a/tests/todo-more.test.ts
+++ b/tests/todo-more.test.ts
@@ -687,3 +687,13 @@ describe('todo tool argument validation', () => {
     expect(result.details?.todos).toEqual([{ id: 1, text: 'second', status: 'pending' }])
   })
 })
+
+describe('replay with a failed todo call', () => {
+  it('keeps replaying the list when an errored result is on the branch', async () => {
+    const h = setup()
+    // pi persists a rejected or blocked call as details: {}, which is truthy; the
+    // list must survive it rather than the replay throwing for the rest of the session.
+    const entries = [resultEntry([{ id: 1, text: 'kept', done: false }], 2), { type: 'message', message: { role: 'toolResult', toolName: 'todo', details: {} } }]
+    await expect(h.fire('session_start', {}, branchCtx(entries as never, fakeUI()))).resolves.not.toThrow()
+  })
+})


### PR DESCRIPTION
The two crash-level findings from the full-project scan. Both were verified against the real runtime, and the todo fix is mutation-checked.

- **One failed `todo` call permanently broke replay** (todo.ts). pi persists a rejected, blocked or aborted tool call as `details: {}`, which is truthy, so the replay mapped over an undefined `todos` array and threw. From then on the list was lost on every resume, fork and compaction, and the handler died before the overlay updated. Replay now requires an actual array; reverting the guard fails the new test.
- **A background subagent finishing after a session switch killed pi** (subagent/index.ts). Every pi call throws once the owning session is disposed, and the completion notification runs from the child's `close` listener with no awaiter, so the error reached Node as an `uncaughtException` and the process exited. Both notification paths now tolerate a session that is already gone.

Note the shape these share with the statusline crash fixed in #72: work that outlives the session which started it, touching a context that throws after disposal. That is worth remembering as a class rather than three separate bugs.