### PR TITLE
Translate pi file-tool inputs to Claude file_path in hook payloads

### DIFF
--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -287,6 +287,23 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+/** Pi's built-in file tools name the target parameter `path`; Claude's name it
+ * `file_path`. Hook payloads are Claude-shaped, so built-in file-tool inputs are
+ * translated on the way out, and updatedInput coming back is translated on the way in. */
+const FILE_TOOL_NAMES = new Set(['read', 'write', 'edit'])
+
+export function toClaudeToolInput(toolName: string, input: unknown): unknown {
+  if (!FILE_TOOL_NAMES.has(toolName) || !isRecord(input) || input.file_path !== undefined) return input
+  const { path, ...rest } = input
+  return path === undefined ? input : { ...rest, file_path: path }
+}
+
+export function fromClaudeToolInput(toolName: string, input: unknown): unknown {
+  if (!FILE_TOOL_NAMES.has(toolName) || !isRecord(input) || input.path !== undefined) return input
+  const { file_path, ...rest } = input
+  return file_path === undefined ? input : { ...rest, path: file_path }
+}
+
 /** Claude's updatedInput replaces the whole tool_input, and pi's tool_call contract is
  * in-place mutation, so the target object is emptied and refilled rather than reassigned. */
 function replaceRecord(target: Record<string, unknown>, next: Record<string, unknown>): void {
@@ -302,13 +319,14 @@ function replaceRecord(target: Record<string, unknown>, next: Record<string, unk
 export async function runPreToolUse(config: HooksConfig, toolName: string, toolInput: unknown, runner: HookRunner, claudeName?: string, onSystemMessage?: SystemMessageSink): Promise<HookDecision> {
   const names = claudeName ? [toolName, claudeName] : [toolName]
   for (const command of matchingCommands(config.PreToolUse, names)) {
-    const result = await runner(command.command, { hook_event_name: 'PreToolUse', tool_name: claudeName ?? toolName, tool_input: toolInput }, timeoutMs(command))
+    const result = await runner(command.command, { hook_event_name: 'PreToolUse', tool_name: claudeName ?? toolName, tool_input: toClaudeToolInput(toolName, toolInput) }, timeoutMs(command))
     // A killed hook never reached its verdict, and SIGKILL leaves a null exit code that
     // would otherwise read as a clean allow. Fail closed instead.
     if (result.timedOut) return { block: true, reason: `Hook timed out after ${timeoutMs(command)}ms: ${command.command}` }
     if (onSystemMessage) surfaceSystemMessages([result], onSystemMessage)
     const updated = tryParseJson(result.stdout)?.hookSpecificOutput?.updatedInput
-    if (isRecord(updated) && isRecord(toolInput)) replaceRecord(toolInput, updated)
+    const translated = isRecord(updated) ? fromClaudeToolInput(toolName, updated) : updated
+    if (isRecord(translated) && isRecord(toolInput)) replaceRecord(toolInput, translated)
     const decision = interpretHookResult(result.code, result.stdout, result.stderr)
     if (decision.block) return decision
   }
@@ -463,7 +481,7 @@ export default function hooksExtension(pi: ExtensionAPI) {
       const failCommands = matchingCommands(config.PostToolUseFailure, names)
       if (failCommands.length === 0) return
       const run = boundRunner(ctx, { tool_use_id: event.toolCallId })
-      const failPayload = { hook_event_name: 'PostToolUseFailure', tool_name: alias ?? event.toolName, tool_input: event.input, tool_response: response }
+      const failPayload = { hook_event_name: 'PostToolUseFailure', tool_name: alias ?? event.toolName, tool_input: toClaudeToolInput(event.toolName, event.input), tool_response: response }
       const failResults = await Promise.all(failCommands.map((command) => run(command.command, failPayload, timeoutMs(command))))
       surfaceSystemMessages(failResults, (message) => ctx.ui.notify(message, 'warning'))
       return
@@ -473,7 +491,7 @@ export default function hooksExtension(pi: ExtensionAPI) {
     const payload = {
       hook_event_name: 'PostToolUse',
       tool_name: alias ?? event.toolName,
-      tool_input: event.input,
+      tool_input: toClaudeToolInput(event.toolName, event.input),
       tool_response: response,
     }
     const run = boundRunner(ctx, { tool_use_id: event.toolCallId })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -5,7 +5,7 @@ import { setTimeout as delay } from 'node:timers/promises'
 
 import { describe, expect, it } from 'vitest'
 
-import { type HookRunner, hookFiles, interpretHookResult, loadHooks, matchingCommands, runHookCommand, runPreToolUse } from '../extensions/hooks.ts'
+import { fromClaudeToolInput, type HookRunner, hookFiles, interpretHookResult, loadHooks, matchingCommands, runHookCommand, runPreToolUse, toClaudeToolInput } from '../extensions/hooks.ts'
 
 const tempDir = (): string => mkdtempSync(join(tmpdir(), 'hooks-'))
 
@@ -144,6 +144,45 @@ describe('runPreToolUse', () => {
     }
     await runPreToolUse(config, 'bash', { command: 'git status' }, runner)
     expect(seen).toEqual({ hook_event_name: 'PreToolUse', tool_name: 'bash', tool_input: { command: 'git status' } })
+  })
+
+  it('reports a file-tool path as the Claude file_path field in the payload', async () => {
+    const writeConfig = { PreToolUse: [{ matcher: 'Write|Edit', hooks: [{ command: 'guard.sh' }] }] }
+    let seen: unknown
+    const runner: HookRunner = async (_command, payload) => {
+      seen = payload
+      return { code: 0, stdout: '', stderr: '', timedOut: false }
+    }
+    await runPreToolUse(writeConfig, 'write', { path: 'src/a.ts', content: 'x' }, runner)
+    expect(seen).toEqual({ hook_event_name: 'PreToolUse', tool_name: 'write', tool_input: { file_path: 'src/a.ts', content: 'x' } })
+  })
+
+  it('translates a Claude-shaped updatedInput back to the pi path field', async () => {
+    const writeConfig = { PreToolUse: [{ matcher: 'Write', hooks: [{ command: 'rewrite.sh' }] }] }
+    const runner: HookRunner = async () => ({
+      code: 0,
+      stdout: JSON.stringify({ hookSpecificOutput: { updatedInput: { file_path: 'src/b.ts', content: 'y' } } }),
+      stderr: '',
+      timedOut: false,
+    })
+    const input: Record<string, unknown> = { path: 'src/a.ts', content: 'x' }
+    await runPreToolUse(writeConfig, 'write', input, runner)
+    expect(input).toEqual({ path: 'src/b.ts', content: 'y' })
+  })
+})
+
+describe('tool input translation', () => {
+  it('maps read/write/edit path to file_path and back', () => {
+    expect(toClaudeToolInput('read', { path: 'a.ts', limit: 5 })).toEqual({ file_path: 'a.ts', limit: 5 })
+    expect(fromClaudeToolInput('read', { file_path: 'a.ts', limit: 5 })).toEqual({ path: 'a.ts', limit: 5 })
+  })
+
+  it('leaves non-file tools and already-shaped inputs untouched', () => {
+    expect(toClaudeToolInput('bash', { command: 'ls' })).toEqual({ command: 'ls' })
+    expect(toClaudeToolInput('mcp__x__y', { path: 'a.ts' })).toEqual({ path: 'a.ts' })
+    expect(toClaudeToolInput('write', { file_path: 'a.ts' })).toEqual({ file_path: 'a.ts' })
+    expect(fromClaudeToolInput('write', { path: 'a.ts' })).toEqual({ path: 'a.ts' })
+    expect(toClaudeToolInput('write', 'not-an-object')).toBe('not-an-object')
   })
 })
 


### PR DESCRIPTION
## Why

pi's built-in `read`/`write`/`edit` tools name the target parameter `path`; Claude's hook contract passes it as `file_path`. Because payloads forwarded pi's `tool_input` verbatim, every Claude-written hook that reads `.tool_input.file_path` silently no-ops under pi (e.g. `jq -r '.tool_input.file_path // ""'` in a PostToolUse validation script).

## What

- `toClaudeToolInput`/`fromClaudeToolInput` translate `path` ↔ `file_path` for the built-in file tools only
- Applied to PreToolUse, PostToolUse, and PostToolUseFailure payloads on the way out, and to `hookSpecificOutput.updatedInput` on the way in
- MCP tools (which report their Claude alias) and already-Claude-shaped inputs pass through unchanged

## Verification

`npm run check` (biome + strict tsc + vitest) passes, including new tests for both directions.