### PR TITLE
Parallelize MCP server connections in session_start

### DIFF
--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -458,26 +458,28 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   }
 
   async function connectServers(servers: Record<string, ServerConfig>): Promise<void> {
-    for (const [name, config] of Object.entries(servers)) {
-      // A later scope must not take the name of a server that already connected: it
-      // would evict that client from the map, leaking it at shutdown, and misreport
-      // the earlier server's status.
-      if (clients.has(name)) {
-        console.warn(`pi-code-mcp: skipping duplicate server name ${name}`)
-        continue
-      }
-      warnOnTypelessUrl(name, config)
-      try {
-        const client = await connect(name, config)
-        clients.set(name, client)
-        const tools = await withTimeout(listAllTools(client), connectTimeoutMs(), `list tools ${name}`)
-        const count = registerTools(name, config, client, tools)
-        subscribeToToolChanges(name, config, client)
-        status.set(name, { state: 'connected', tools: count })
-      } catch (error) {
-        status.set(name, { state: `failed: ${error instanceof Error ? error.message : String(error)}`, tools: 0 })
-      }
-    }
+    await Promise.all(
+      Object.entries(servers).map(async ([name, config]) => {
+        // A later scope must not take the name of a server that already connected: it
+        // would evict that client from the map, leaking it at shutdown, and misreport
+        // the earlier server's status.
+        if (clients.has(name)) {
+          console.warn(`pi-code-mcp: skipping duplicate server name ${name}`)
+          return
+        }
+        warnOnTypelessUrl(name, config)
+        try {
+          const client = await connect(name, config)
+          clients.set(name, client)
+          const tools = await withTimeout(listAllTools(client), connectTimeoutMs(), `list tools ${name}`)
+          const count = registerTools(name, config, client, tools)
+          subscribeToToolChanges(name, config, client)
+          status.set(name, { state: 'connected', tools: count })
+        } catch (error) {
+          status.set(name, { state: `failed: ${error instanceof Error ? error.message : String(error)}`, tools: 0 })
+        }
+      }),
+    )
   }
 
   /** Connect the project scope under the per-server policy. Returns whether the scope


### PR DESCRIPTION
## Summary

`connectServers` in `extensions/mcp.ts` connects MCP servers **serially** inside `session_start`, blocking the first turn for ~2s with 3 stdio servers. Parallelizing it cuts that to ~0.6s.

Resolves #85

## Problem

Each stdio server takes 0.5–1.1s to spawn + handshake + list tools (`npx`/`uvx`). The `for` loop awaits each server in turn, so 3 servers cost ~2s of serial wall time — and since `session_start` awaits `connectServers`, the session isn't usable until then.

Measured with `pi -p "reply ok"` (non-interactive session, 3 stdio servers: context7, fetch, open-websearch):

| | serial (1.0.2) | parallel (this PR) |
|---|---|---|
| MCP connect phase completes (log timestamp) | ~2.07s | ~0.64s |
| Full session | 7.0–8.8s | 4.8–5.0s |

The other ~4s is pi startup + model network call, unrelated to this extension.

## Change

`connectServers` loops with `await Promise.all(...)` over `Object.entries(servers)`.

Each server is fully independent: own `Client`, own `clients`/`status` keys, own try/catch (a failing server is recorded in `status` and never rejects the batch). `registered`/`aliases` writes are per unique `<server>_<tool>` names and `pi.registerTool` is synchronous, so there is no shared-state race.

## Test plan

- Extension loads: all 16 pi-code extensions import fine
- Non-interactive session runs end-to-end with all 3 servers connecting (MCP tools registered, no connect warnings in logs)
- `npm run type:check` passes
