### PR TITLE
Look for claude-shaped config up to the repository root

### DIFF
--- a/extensions/internal/project-approval.ts
+++ b/extensions/internal/project-approval.ts
@@ -37,8 +37,25 @@ const CLAUDE_SHAPED = [
   path.join('.pi', 'agents'),
 ]
 
+/** Markers that end the upward walk, matching the subagent's own discovery bound. */
+const ROOT_MARKERS = ['.git', 'package.json']
+
+/** Claude-shaped config anywhere between `cwd` and the repository root.
+ *
+ * The walk matters: agent discovery already searches upward, so starting pi in a
+ * subdirectory of a repository whose `.claude/agents` sits at the root found those
+ * agents while a cwd-only check reported nothing to gate, and the short-circuit
+ * approved the project without ever asking. The bound is the repository root, so a
+ * directory outside any repository never inherits a parent's config. */
 export function hasClaudeShapedConfig(cwd: string): boolean {
-  return CLAUDE_SHAPED.some((entry) => fs.existsSync(path.join(cwd, entry)))
+  let currentDir = cwd
+  while (true) {
+    if (CLAUDE_SHAPED.some((entry) => fs.existsSync(path.join(currentDir, entry)))) return true
+    if (ROOT_MARKERS.some((marker) => fs.existsSync(path.join(currentDir, marker)))) return false
+    const parentDir = path.dirname(currentDir)
+    if (parentDir === currentDir) return false
+    currentDir = parentDir
+  }
 }
 
 export interface ApprovalContext {

--- a/tests/project-approval.test.ts
+++ b/tests/project-approval.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -168,5 +168,32 @@ describe('the trust trigger stays in sync with what the trust-gated extensions c
     const cwd = tempDir()
     writeFileSync(join(cwd, 'CLAUDE.local.md'), 'notes')
     expect(hasClaudeShapedConfig(cwd)).toBe(true)
+  })
+})
+
+describe('hasClaudeShapedConfig walks to the repository root', () => {
+  const tmp = (): string => mkdtempSync(join(tmpdir(), 'shaped-'))
+
+  it('sees config at the repo root when started in a subdirectory', () => {
+    // Agent discovery already walks up, so a cwd-only check approved a project
+    // whose .claude/agents at the root was about to be loaded.
+    const root = tmp()
+    mkdirSync(join(root, '.git'), { recursive: true })
+    mkdirSync(join(root, '.claude', 'agents'), { recursive: true })
+    const sub = join(root, 'src', 'deep')
+    mkdirSync(sub, { recursive: true })
+
+    expect(hasClaudeShapedConfig(sub)).toBe(true)
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('stops at the repository root rather than inheriting a parent', () => {
+    const outer = tmp()
+    mkdirSync(join(outer, '.claude', 'agents'), { recursive: true })
+    const inner = join(outer, 'nested')
+    mkdirSync(join(inner, '.git'), { recursive: true })
+
+    expect(hasClaudeShapedConfig(inner)).toBe(false)
+    rmSync(outer, { recursive: true, force: true })
   })
 })


### PR DESCRIPTION
Agent discovery already walks upward from `cwd` to the repository root, but the trust check only looked at `cwd`. Starting pi in a subdirectory of a repository whose `.claude/agents` lives at the root therefore found those agents while the trust check reported nothing to gate, and the short-circuit meant for a project with nothing to gate approved it without asking.

The consequence was not only the dialog being skipped: the repo-controlled agent descriptions went straight into the system prompt with no prompt anywhere, and a headless run allowed the agents themselves.

The check now walks up, bounded at the repository root by the same markers the subagent's own discovery uses, so a directory outside any repository never inherits a parent's config. Both directions are tested, and a mutation check confirms the cwd-only version fails the new test.