### PR TITLE
Make a command's allowed-tools actually restrict its turn

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -61,6 +61,14 @@ export function collectCommands(dirs: string[]): DiscoveredCommand[] {
 
 export default function commandsExtension(pi: ExtensionAPI) {
   const registered = new Set<string>()
+  /** Tool set to put back once the turn a restricted command drove has ended. */
+  let pendingRestore: string[] | undefined
+
+  pi.on('turn_end', async () => {
+    if (!pendingRestore) return
+    pi.setActiveTools(pendingRestore)
+    pendingRestore = undefined
+  })
 
   async function runCommand(parsed: ParsedCommand, args: string, ctx: ExtensionCommandContext): Promise<void> {
     const withArgs = substituteArgs(parsed.body, args)
@@ -73,17 +81,16 @@ export default function commandsExtension(pi: ExtensionAPI) {
       return { stdout: result.stdout, stderr: result.stderr, code: result.code }
     })
 
-    // allowed-tools restricts the turn the command drives, then the previous set is
-    // restored: the restriction belongs to the command, not to the rest of the session.
-    const saved = parsed.allowedTools ? pi.getActiveTools() : undefined
-    if (parsed.allowedTools && saved) {
+    // allowed-tools restricts the turn the command drives, and the previous set is
+    // restored when that turn ends. Restoring inline does not work: sendUserMessage is
+    // fire-and-forget, so the restore would land before the agent ever read the tool
+    // list, leaving the command running with everything enabled.
+    if (parsed.allowedTools) {
+      const saved = pi.getActiveTools()
+      pendingRestore = saved
       pi.setActiveTools(parsed.allowedTools.filter((tool) => saved.includes(tool)))
     }
-    try {
-      pi.sendUserMessage(expanded)
-    } finally {
-      if (saved) pi.setActiveTools(saved)
-    }
+    pi.sendUserMessage(expanded)
   }
 
   pi.on('session_start', async (_event, ctx) => {

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -27,9 +27,23 @@ export interface DiscoveredCommand {
   filePath: string
 }
 
-/** Claude tool names are PascalCase; pi's are lowercase. */
-function normalizeToolName(name: string): string {
-  return name.trim().toLowerCase()
+/** Claude tool names are PascalCase and do not all exist in pi: `Glob` is pi's
+ * `find`. Lowercasing alone left `glob` in the list, and since pi has no tool by
+ * that name the grant was silently dropped when the list was intersected with the
+ * active tools. Shared with the subagent's own frontmatter parsing. */
+const CLAUDE_TOOL_MAP: Record<string, string> = {
+  read: 'read',
+  write: 'write',
+  edit: 'edit',
+  bash: 'bash',
+  grep: 'grep',
+  glob: 'find',
+  ls: 'ls',
+}
+
+export function normalizeToolName(name: string): string {
+  const lower = name.trim().toLowerCase()
+  return CLAUDE_TOOL_MAP[lower] ?? lower
 }
 
 function field(frontmatter: string, key: string): string {

--- a/tests/command-parse.test.ts
+++ b/tests/command-parse.test.ts
@@ -18,11 +18,11 @@ afterEach(() => {
 
 describe('parseCommandFile', () => {
   it('reads the frontmatter Claude documents and keeps the body', () => {
-    const md = ['---', 'description: Ship it', 'argument-hint: [pr]', 'allowed-tools: Bash, Read', 'model: sonnet', 'disable-model-invocation: true', '---', 'Do the thing with $1.'].join('\n')
+    const md = ['---', 'description: Ship it', 'argument-hint: [pr]', 'allowed-tools: Bash, Read, Glob', 'model: sonnet', 'disable-model-invocation: true', '---', 'Do the thing with $1.'].join('\n')
     expect(parseCommandFile(md)).toEqual({
       description: 'Ship it',
       argumentHint: '[pr]',
-      allowedTools: ['bash', 'read'],
+      allowedTools: ['bash', 'read', 'find'],
       model: 'sonnet',
       disableModelInvocation: true,
       body: 'Do the thing with $1.',

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -128,14 +128,20 @@ describe('commands extension', () => {
     expect(s.execCalls[0].shell).toContain('pwd')
   })
 
-  it('restricts tools for the command turn and restores them afterwards', async () => {
+  it('keeps the restriction in place for the turn, restoring only when it ends', async () => {
     const cwd = tempDir()
     writeCommand(cwd, 'safe.md', '---\nallowed-tools: Read\n---\nLook only.')
     const s = setup(cwd)
     await s.handlers.get('session_start')?.({}, s.ctx)
     await s.commands.get('safe')?.handler('', s.ctx)
 
+    // sendUserMessage is fire-and-forget, so restoring inside the handler would put
+    // the full set back before the agent ever read it: the restriction must outlive
+    // the handler and end with the turn.
     expect(s.toolSets[0]).toEqual(['read'])
+    expect(s.activeTools()).toEqual(['read'])
+
+    await s.handlers.get('turn_end')?.({}, s.ctx)
     expect(s.activeTools()).toEqual(['bash', 'read', 'edit', 'write'])
   })
 


### PR DESCRIPTION
`allowed-tools` on a slash command was inert, which matters because the README presents it as a restriction.

- **The restriction now outlives the handler** (commands.ts). `pi.sendUserMessage` is fire-and-forget, so the `finally` block put the full tool set back before the agent ever read the list: a command declaring `allowed-tools: Read` ran with `bash`, `edit` and `write` live. The restore now happens on `turn_end`, which is the point the restriction is meant to end. A mutation check confirms restoring inline fails the new test, and the old test could not catch it because its fake `sendUserMessage` was synchronous, a faked dependency that could not exhibit the defect.
- **Claude's `Glob` maps to pi's `find`** (internal/command-file.ts). Lowercasing alone left the token `glob`, which was then dropped when the list was intersected with the active tools, so a command granting `Glob` silently lost it. The mapping the subagent already used now lives beside the command parsing and is shared by both, removing a drifted duplicate the scan flagged.