### PR TITLE
Validate hook entries at load instead of failing every tool call

### DIFF
--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -97,8 +97,14 @@ export function loadHooks(files: string[]): HooksConfig {
     } catch {
       continue
     }
-    for (const [event, matchers] of Object.entries(parsed.hooks ?? {})) {
-      if (Array.isArray(matchers)) config[event] = [...(config[event] ?? []), ...matchers]
+    for (const [event, matchers] of Object.entries(parsed?.hooks ?? {})) {
+      if (!Array.isArray(matchers)) continue
+      // Entries are validated here rather than where they run: a hand-edited settings
+      // file that writes `hooks` as an object instead of a list used to throw out of
+      // the tool_call handler, and pi turns that into an error result, so every tool
+      // call for the rest of the session failed with an opaque type error.
+      const usable = matchers.filter((entry) => isUsableMatcher(entry, file, event))
+      if (usable.length > 0) config[event] = [...(config[event] ?? []), ...usable]
     }
   }
   return config
@@ -122,6 +128,26 @@ function exactListApplies(matcher: string, names: readonly string[]): boolean {
       .filter(Boolean),
   )
   return names.some((name) => tokens.has(foldName(name)))
+}
+
+/** A matcher entry pi-code can run: an object whose `hooks` is a list. Anything else
+ * is reported by name and skipped, so one bad entry costs its own hooks, not the
+ * session's tool calls. */
+function isUsableMatcher(entry: unknown, file: string, event: string): entry is HookMatcher {
+  const candidate = entry as HookMatcher | null
+  if (candidate === null || typeof candidate !== 'object') {
+    console.warn(`pi-code-hooks: ignoring a non-object ${event} entry in ${file}`)
+    return false
+  }
+  if (candidate.hooks !== undefined && !Array.isArray(candidate.hooks)) {
+    console.warn(`pi-code-hooks: ignoring ${event} entry in ${file}: "hooks" must be a list`)
+    return false
+  }
+  if (candidate.matcher !== undefined && typeof candidate.matcher !== 'string') {
+    console.warn(`pi-code-hooks: ignoring ${event} entry in ${file}: "matcher" must be a string`)
+    return false
+  }
+  return true
 }
 
 function matcherApplies(matcher: string | undefined, names: readonly string[]): boolean {

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -510,6 +510,42 @@ describe('loadHooks malformed config shapes', () => {
   })
 })
 
+describe('malformed hook config', () => {
+  it('skips an entry whose hooks is not a list, keeping the rest of the event usable', () => {
+    const dir = tempDir('hooks-cfg-')
+    const file = join(dir, 'settings.json')
+    // A plausible hand-edit: one entry as an object instead of a one-element list.
+    writeFileSync(
+      file,
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { matcher: 'Bash', hooks: { type: 'command', command: 'bad' } },
+            { matcher: 'Edit', hooks: [{ command: 'good' }] },
+          ],
+        },
+      }),
+    )
+
+    const config = loadHooks([file])
+    expect(config.PreToolUse).toHaveLength(1)
+    // The whole session used to fail every tool call on this; now it costs one entry.
+    expect(() => matchingCommands(config.PreToolUse, 'bash')).not.toThrow()
+    expect(matchingCommands(config.PreToolUse, 'edit')).toEqual([{ command: 'good' }])
+  })
+
+  it('survives a settings file that is bare null, or a non-string matcher', () => {
+    const dir = tempDir('hooks-cfg-')
+    const nullFile = join(dir, 'null.json')
+    writeFileSync(nullFile, 'null')
+    expect(loadHooks([nullFile])).toEqual({})
+
+    const badMatcher = join(dir, 'matcher.json')
+    writeFileSync(badMatcher, JSON.stringify({ hooks: { PreToolUse: [{ matcher: 42, hooks: [{ command: 'x' }] }] } }))
+    expect(loadHooks([badMatcher]).PreToolUse ?? []).toEqual([])
+  })
+})
+
 describe('hooks extension registration', () => {
   it('subscribes to the lifecycle events it bridges', () => {
     expect(setupExtension().registered).toEqual(['session_start', 'before_agent_start', 'tool_call', 'tool_result', 'input', 'agent_end', 'session_before_compact', 'session_compact', 'session_shutdown'])


### PR DESCRIPTION
A settings file that writes an event's `hooks` as an object rather than a one-element list, a plausible hand-edit, threw a `TypeError` inside the `tool_call` handler. pi converts an extension throw into an error result, so **every tool call for the rest of the session failed** with a message that named neither the file nor the event.

- Entries are now checked as they load. A malformed one is reported by name (file and event) and skipped, so a bad entry costs its own hooks rather than the session's tool calls, and the rest of the event still works.
- A settings file containing bare `null` parses successfully and then threw on property access outside the parse guard; that is handled too.
- A non-string `matcher` is rejected the same way rather than reaching the regex path.

Mutation-checked: removing the validation fails the new test.