### PR TITLE
Bound MCP tool results as a whole, not per content block

### DIFF
--- a/extensions/internal/output-guard.ts
+++ b/extensions/internal/output-guard.ts
@@ -16,10 +16,11 @@ import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from '
  * Trim `text` to a byte budget. `String.slice` counts UTF-16 units, so slicing a CJK
  * string by a byte budget keeps up to three times the bytes asked for; cutting the
  * encoded buffer is exact. A character straddling the cut decodes to U+FFFD.
- * Shorter input comes back whole, so callers need no length check of their own.
+ * Shorter input comes back whole and a negative budget yields nothing, so callers
+ * need no length check of their own.
  */
 export function sliceBytes(text: string, maxBytes: number): string {
-  return Buffer.from(text, 'utf-8').subarray(0, maxBytes).toString('utf-8')
+  return Buffer.from(text, 'utf-8').subarray(0, Math.max(0, maxBytes)).toString('utf-8')
 }
 
 /** Trim `text` to pi's documented tool-output budget, noting what was dropped. */

--- a/extensions/internal/output-guard.ts
+++ b/extensions/internal/output-guard.ts
@@ -12,11 +12,21 @@
 
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from '@earendil-works/pi-coding-agent'
 
+/**
+ * Trim `text` to a byte budget. `String.slice` counts UTF-16 units, so slicing a CJK
+ * string by a byte budget keeps up to three times the bytes asked for; cutting the
+ * encoded buffer is exact. A character straddling the cut decodes to U+FFFD.
+ * Shorter input comes back whole, so callers need no length check of their own.
+ */
+export function sliceBytes(text: string, maxBytes: number): string {
+  return Buffer.from(text, 'utf-8').subarray(0, maxBytes).toString('utf-8')
+}
+
 /** Trim `text` to pi's documented tool-output budget, noting what was dropped. */
 export function capForContext(text: string): string {
   const cut = truncateHead(text, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES })
   if (!cut.truncated) return text
-  const kept = cut.content || text.slice(0, DEFAULT_MAX_BYTES)
+  const kept = cut.content || sliceBytes(text, DEFAULT_MAX_BYTES)
   const capped = `${kept}\n\n[truncated: ${formatSize(cut.totalBytes)} total, ${cut.totalLines} lines]`
   // Just over the budget, the notice can cost more than the trim saves.
   return capped.length < text.length ? capped : text

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -32,7 +32,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
 import { Type } from 'typebox'
 import { MCP_TOOLS_CHANNEL, type McpToolAlias } from './internal/mcp-alias.js'
-import { capForContext, sliceBytes } from './internal/output-guard.js'
+import { capForContext } from './internal/output-guard.js'
 import { isProjectApproved, isProjectApprovedSilently } from './internal/project-approval.js'
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
@@ -246,39 +246,45 @@ export function mapContent(content: McpContentBlock[] | undefined, structured?: 
 }
 
 /**
- * Bound the whole result, not each block. The per-block cap multiplies by the block
- * count, so a server answering with one block per file still injects megabytes.
+ * Bound a result's text as a whole, not each block. The per-block cap multiplies by
+ * the block count, so a server answering with one block per file still injects
+ * megabytes.
  *
- * Text blocks are kept whole while the budget lasts, the one that overruns it is
- * trimmed, and the number omitted after that is stated so the model can tell a
- * truncated set from a complete one. Images pass through unconditionally: base64
- * cut in half is not a smaller image, it is a broken one, and a single screenshot
- * routinely exceeds the whole text budget. They still spend it, so text arriving
- * after an image is trimmed against what is left.
+ * Blocks are kept whole. Each has already been capped on its own, so keeping the one
+ * that crosses the budget bounds the text at roughly a single cap rather than at the
+ * block count times it, and it preserves that block's own truncation notice, which
+ * states how much of it was dropped. Blocks after it are omitted rather than skipped
+ * over, so what reaches the model is a prefix of what the server sent, and the number
+ * omitted is stated so a truncated set is distinguishable from a complete one.
+ *
+ * Images pass through uncut and do not spend the budget: base64 cut short is a broken
+ * image rather than a smaller one, so nothing here can bound them, and charging the
+ * budget for one would only delete the caption that accompanies a screenshot.
  */
 export function capTotal(blocks: ToolContent[]): ToolContent[] {
-  let budget = DEFAULT_MAX_BYTES
   const kept: ToolContent[] = []
+  let spent = 0
+  let full = false
   let dropped = 0
   for (const block of blocks) {
     if (block.type !== 'text') {
       kept.push(block)
-      budget -= Buffer.byteLength(block.data, 'utf-8')
       continue
     }
     const size = Buffer.byteLength(block.text, 'utf-8')
-    if (size <= budget) {
-      kept.push(block)
-      budget -= size
+    // The first text block always goes through: a lone oversized one is better read
+    // truncated, with its own notice, than replaced by a marker saying it existed.
+    if (full || (spent > 0 && spent + size > DEFAULT_MAX_BYTES)) {
+      full = true
+      dropped++
       continue
     }
-    if (budget > 0) {
-      kept.push({ type: 'text', text: `${sliceBytes(block.text, budget)}\n[truncated: tool output budget spent]` })
-      budget = 0
-    }
-    dropped++
+    kept.push(block)
+    spent += size
   }
-  if (dropped > 0) kept.push({ type: 'text', text: `[${dropped} further content block${dropped === 1 ? '' : 's'} omitted: tool output budget spent]` })
+  if (dropped > 0) {
+    kept.push({ type: 'text', text: `[${dropped} further content block${dropped === 1 ? '' : 's'} omitted: tool output budget spent]` })
+  }
   return kept
 }
 
@@ -420,7 +426,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           if (result.isError) {
             details.error = 'tool_error'
             const hint = JSON.stringify(normalizeSchema(tool.inputSchema))
-            content.push({ type: 'text', text: `Tool reported an error. Expected input schema: ${hint}` })
+            content.push({ type: 'text', text: capForContext(`Tool reported an error. Expected input schema: ${hint}`) })
           }
           return { content, details }
         },

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -22,6 +22,7 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
+import { DEFAULT_MAX_BYTES } from '@earendil-works/pi-coding-agent'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 // SSE is deprecated in favour of Streamable HTTP, but the SDK notes servers still on
 // the old spec exist, so this stays as a fallback for the migration period.
@@ -31,7 +32,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
 import { Type } from 'typebox'
 import { MCP_TOOLS_CHANNEL, type McpToolAlias } from './internal/mcp-alias.js'
-import { capForContext } from './internal/output-guard.js'
+import { capForContext, sliceBytes } from './internal/output-guard.js'
 import { isProjectApproved, isProjectApprovedSilently } from './internal/project-approval.js'
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
@@ -222,12 +223,14 @@ export type ToolContent = { type: 'text'; text: string } | { type: 'image'; data
 export function mapContent(content: McpContentBlock[] | undefined, structured?: unknown): ToolContent[] {
   // capForContext every text output, whatever its source: a server can blow the tool-output
   // budget through a resource block, a JSON-stringified block, or the structured fallback,
-  // not only a text block.
+  // not only a text block. The per-block cap alone is not a budget, though: a server
+  // answering with one block per file multiplies it by the block count, so the blocks
+  // are capped again as a whole below.
   const text = (value: string): ToolContent => ({ type: 'text', text: capForContext(value) })
   if (!content || content.length === 0) {
     return [text(structured !== undefined ? JSON.stringify(structured, null, 2) : '(empty result)')]
   }
-  return content.map((block) => {
+  const mapped: ToolContent[] = content.map((block): ToolContent => {
     if (block.type === 'text') {
       return text(block.text ?? '')
     }
@@ -239,6 +242,44 @@ export function mapContent(content: McpContentBlock[] | undefined, structured?: 
     }
     return text(JSON.stringify(block))
   })
+  return capTotal(mapped)
+}
+
+/**
+ * Bound the whole result, not each block. The per-block cap multiplies by the block
+ * count, so a server answering with one block per file still injects megabytes.
+ *
+ * Text blocks are kept whole while the budget lasts, the one that overruns it is
+ * trimmed, and the number omitted after that is stated so the model can tell a
+ * truncated set from a complete one. Images pass through unconditionally: base64
+ * cut in half is not a smaller image, it is a broken one, and a single screenshot
+ * routinely exceeds the whole text budget. They still spend it, so text arriving
+ * after an image is trimmed against what is left.
+ */
+export function capTotal(blocks: ToolContent[]): ToolContent[] {
+  let budget = DEFAULT_MAX_BYTES
+  const kept: ToolContent[] = []
+  let dropped = 0
+  for (const block of blocks) {
+    if (block.type !== 'text') {
+      kept.push(block)
+      budget -= Buffer.byteLength(block.data, 'utf-8')
+      continue
+    }
+    const size = Buffer.byteLength(block.text, 'utf-8')
+    if (size <= budget) {
+      kept.push(block)
+      budget -= size
+      continue
+    }
+    if (budget > 0) {
+      kept.push({ type: 'text', text: `${sliceBytes(block.text, budget)}\n[truncated: tool output budget spent]` })
+      budget = 0
+    }
+    dropped++
+  }
+  if (dropped > 0) kept.push({ type: 'text', text: `[${dropped} further content block${dropped === 1 ? '' : 's'} omitted: tool output budget spent]` })
+  return kept
 }
 
 function isStdio(config: ServerConfig): config is StdioServerConfig {

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -729,6 +729,18 @@ describe('mcp tool execution', () => {
     ])
   })
 
+  it('caps the schema hint on error, so a huge schema cannot escape the output budget', async () => {
+    // The hint is appended after mapContent, so it is the one part of a result the
+    // aggregate cap never sees. The schema is server-controlled.
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'bad argument' }], isError: true })
+    const harness = await registerOne({ type: 'object', properties: { blob: { type: 'string', description: 'x'.repeat(400_000) } } })
+
+    const result = await harness.tools[0].execute('call-1', {})
+
+    const hint = result.content.at(-1)
+    expect(Buffer.byteLength(hint?.text ?? '', 'utf-8')).toBeLessThan(60_000)
+  })
+
   it('propagates a call timeout as a rejection naming the namespaced tool', async () => {
     hoisted.control.callTool = () => new Promise<CallResult>(() => {})
     const harness = await registerOne()
@@ -1164,43 +1176,57 @@ describe('in-project consent cannot self-approve', () => {
 })
 
 describe('aggregate tool-output budget', () => {
-  it('bounds the whole result, not each block, and says what was omitted', () => {
+  const textBytes = (blocks: ReturnType<typeof mapContent>): number => blocks.reduce((sum, block) => sum + (block.type === 'text' ? Buffer.byteLength(block.text, 'utf-8') : 0), 0)
+
+  it('bounds the whole result, not each block, and states how many blocks were omitted', () => {
     // A server answering with one block per file multiplies the per-block cap by the
-    // block count; 200 blocks of 40KB used to reach the model as ~8MB.
-    // Through mapContent, the path production actually uses: asserting capTotal
-    // directly would pass even if mapContent stopped calling it.
+    // block count; 200 blocks of 40KB used to reach the model as ~8MB. Driven through
+    // mapContent because asserting capTotal directly would pass even if mapContent
+    // stopped calling it.
     const blocks = Array.from({ length: 200 }, () => ({ type: 'text', text: 'x'.repeat(40_000) }))
     const capped = mapContent(blocks)
 
-    const total = capped.reduce((sum, block) => sum + (block.type === 'text' ? Buffer.byteLength(block.text, 'utf-8') : 0), 0)
-    expect(total).toBeLessThan(60_000)
-    const last = capped.at(-1)
-    expect(last?.type === 'text' ? last.text : '').toContain('omitted')
+    expect(textBytes(capped)).toBeLessThan(60_000)
+    // One block fits, 199 do not: the count must name the blocks the model never saw.
+    expect(capped.at(-1)).toEqual({ type: 'text', text: '[199 further content blocks omitted: tool output budget spent]' })
   })
 
-  it('never cuts an image, but spends the budget on it so later text is trimmed', () => {
-    // A screenshot routinely exceeds the whole text budget; half a base64 payload is a
-    // broken image, not a smaller one. The text after it must still be bounded.
-    const image = { type: 'image', data: 'A'.repeat(200_000), mimeType: 'image/png' }
-    const capped = mapContent([image, { type: 'text', text: 'y'.repeat(10_000) }])
+  it('reports no omission when the server sent a single oversized block', () => {
+    // That block reaches the model whole; claiming a further block exists invites a
+    // re-call for content that was never sent.
+    const capped = mapContent([{ type: 'text', text: 'x'.repeat(60_000) }])
 
-    expect(capped[0]).toEqual({ type: 'image', data: 'A'.repeat(200_000), mimeType: 'image/png' })
-    expect(capped.some((block) => block.type === 'text' && block.text.startsWith('yyy'))).toBe(false)
+    expect(capped).toHaveLength(1)
+    expect(capped[0]?.type === 'text' && capped[0].text).toContain('[truncated:')
   })
 
-  it('trims the overrunning block by bytes, not by UTF-16 units', () => {
-    // Three bytes per character: slicing by the byte budget with String.slice would
-    // keep three times the budget.
+  it('keeps what reaches the model a prefix of what the server sent', () => {
+    // Skipping an oversized block and resuming with smaller ones would hand the model
+    // blocks 1 and 3 under a notice saying one was omitted, which reads as contiguous.
     const capped = mapContent([
-      { type: 'text', text: 'a'.repeat(40_000) },
-      { type: 'text', text: '\u4f60'.repeat(40_000) },
+      { type: 'text', text: 'first' },
+      { type: 'text', text: 'B'.repeat(60_000) },
+      { type: 'text', text: 'third' },
     ])
-    const total = capped.reduce((sum, block) => sum + (block.type === 'text' ? Buffer.byteLength(block.text, 'utf-8') : 0), 0)
 
-    expect(total).toBeLessThan(60_000)
+    expect(capped.some((block) => block.type === 'text' && block.text === 'third')).toBe(false)
+    expect(capped.at(-1)).toEqual({ type: 'text', text: '[2 further content blocks omitted: tool output budget spent]' })
   })
 
-  it('passes a small result through untouched and keeps image blocks', () => {
+  it('keeps the caption alongside an oversized image', () => {
+    // The screenshot shape: one image over the whole text budget plus a one-line
+    // caption. Charging the image against the budget deleted the only text the model
+    // could act on, and the marker replacing it was larger than the caption itself.
+    const image = { type: 'image', data: 'A'.repeat(200_000), mimeType: 'image/png' }
+    const capped = mapContent([image, { type: 'text', text: 'Clicked the login button at (120,340)' }])
+
+    expect(capped).toEqual([
+      { type: 'image', data: 'A'.repeat(200_000), mimeType: 'image/png' },
+      { type: 'text', text: 'Clicked the login button at (120,340)' },
+    ])
+  })
+
+  it('passes a small result through untouched', () => {
     const blocks = [
       { type: 'text', text: 'small' },
       { type: 'image', data: 'AAA', mimeType: 'image/png' },

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -127,7 +127,7 @@ vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
 }))
 
 const mcpExtension = (await import('../extensions/mcp.ts')).default
-const { splitByPolicy, expandCwd, resolveBearerToken } = await import('../extensions/mcp.ts')
+const { splitByPolicy, expandCwd, resolveBearerToken, mapContent } = await import('../extensions/mcp.ts')
 
 interface RegisteredTool {
   name: string
@@ -1160,5 +1160,54 @@ describe('in-project consent cannot self-approve', () => {
 
     expect(harness.toolNames()).toEqual([])
     expect(hoisted.transports).toEqual([])
+  })
+})
+
+describe('aggregate tool-output budget', () => {
+  it('bounds the whole result, not each block, and says what was omitted', () => {
+    // A server answering with one block per file multiplies the per-block cap by the
+    // block count; 200 blocks of 40KB used to reach the model as ~8MB.
+    // Through mapContent, the path production actually uses: asserting capTotal
+    // directly would pass even if mapContent stopped calling it.
+    const blocks = Array.from({ length: 200 }, () => ({ type: 'text', text: 'x'.repeat(40_000) }))
+    const capped = mapContent(blocks)
+
+    const total = capped.reduce((sum, block) => sum + (block.type === 'text' ? Buffer.byteLength(block.text, 'utf-8') : 0), 0)
+    expect(total).toBeLessThan(60_000)
+    const last = capped.at(-1)
+    expect(last?.type === 'text' ? last.text : '').toContain('omitted')
+  })
+
+  it('never cuts an image, but spends the budget on it so later text is trimmed', () => {
+    // A screenshot routinely exceeds the whole text budget; half a base64 payload is a
+    // broken image, not a smaller one. The text after it must still be bounded.
+    const image = { type: 'image', data: 'A'.repeat(200_000), mimeType: 'image/png' }
+    const capped = mapContent([image, { type: 'text', text: 'y'.repeat(10_000) }])
+
+    expect(capped[0]).toEqual({ type: 'image', data: 'A'.repeat(200_000), mimeType: 'image/png' })
+    expect(capped.some((block) => block.type === 'text' && block.text.startsWith('yyy'))).toBe(false)
+  })
+
+  it('trims the overrunning block by bytes, not by UTF-16 units', () => {
+    // Three bytes per character: slicing by the byte budget with String.slice would
+    // keep three times the budget.
+    const capped = mapContent([
+      { type: 'text', text: 'a'.repeat(40_000) },
+      { type: 'text', text: '\u4f60'.repeat(40_000) },
+    ])
+    const total = capped.reduce((sum, block) => sum + (block.type === 'text' ? Buffer.byteLength(block.text, 'utf-8') : 0), 0)
+
+    expect(total).toBeLessThan(60_000)
+  })
+
+  it('passes a small result through untouched and keeps image blocks', () => {
+    const blocks = [
+      { type: 'text', text: 'small' },
+      { type: 'image', data: 'AAA', mimeType: 'image/png' },
+    ]
+    expect(mapContent(blocks)).toEqual([
+      { type: 'text', text: 'small' },
+      { type: 'image', data: 'AAA', mimeType: 'image/png' },
+    ])
   })
 })

--- a/tests/output-guard.test.ts
+++ b/tests/output-guard.test.ts
@@ -43,6 +43,17 @@ describe('capForContext', () => {
     expect(capped).toContain('truncated')
   })
 
+  it('honors the byte budget for multi-byte text on the single-long-line path', () => {
+    // The fallback slice is the only place the budget is applied by hand. String.slice
+    // counts UTF-16 units, so this 150KB line used to come back at ~150KB against a
+    // 50KB budget: one CJK character per byte of budget rather than one third of one.
+    const oneLongLine = '\u4f60'.repeat(DEFAULT_MAX_BYTES)
+    const capped = capForContext(oneLongLine)
+
+    expect(capped.startsWith('\u4f60')).toBe(true)
+    expect(Buffer.byteLength(capped, 'utf-8')).toBeLessThan(DEFAULT_MAX_BYTES * 1.1)
+  })
+
   it('reports the original size and line count in the notice', () => {
     const capped = capForContext(lines(5000))
     expect(capped).toMatch(/\[truncated: .+ total, 5000 lines\]/)


### PR DESCRIPTION
The MCP tool-output cap was applied per content block instead of per result, so a well-behaved-looking server could inject megabytes into one tool result. Fixes in `mcp` and `output-guard`, each paired with a test that fails without it.

### Unbounded context injection from an MCP server

- **A tool result's text is now capped as a whole (`mcp`).** `capForContext` ran inside the `map` over content blocks, which caps each block at 50KB but multiplies that by the block count. A server answering with one block per file (a `read_multiple_files` shape) returning 200 blocks of 40KB put ~8MB into a single tool result, all of it into the conversation. Blocks are kept whole while the budget lasts, and a final block states how many were omitted so the model can tell a truncated set from a complete one.
- **What reaches the model is a prefix of what the server sent (`mcp`).** Blocks after the budget is spent are omitted rather than skipped over: handing back blocks 1 and 3 under a notice saying one was omitted reads as contiguous content.
- **The server-controlled schema hint is capped too (`mcp`).** On `isError`, the tool's `inputSchema` is JSON-stringified and appended after `mapContent`, so it was the one part of a result no cap saw. A 400KB schema description reached the conversation whole.

### Byte budget applied to UTF-16 units

- **The hand-applied slice now cuts the encoded buffer (`output-guard`).** `capForContext` falls back to a manual slice when `truncateHead` yields nothing, which happens when the first line alone exceeds the budget. `String.slice` counts UTF-16 units, so a 150KB single-line CJK string was sliced to `DEFAULT_MAX_BYTES` *characters* and came back at the full 150KB against a 50KB cap. `sliceBytes` cuts the UTF-8 buffer, so the budget holds regardless of script; a character straddling the cut decodes to U+FFFD.

### Deliberate limits

*Behavior change: a lone oversized block still passes through.* It is bounded by the per-block cap and carries its own notice stating how much was dropped, which is more useful than a marker saying content existed. The text bound is therefore about one cap rather than exactly one.

*Images are never cut and do not spend the budget.* Base64 cut short is a broken image rather than a smaller one, so nothing here can bound them; charging the budget for one would only delete the caption in the usual screenshot-plus-caption result, and the marker replacing that caption is longer than the caption itself.

Each test drives `mapContent` rather than the new helper directly, so it fails if production stops calling the cap. Verified by reverting each guard in turn: the aggregate test reports 8000000 bytes, the single-block test loses its truncation notice, the prefix test keeps a non-contiguous block, the caption test loses the caption, the schema-hint test reports 400121 bytes, and the multi-byte test reports 153600 against a 56320 bound.