### PR TITLE
Stop a background run outliving its session from exiting pi

### DIFF
--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -190,6 +190,10 @@ function driveRun(run: BackgroundRun, invocation: BackgroundSpawn, onComplete: (
   proc.stdout.on('data', (data) => {
     stdout += data.toString()
   })
+  // An 'error' on a stream with no listener is rethrown by EventEmitter, and this one
+  // belongs to a detached child, so a pipe read failure would exit pi the same way an
+  // unguarded completion would. The foreground runner guards its streams the same way.
+  proc.stdout.on('error', () => {})
   proc.on('close', (code) => {
     const { text, turns } = parseFinalOutputFromJsonl(stdout)
     run.kill = undefined

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -175,7 +175,17 @@ function driveRun(run: BackgroundRun, invocation: BackgroundSpawn, onComplete: (
   const complete = (): void => {
     if (completed) return
     completed = true
-    onComplete(run)
+    // A run outlives the session that started it, and pi's loader wires assertActive()
+    // into every runtime call, so notifying a disposed session throws. This fires from
+    // the child's 'close'/'error' listener, where nothing upstream catches: an escaping
+    // error reaches Node as an uncaughtException and takes pi down with it. The run
+    // state is already recorded by this point, so there is nothing to do but drop the
+    // notification for a session that is no longer there to receive it.
+    try {
+      onComplete(run)
+    } catch {
+      // the session that asked for this run is gone
+    }
   }
   proc.stdout.on('data', (data) => {
     stdout += data.toString()

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -628,15 +628,11 @@ async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConf
   const invocation = getPiInvocation(args)
   const id = startBackgroundRun(agent.name, task, { command: invocation.command, args: invocation.args, cwd: params.cwd ?? defaultCwd, promptBody: tmpPrompt ? promptWithSkills : undefined }, (run) => {
     removeTmpPrompt(tmpPrompt)
+    // Both calls throw once the session that started the run is disposed; driveRun
+    // catches for the whole callback, so neither can escape into the child's close
+    // listener and become an uncaughtException.
     pi.events.emit(SUBAGENT_CHANNEL, { phase: 'stop', agentType: run.agent, agentId: run.id })
-    // The run outlives the session that started it, and every pi call throws once
-    // that session is disposed; an escaping error here would reach Node as an
-    // uncaughtException and take the process down with it.
-    try {
-      pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
-    } catch {
-      // the session that asked for this run is gone; nothing left to notify
-    }
+    pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
   })
   if (id === null) {
     // Lost the cap race to a parallel batch: the atomic check inside startBackgroundRun refused.
@@ -1113,11 +1109,8 @@ function renderParallelResult(results: SingleResult[], expanded: boolean, theme:
 
 export default function subagentExtension(pi: ExtensionAPI) {
   const notifyBackgroundCompletion = (run: { id: string; agent: string; state: string; turns: number; output?: string }): void => {
-    try {
-      pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
-    } catch {
-      // same as above: the session that started the run may already be gone
-    }
+    // Runs through driveRun's guard, same as the background-mode callback above.
+    pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
   }
 
   // Claude surfaces each agent's description so the model can pick one autonomously.

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -487,6 +487,22 @@ describe('cancelBackgroundRun', () => {
 describe('startBackgroundRun', () => {
   const invocation = { command: 'pi', args: ['--mode', 'json'], cwd: '/work/dir' }
 
+  it('survives a completion callback that throws because the session was disposed', async () => {
+    // pi's loader wires assertActive() into events.emit and sendMessage, so every call
+    // in the completion path throws once the session that started the run is gone (a
+    // /new, /resume, /fork or /reload while it was still running). This runs from the
+    // child's close listener, where an escaping error reaches Node as an
+    // uncaughtException and exits pi.
+    const { startBackgroundRun, backgroundStatusText } = await loadBackground()
+    startBackgroundRun('scout', 'survey', invocation, () => {
+      throw new Error('This extension ctx is stale after session replacement or reload.')
+    })
+
+    expect(() => spawned.children[0].emit('close', 0)).not.toThrow()
+    // The run itself still finished; only the notification is lost.
+    expect(backgroundStatusText()).toContain('done')
+  })
+
   it('returns a bg- prefixed id built from a uuid prefix', async () => {
     const { startBackgroundRun } = await loadBackground()
 

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -493,14 +493,28 @@ describe('startBackgroundRun', () => {
     // /new, /resume, /fork or /reload while it was still running). This runs from the
     // child's close listener, where an escaping error reaches Node as an
     // uncaughtException and exits pi.
-    const { startBackgroundRun, backgroundStatusText } = await loadBackground()
-    startBackgroundRun('scout', 'survey', invocation, () => {
+    const { startBackgroundRun } = await loadBackground()
+    let seen: { state: string; exitCode?: number } | undefined
+    startBackgroundRun('scout', 'survey', invocation, (run) => {
+      // Snapshot before throwing: reading the registry after the listener returns
+      // would pass even if the state were written after the callback.
+      seen = { state: run.state, exitCode: run.exitCode }
       throw new Error('This extension ctx is stale after session replacement or reload.')
     })
 
     expect(() => spawned.children[0].emit('close', 0)).not.toThrow()
-    // The run itself still finished; only the notification is lost.
-    expect(backgroundStatusText()).toContain('done')
+    // The run finished and was recorded before the notification was attempted;
+    // only the notification is lost.
+    expect(seen).toEqual({ state: 'done', exitCode: 0 })
+  })
+
+  it('survives a pipe error on the child stdout', async () => {
+    // EventEmitter rethrows an 'error' with no listener, and this stream belongs to a
+    // detached child, so the throw exits pi exactly as an unguarded completion would.
+    const { startBackgroundRun } = await loadBackground()
+    startBackgroundRun('scout', 'survey', invocation, () => {})
+
+    expect(() => spawned.children[0].stdout.emit('error', new Error('EPIPE'))).not.toThrow()
   })
 
   it('returns a bg- prefixed id built from a uuid prefix', async () => {


### PR DESCRIPTION
A background subagent that finished after the user switched sessions took pi down with it. The completion notification runs from the child process's `close` listener, and every pi runtime call throws once the session that started the run is disposed.

### Process exit on a completed background run

- **The completion callback is guarded at the single point both entry paths go through (`subagent/background.ts`).** pi's extension loader wires `runtime.assertActive()` into `events.emit`, `sendMessage` and the rest, and `reload()`/session replacement calls `invalidate()`, so a run still going during `/new`, `/resume`, `/fork` or `/reload` throws `This extension ctx is stale after session replacement or reload` when it finishes. Nothing upstream of the child's `close` listener catches, so the throw reached Node as an `uncaughtException` and exited the process, discarding the run's result at the moment it became available. `driveRun` now catches around `onComplete`, so a disposed session costs the notification rather than the process.
- **The gap was on the line above an existing guard (`subagent/index.ts`).** `sendMessage` was wrapped in the background-mode callback, but the `pi.events.emit(SUBAGENT_CHANNEL, {phase: 'stop'})` immediately before it was not, and the resume path's `notifyBackgroundCompletion` had a guard for `sendMessage` with no equivalent for the callback as a whole. Both call sites now rely on the single guard rather than repeating a partial one.
- **A pipe error on the child's stdout exits pi the same way (`subagent/background.ts`).** `EventEmitter` rethrows an `'error'` emitted with no listener, and this stream belongs to a detached child, so a read failure was an `uncaughtException` too. The foreground runner has guarded its streams since they were added; the background runner never did.

The run's own state is recorded before the callback fires, so a run completing into a dead session is still `done` in the registry. The test snapshots the run inside the callback rather than reading the registry afterwards, so it fails if that ordering is reversed.

Verified against a real child process: with the guard removed the listener produces `uncaughtException: This extension ctx is stale…` and exit 7; with it present the run reports `done (exit 0)`.