### PR TITLE
Give parallel mode the same context, and rebuild a resumed run's prompt

### DIFF
--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -7,6 +7,9 @@
 
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 
 export interface BackgroundRun {
   id: string
@@ -28,6 +31,10 @@ export interface BackgroundSpawn {
   command: string
   args: string[]
   cwd: string
+  /** The --append-system-prompt body, kept so a resume can rebuild the file the
+   * completing run deleted. Without it the resumed child is handed a path that no
+   * longer exists, and pi falls back to using that path as the prompt text. */
+  promptBody?: string
 }
 
 const runs = new Map<string, BackgroundRun>()
@@ -97,13 +104,33 @@ export function resumeBackgroundRun(id: string, task: string, onComplete: (run: 
   const run = runs.get(id)
   if (!run) return 'unknown'
   if (run.state === 'running') return 'still-running'
-  const args = run.spawn.args.map((arg) => (arg.startsWith('Task: ') ? `Task: ${task}` : arg))
+  const args = withRebuiltPrompt(run.spawn).map((arg) => (arg.startsWith('Task: ') ? `Task: ${task}` : arg))
   run.state = 'running'
   run.task = task
   run.output = undefined
   run.exitCode = undefined
   driveRun(run, { ...run.spawn, args }, onComplete)
   return 'resumed'
+}
+
+/** Re-point --append-system-prompt at a fresh file when the original is gone. */
+function withRebuiltPrompt(spawnSpec: BackgroundSpawn): string[] {
+  const flag = spawnSpec.args.indexOf('--append-system-prompt')
+  if (flag === -1 || !spawnSpec.promptBody) return spawnSpec.args
+  const current = spawnSpec.args[flag + 1]
+  if (current && fs.existsSync(current)) return spawnSpec.args
+  try {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-subagent-'))
+    const file = path.join(dir, 'prompt.md')
+    fs.writeFileSync(file, spawnSpec.promptBody, { mode: 0o600 })
+    const rebuilt = [...spawnSpec.args]
+    rebuilt[flag + 1] = file
+    return rebuilt
+  } catch {
+    // Cannot rewrite it: drop the pair rather than hand pi a path it will treat as
+    // prompt text, which would replace the agent persona with a temp path.
+    return spawnSpec.args.filter((_arg, i) => i !== flag && i !== flag + 1)
+  }
 }
 
 export function startBackgroundRun(agent: string, task: string, invocation: BackgroundSpawn, onComplete: (run: BackgroundRun) => void): string | null {

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -626,7 +626,7 @@ async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConf
   }
   args.push(`Task: ${task}`)
   const invocation = getPiInvocation(args)
-  const id = startBackgroundRun(agent.name, task, { command: invocation.command, args: invocation.args, cwd: params.cwd ?? defaultCwd }, (run) => {
+  const id = startBackgroundRun(agent.name, task, { command: invocation.command, args: invocation.args, cwd: params.cwd ?? defaultCwd, promptBody: tmpPrompt ? promptWithSkills : undefined }, (run) => {
     removeTmpPrompt(tmpPrompt)
     pi.events.emit(SUBAGENT_CHANNEL, { phase: 'stop', agentType: run.agent, agentId: run.id })
     // The run outlives the session that started it, and every pi call throws once
@@ -756,6 +756,10 @@ async function runParallelMode(tasks: TaskItemParam[], mode: ModeContext): Promi
       cwd: t.cwd,
       signal,
       onPhase: mode.onPhase,
+      // Same context single and chain mode pass: without these, an agent's skills
+      // preload and its model tier alias silently do nothing in parallel mode only.
+      skillRoots: mode.skillRoots,
+      availableModels: mode.availableModels,
       // Per-task update callback
       onUpdate: (partial) => {
         const live = partial.details?.results[0]

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -1,5 +1,5 @@
 import type { EventEmitter } from 'node:events'
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -698,6 +698,26 @@ describe('resumeBackgroundRun', () => {
     const followUp = spawned.calls[1].args
     expect(followUp[followUp.indexOf('--session-id') + 1]).toBe(sessionId)
     expect(followUp.at(-1)).toBe('Task: second')
+  })
+
+  it('rebuilds the system-prompt file when the finished run deleted it', async () => {
+    const { startBackgroundRun, resumeBackgroundRun } = await loadBackground()
+    const dir = mkdtempSync(join(tmpdir(), 'prompt-'))
+    const promptPath = join(dir, 'prompt.md')
+    writeFileSync(promptPath, 'AGENT PERSONA')
+    const withPrompt = { command: 'pi', args: ['--mode', 'json', '-p', '--no-session', '--append-system-prompt', promptPath, 'Task: first'], cwd: '/w', promptBody: 'AGENT PERSONA' }
+
+    const id = startBackgroundRun('scout', 'first', withPrompt, () => {}) as string
+    spawned.children[0].emit('close', 0)
+    rmSync(dir, { recursive: true, force: true }) // the completing run deletes its temp prompt
+
+    expect(resumeBackgroundRun(id, 'second', () => {})).toBe('resumed')
+    const args = spawned.calls[1].args
+    const rebuilt = args[args.indexOf('--append-system-prompt') + 1]
+    // A path pi cannot read is used as the prompt text itself, replacing the persona.
+    expect(existsSync(rebuilt)).toBe(true)
+    expect(readFileSync(rebuilt, 'utf-8')).toBe('AGENT PERSONA')
+    rmSync(join(rebuilt, '..'), { recursive: true, force: true })
   })
 
   it('refuses to resume a run that is still going, or an unknown id', async () => {


### PR DESCRIPTION
Two shipped features that quietly did nothing in specific paths.

- **Parallel mode omitted `skillRoots` and `availableModels`** (subagent/index.ts) from the options that single and chain mode both pass, so an agent's `skills` preload and its model tier alias silently did nothing there. The same agent file behaved differently purely by which mode invoked it, contradicting the subagent README.
- **Resuming a background run re-spawned a deleted prompt file** (subagent/background.ts). The recorded arguments still carried `--append-system-prompt <path>`, and the completing run had already deleted that file. pi treats an unreadable path as the prompt text itself, so the resumed child's persona became a literal temp path. The prompt body now travels with the run and is written to a fresh file when the original is gone; if that write fails the flag is dropped rather than handing pi a path to use as prompt text. Mutation-checked: the test fails without the rebuild.