### PR TITLE
Stop /reload making plan mode's tool restriction permanent

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ One `pi install` and everything below loads on the next start. `pi list` shows w
 | MCP servers | user `~/.claude.json` (incl. per-project `projects[cwd]` local scope), `~/.pi/agent/mcp.json`; project `.mcp.json`, `.pi/mcp.json` (once approved; `enabledMcpjsonServers`/`disabledMcpjsonServers`/`enableAllProjectMcpServers` honored, consent keys only from non-repo settings); stdio/HTTP/SSE by `type`; `${VAR:-default}` expansion; `MCP_TIMEOUT`/`MCP_TOOL_TIMEOUT`; tools refresh on `list_changed` | `mcp.ts` |
 | Project trust | prompts before loading project config (MCP servers, hooks, agents, rules, output styles, commands, skills) that pi would otherwise trust silently | `internal/project-approval.ts` |
 | Subagents / Task | builtin Explore/Plan/general-purpose agents, `~/.claude/agents` and `~/.pi/agent/agents`, plus project `.claude/agents` and `.pi/agents`; agent roster with descriptions in the system prompt; `skills` preload; background runs with cancel and resume | `subagent/` |
-| Plan mode | `plan_mode_complete` tool, exact tool snapshot/restore | `plan-mode/` |
+| Plan mode | `plan_mode_complete` tool, tool snapshot/restore that survives `/reload` | `plan-mode/` |
 | Todo list | persistent overlay, status machine, compaction-safe | `todo.ts` |
 | Checkpoints / rewind | shadow-repo snapshots; restore overwrites checkpointed files, keeps files created later; 100 per session, repos pruned after 30 days | `git-checkpoint.ts` |
 | Persistent memory | per-project memories, index injected each session within Claude's 200-line/25KB bound; a save that would overflow it reports why | `memory.ts` |

--- a/extensions/plan-mode/index.ts
+++ b/extensions/plan-mode/index.ts
@@ -406,13 +406,18 @@ After completing a step, include a [DONE:n] tag in your response.`,
       // across /reload and cost the session edit and write for good; applying the
       // snapshot when plan mode is off would instead push a stale set over whatever
       // pi has registered since, so it stays scoped to this branch.
-      const recorded = planModeEntry?.data?.savedTools
-      savedTools = recorded ?? pi.getActiveTools()
+      savedTools = planModeEntry?.data?.savedTools ?? pi.getActiveTools()
       pi.setActiveTools(PLAN_MODE_TOOLS.filter((t) => savedTools.includes(t)))
       // --plan enters plan mode without ever toggling, so nothing has persisted yet
       // and a /reload would find no snapshot to restore from. Record it now, while
       // the active set still says what was there before the restriction.
-      if (!recorded) persistState()
+      //
+      // Only with no entry at all: an entry written before this field existed means
+      // the active set has already been through a restore and may be the restriction
+      // itself. Those tools are lost for this process either way, but persisting a
+      // guess would write the loss into the session file, where a later resume would
+      // inherit it instead of starting over.
+      if (!planModeEntry) persistState()
     } else {
       // A prior session in this instance may have shrunk the tool set; undo that when
       // the restored/fresh state is not plan mode.

--- a/extensions/plan-mode/index.ts
+++ b/extensions/plan-mode/index.ts
@@ -61,26 +61,8 @@ export default function planModeExtension(pi: ExtensionAPI): void {
   let planFromTool = false
   let savedTools: string[] = []
 
-  /**
-   * pi carries the active tool names across /reload (agent-session's reload() feeds
-   * getActiveToolNames() into the rebuilt runtime) while this extension is rebuilt with
-   * an empty snapshot, so a restore can find the tool set already restricted. Taking
-   * that as the snapshot would make the restriction permanent: toggling plan mode off
-   * would restore the read-only set and edit/write would be gone for the session. The
-   * tool registry still holds every configured tool, so recover from it instead.
-   *
-   * A session deliberately narrowed to within the plan set is widened back to all tools
-   * by this, which is the price of not being able to tell it apart from a carried-over
-   * restriction. That is recoverable; silently losing edit and write is not.
-   */
-  function toolsToRestore(): string[] {
-    const active = pi.getActiveTools()
-    if (active.some((name) => !PLAN_MODE_TOOLS.includes(name))) return active
-    return pi.getAllTools().map((tool) => tool.name)
-  }
-
   function enterPlanTools(): void {
-    savedTools = toolsToRestore()
+    savedTools = pi.getActiveTools()
     pi.setActiveTools(PLAN_MODE_TOOLS.filter((t) => savedTools.includes(t)))
   }
 
@@ -150,6 +132,11 @@ export default function planModeExtension(pi: ExtensionAPI): void {
       enabled: planModeEnabled,
       todos: todoItems,
       executing: executionMode,
+      // The pre-plan tool set has to survive with the state that caused it to shrink.
+      // /reload rebuilds this extension with an empty snapshot while pi carries the
+      // restricted tools into the new runtime, so a restore has no way to work out
+      // what was active before plan mode unless it was written down here.
+      savedTools,
     })
   }
 
@@ -397,12 +384,13 @@ After completing a step, include a [DONE:n] tag in your response.`,
     const entries = ctx.sessionManager.getEntries()
 
     // Restore persisted state
-    const planModeEntry = findLast(entries, (e: { type: string; customType?: string }) => e.type === 'custom' && e.customType === 'plan-mode') as { data?: { enabled: boolean; todos?: TodoItem[]; executing?: boolean } } | undefined
+    const planModeEntry = findLast(entries, (e: { type: string; customType?: string }) => e.type === 'custom' && e.customType === 'plan-mode') as { data?: { enabled: boolean; todos?: TodoItem[]; executing?: boolean; savedTools?: string[] } } | undefined
 
     if (planModeEntry?.data) {
       planModeEnabled = planModeEntry.data.enabled ?? planModeEnabled
       todoItems = planModeEntry.data.todos ?? todoItems
       executionMode = planModeEntry.data.executing ?? executionMode
+      savedTools = planModeEntry.data.savedTools ?? savedTools
     }
     publishPlanState()
 
@@ -414,7 +402,11 @@ After completing a step, include a [DONE:n] tag in your response.`,
     }
 
     if (planModeEnabled) {
-      enterPlanTools()
+      // Only snapshot when the entry carried nothing: re-reading the active set here
+      // would capture the restriction pi carried across /reload, and restoring it
+      // later would cost the session edit and write for good.
+      if (savedTools.length === 0) savedTools = pi.getActiveTools()
+      pi.setActiveTools(PLAN_MODE_TOOLS.filter((t) => savedTools.includes(t)))
     } else {
       // A prior session in this instance may have shrunk the tool set; undo that when
       // the restored/fresh state is not plan mode.

--- a/extensions/plan-mode/index.ts
+++ b/extensions/plan-mode/index.ts
@@ -406,8 +406,13 @@ After completing a step, include a [DONE:n] tag in your response.`,
       // across /reload and cost the session edit and write for good; applying the
       // snapshot when plan mode is off would instead push a stale set over whatever
       // pi has registered since, so it stays scoped to this branch.
-      savedTools = planModeEntry?.data?.savedTools ?? pi.getActiveTools()
+      const recorded = planModeEntry?.data?.savedTools
+      savedTools = recorded ?? pi.getActiveTools()
       pi.setActiveTools(PLAN_MODE_TOOLS.filter((t) => savedTools.includes(t)))
+      // --plan enters plan mode without ever toggling, so nothing has persisted yet
+      // and a /reload would find no snapshot to restore from. Record it now, while
+      // the active set still says what was there before the restriction.
+      if (!recorded) persistState()
     } else {
       // A prior session in this instance may have shrunk the tool set; undo that when
       // the restored/fresh state is not plan mode.

--- a/extensions/plan-mode/index.ts
+++ b/extensions/plan-mode/index.ts
@@ -61,8 +61,26 @@ export default function planModeExtension(pi: ExtensionAPI): void {
   let planFromTool = false
   let savedTools: string[] = []
 
+  /**
+   * pi carries the active tool names across /reload (agent-session's reload() feeds
+   * getActiveToolNames() into the rebuilt runtime) while this extension is rebuilt with
+   * an empty snapshot, so a restore can find the tool set already restricted. Taking
+   * that as the snapshot would make the restriction permanent: toggling plan mode off
+   * would restore the read-only set and edit/write would be gone for the session. The
+   * tool registry still holds every configured tool, so recover from it instead.
+   *
+   * A session deliberately narrowed to within the plan set is widened back to all tools
+   * by this, which is the price of not being able to tell it apart from a carried-over
+   * restriction. That is recoverable; silently losing edit and write is not.
+   */
+  function toolsToRestore(): string[] {
+    const active = pi.getActiveTools()
+    if (active.some((name) => !PLAN_MODE_TOOLS.includes(name))) return active
+    return pi.getAllTools().map((tool) => tool.name)
+  }
+
   function enterPlanTools(): void {
-    savedTools = pi.getActiveTools()
+    savedTools = toolsToRestore()
     pi.setActiveTools(PLAN_MODE_TOOLS.filter((t) => savedTools.includes(t)))
   }
 

--- a/extensions/plan-mode/index.ts
+++ b/extensions/plan-mode/index.ts
@@ -390,7 +390,6 @@ After completing a step, include a [DONE:n] tag in your response.`,
       planModeEnabled = planModeEntry.data.enabled ?? planModeEnabled
       todoItems = planModeEntry.data.todos ?? todoItems
       executionMode = planModeEntry.data.executing ?? executionMode
-      savedTools = planModeEntry.data.savedTools ?? savedTools
     }
     publishPlanState()
 
@@ -402,10 +401,12 @@ After completing a step, include a [DONE:n] tag in your response.`,
     }
 
     if (planModeEnabled) {
-      // Only snapshot when the entry carried nothing: re-reading the active set here
-      // would capture the restriction pi carried across /reload, and restoring it
-      // later would cost the session edit and write for good.
-      if (savedTools.length === 0) savedTools = pi.getActiveTools()
+      // Restoring into plan mode is the only case the recorded snapshot is for.
+      // Re-reading the active set here would capture the restriction pi carried
+      // across /reload and cost the session edit and write for good; applying the
+      // snapshot when plan mode is off would instead push a stale set over whatever
+      // pi has registered since, so it stays scoped to this branch.
+      savedTools = planModeEntry?.data?.savedTools ?? pi.getActiveTools()
       pi.setActiveTools(PLAN_MODE_TOOLS.filter((t) => savedTools.includes(t)))
     } else {
       // A prior session in this instance may have shrunk the tool set; undo that when

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -492,6 +492,21 @@ describe('session restore', () => {
     expect(reloaded.getActiveTools()).toEqual(['read', 'bash', 'edit', 'plan_mode_complete'])
   })
 
+  it('does not push a recorded snapshot over the live tool set when plan mode is off', async () => {
+    // The snapshot is only meaningful for undoing a restriction. Applying it on a
+    // restore that is not in plan mode would drop whatever pi registered since it was
+    // taken, e.g. an MCP server's tools connecting into the rebuilt session.
+    const s = setup()
+    await s.runCommand('plan')
+    await s.runCommand('plan')
+    const entries = s.appended.filter((e) => e.type === 'plan-mode').map((e) => ({ type: 'custom', customType: 'plan-mode', data: e.data }))
+
+    const reloaded = setup({ activeTools: [...ALL_TOOLS, 'mcp_sonar_search'] })
+    await reloaded.emit('session_start', { reason: 'reload' }, restoreCtx(reloaded, entries))
+
+    expect(reloaded.getActiveTools()).toContain('mcp_sonar_search')
+  })
+
   it('falls back to the active set when the entry predates the recorded snapshot', async () => {
     // Sessions written before savedTools was persisted must still restore something.
     const s = setup()

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -492,6 +492,25 @@ describe('session restore', () => {
     expect(reloaded.getActiveTools()).toEqual(['read', 'bash', 'edit', 'plan_mode_complete'])
   })
 
+  it('records the snapshot for a --plan session, which never toggles', async () => {
+    // The flag enters plan mode at session_start with no entry to restore from, so
+    // without a write here a /reload has nothing but the restricted active set to
+    // infer from, and the next persist cements that loss into the session file.
+    const s = setup({ flag: true })
+    await s.emit('session_start', {}, restoreCtx(s, []))
+    const entries = s.appended.filter((e) => e.type === 'plan-mode').map((e) => ({ type: 'custom', customType: 'plan-mode', data: e.data }))
+
+    const reloaded = setup({ flag: true, activeTools: afterReload(s.getActiveTools()) })
+    await reloaded.emit('session_start', { reason: 'reload' }, restoreCtx(reloaded, entries))
+    // A restore that already had a snapshot has nothing new to say; writing one per
+    // restore would grow the session file for every reload.
+    expect(reloaded.appended.filter((e) => e.type === 'plan-mode')).toEqual([])
+
+    await reloaded.runCommand('plan')
+    expect(reloaded.getActiveTools()).toContain('edit')
+    expect(reloaded.getActiveTools()).toContain('write')
+  })
+
   it('does not push a recorded snapshot over the live tool set when plan mode is off', async () => {
     // The snapshot is only meaningful for undoing a restriction. Applying it on a
     // restore that is not in plan mode would drop whatever pi registered since it was

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -15,7 +15,16 @@ const theme = {
 const assistant = (text: string) => ({ role: 'assistant', content: [{ type: 'text', text }] })
 
 /** Every tool the session has configured, which is what pi's getAllTools reports. */
-const ALL_TOOLS = ['read', 'bash', 'grep', 'find', 'ls', 'question', 'plan_mode_complete', 'edit', 'write']
+const ALL_TOOLS = ['read', 'bash', 'grep', 'find', 'ls', 'question', 'plan_mode_complete', 'edit', 'write', 'todo', 'memory']
+
+/**
+ * pi's reload() rebuilds the runtime with `activeToolNames: getActiveToolNames()` and
+ * `includeAllExtensionTools: true`, so _refreshToolRegistry force-adds every
+ * extension-registered tool on top of the carried set. The restricted set therefore
+ * comes back with pi-code's own tools mixed in, never as the bare plan subset.
+ */
+const EXTENSION_TOOLS = ['todo', 'memory', 'question', 'plan_mode_complete']
+const afterReload = (active: string[]): string[] => [...new Set([...active, ...EXTENSION_TOOLS])]
 
 /** Fresh extension instance: the extension closes over mutable plan state per registration. */
 function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
@@ -454,19 +463,44 @@ describe('session restore', () => {
   })
 
   it('recovers edit and write when a reload restores plan mode over an already-restricted set', async () => {
-    // pi's reload() feeds getActiveToolNames() into the rebuilt runtime, so the new
-    // extension instance sees the restricted set with no snapshot of its own. Taking
-    // that as the snapshot made the restriction permanent for the session.
+    // The new extension instance has no snapshot of its own, and the set pi hands it
+    // is the restriction plus every extension tool: nothing in it says edit and write
+    // were ever active. Reading it as the snapshot lost them for the whole session.
     const s = setup()
     await s.runCommand('plan')
     const entries = s.appended.filter((e) => e.type === 'plan-mode').map((e) => ({ type: 'custom', customType: 'plan-mode', data: e.data }))
 
-    const reloaded = setup({ activeTools: s.getActiveTools() })
+    const reloaded = setup({ activeTools: afterReload(s.getActiveTools()) })
     await reloaded.emit('session_start', { reason: 'reload' }, restoreCtx(reloaded, entries))
     await reloaded.runCommand('plan')
 
     expect(reloaded.getActiveTools()).toContain('edit')
     expect(reloaded.getActiveTools()).toContain('write')
+  })
+
+  it('restores exactly what was active before plan mode, not the whole registry', async () => {
+    // A session that had narrowed itself must come back narrowed: the recovery is the
+    // recorded set, not everything pi has configured.
+    const s = setup({ activeTools: ['read', 'bash', 'edit', 'plan_mode_complete'] })
+    await s.runCommand('plan')
+    const entries = s.appended.filter((e) => e.type === 'plan-mode').map((e) => ({ type: 'custom', customType: 'plan-mode', data: e.data }))
+
+    const reloaded = setup({ activeTools: afterReload(s.getActiveTools()) })
+    await reloaded.emit('session_start', { reason: 'reload' }, restoreCtx(reloaded, entries))
+    await reloaded.runCommand('plan')
+
+    expect(reloaded.getActiveTools()).toEqual(['read', 'bash', 'edit', 'plan_mode_complete'])
+  })
+
+  it('falls back to the active set when the entry predates the recorded snapshot', async () => {
+    // Sessions written before savedTools was persisted must still restore something.
+    const s = setup()
+    const entries = [{ type: 'custom', customType: 'plan-mode', data: { enabled: true, todos: [], executing: false } }]
+    await s.emit('session_start', {}, restoreCtx(s, entries))
+
+    expect(s.getActiveTools()).not.toContain('write')
+    await s.runCommand('plan')
+    expect(s.getActiveTools()).toContain('write')
   })
 
   it('does not carry plan state into a fresh session with no plan entry', async () => {

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -14,6 +14,9 @@ const theme = {
 
 const assistant = (text: string) => ({ role: 'assistant', content: [{ type: 'text', text }] })
 
+/** Every tool the session has configured, which is what pi's getAllTools reports. */
+const ALL_TOOLS = ['read', 'bash', 'grep', 'find', 'ls', 'question', 'plan_mode_complete', 'edit', 'write']
+
 /** Fresh extension instance: the extension closes over mutable plan state per registration. */
 function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
   const handlers = new Map<string, Handler>()
@@ -24,12 +27,15 @@ function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
   const userMessages: string[] = []
   const appended: Array<{ type: string; data: unknown }> = []
   const emitted: Array<{ channel: string; data: unknown }> = []
-  let activeTools = options.activeTools ?? ['read', 'bash', 'grep', 'find', 'ls', 'question', 'plan_mode_complete', 'edit', 'write']
+  let activeTools = options.activeTools ?? [...ALL_TOOLS]
 
   const pi = {
     registerFlag: () => {},
     getFlag: () => options.flag,
     getActiveTools: () => activeTools,
+    // The real getAllTools reads the tool-definition registry, so the active-tool
+    // restriction does not narrow it.
+    getAllTools: () => ALL_TOOLS.map((name) => ({ name })),
     setActiveTools: (next: string[]) => {
       activeTools = next
     },
@@ -445,6 +451,22 @@ describe('session restore', () => {
     const s2 = setup()
     await s2.emit('session_start', {}, restoreCtx(s2, entries))
     expect(s2.getActiveTools()).toContain('write')
+  })
+
+  it('recovers edit and write when a reload restores plan mode over an already-restricted set', async () => {
+    // pi's reload() feeds getActiveToolNames() into the rebuilt runtime, so the new
+    // extension instance sees the restricted set with no snapshot of its own. Taking
+    // that as the snapshot made the restriction permanent for the session.
+    const s = setup()
+    await s.runCommand('plan')
+    const entries = s.appended.filter((e) => e.type === 'plan-mode').map((e) => ({ type: 'custom', customType: 'plan-mode', data: e.data }))
+
+    const reloaded = setup({ activeTools: s.getActiveTools() })
+    await reloaded.emit('session_start', { reason: 'reload' }, restoreCtx(reloaded, entries))
+    await reloaded.runCommand('plan')
+
+    expect(reloaded.getActiveTools()).toContain('edit')
+    expect(reloaded.getActiveTools()).toContain('write')
   })
 
   it('does not carry plan state into a fresh session with no plan entry', async () => {

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -511,6 +511,18 @@ describe('session restore', () => {
     expect(reloaded.getActiveTools()).toContain('write')
   })
 
+  it('does not write a guessed snapshot over an entry that predates the field', async () => {
+    // Upgrading pi-code mid-session then reloading: the entry says plan mode is on but
+    // carries no snapshot, and the active set is already the restriction. Persisting
+    // what it sees would cement the loss into the session file for every later resume.
+    const s = setup({ activeTools: afterReload(['read', 'bash', 'plan_mode_complete']) })
+    const entries = [{ type: 'custom', customType: 'plan-mode', data: { enabled: true, todos: [], executing: false } }]
+
+    await s.emit('session_start', { reason: 'reload' }, restoreCtx(s, entries))
+
+    expect(s.appended.filter((e) => e.type === 'plan-mode')).toEqual([])
+  })
+
   it('does not push a recorded snapshot over the live tool set when plan mode is off', async () => {
     // The snapshot is only meaningful for undoing a restriction. Applying it on a
     // restore that is not in plan mode would drop whatever pi registered since it was


### PR DESCRIPTION
Plan mode restricts the session to seven read-only tools and restores the previous set when it is switched off. Across `/reload` that restore handed back the restricted set, so `edit` and `write` were lost for the rest of the session.

### Permanent loss of edit and write

- **The pre-plan tool set is recorded in the session entry that plan mode already writes (`plan-mode`).** pi's `reload()` passes `getActiveToolNames()` into the rebuilt runtime *and* `includeAllExtensionTools: true`, so `_refreshToolRegistry` force-adds every extension tool on top of the carried restriction. The extension itself is rebuilt with an empty snapshot, so on restore it re-read the active set — the seven plan tools plus `todo`, `memory`, `question` and the rest — and took that as the pre-plan set. Toggling plan mode off then set the active tools to that, and `edit` and `write` were gone with no way back short of another restart. `persistState()` now writes `savedTools` alongside the state that caused the restriction, and the restore reads it back instead of inferring it from a set that no longer says what was active.
- **`--plan` records its snapshot too (`plan-mode`).** The flag enters plan mode at `session_start` and never toggles, so nothing was persisted and a `/reload` before any toggle fell through to the same inference. Worse, the next `persistState()` wrote that restricted set into the session file as `savedTools`, cementing the loss for every later restore. The snapshot is written on the restore that captures it, and only then, so a restore that already has one appends nothing.
- **The snapshot is applied only when restoring into plan mode (`plan-mode`).** Reading it unconditionally made a restore with plan mode *off* push a stale set over the live tools, dropping anything registered since it was taken — an MCP server connecting into the rebuilt session lost its tools on the next `/reload`.

Verified against the real SDK (`createAgentSession` + `DefaultResourceLoader`, the real extension, the real `/plan` command and a real `session.reload()`): `[read, bash, edit, write, plan_mode_complete, todo]` at startup, `[read, bash, plan_mode_complete]` in plan mode and after reload, and the full set back on toggling off. The `savedTools` array round-trips the session store unchanged, including through the on-disk path.

Each behavior is pinned by mutation: reverting the entry read fails the two recovery tests, removing the flag-path write fails the `--plan` test, and applying the snapshot outside the plan-mode branch fails the MCP-tool test.

The README row claiming "exact tool snapshot/restore" is updated, since the restore is a recorded snapshot rather than a live read.