### PR TITLE
Restore empty checkpoint snapshots as a no-op and surface shadow init failures

### DIFF
--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -137,10 +137,23 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
     pruneCheckpointRepos(checkpointsRoot, CHECKPOINT_RETENTION_DAYS, shadowDir)
     const check = await pi.exec('git', ['--git-dir', shadowDir, 'rev-parse', '--git-dir'], { cwd: ctx.cwd })
     if (check.code !== 0) {
-      await pi.exec('git', ['init', '--bare', '-b', 'main', shadowDir], { cwd: ctx.cwd })
+      const init = await pi.exec('git', ['init', '--bare', '-b', 'main', shadowDir], { cwd: ctx.cwd })
+      if (init.code !== 0) {
+        // Every later snapshot fails against the missing repo, so without this the
+        // user first learns /rewind is dead at the moment they need it.
+        ctx.ui.notify(`Checkpoints disabled: ${init.stderr.trim() || 'git init failed'}`, 'warning')
+        return
+      }
       await pi.exec('git', ['--git-dir', shadowDir, 'config', 'user.email', 'checkpoint@pi-code'], { cwd: ctx.cwd })
       await pi.exec('git', ['--git-dir', shadowDir, 'config', 'user.name', 'pi-code-checkpoint'], { cwd: ctx.cwd })
     }
+  }
+
+  /** `checkout -f <ref> -- .` errors when the ref's tree holds no files, so an empty
+   * snapshot restores as a no-op rather than vetoing the whole rewind. */
+  async function snapshotIsEmpty(ref: string): Promise<boolean> {
+    const files = await gitShadow(['ls-tree', '-r', '--name-only', ref])
+    return files.code === 0 && files.stdout.trim() === ''
   }
 
   async function snapshot(): Promise<{ ref: string; createdAt: string } | undefined> {
@@ -173,6 +186,10 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
   async function restoreCode(ctx: ExtensionCommandContext, checkpoint: Checkpoint): Promise<boolean> {
     if (!checkpoint.ref) {
       ctx.ui.notify('Checkpoint has no code snapshot; code left untouched', 'warning')
+      return true
+    }
+    if (await snapshotIsEmpty(checkpoint.ref)) {
+      ctx.ui.notify('Checkpoint has no files; code left untouched', 'warning')
       return true
     }
     const result = await gitShadow(['checkout', '-f', checkpoint.ref, '--', '.'])
@@ -248,6 +265,10 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
 
     const choice = await ctx.ui.select('Restore code state?', ['Yes, restore code to that point', 'No, keep current code'])
     if (choice?.startsWith('Yes')) {
+      if (await snapshotIsEmpty(checkpoint.ref)) {
+        ctx.ui.notify('Checkpoint has no files; code left untouched', 'warning')
+        return
+      }
       const result = await gitShadow(['checkout', '-f', checkpoint.ref, '--', '.'])
       ctx.ui.notify(result.code === 0 ? 'Code restored to checkpoint' : `Restore failed: ${result.stderr.trim()}`, result.code === 0 ? 'info' : 'warning')
     }

--- a/tests/git-checkpoint-more.test.ts
+++ b/tests/git-checkpoint-more.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -613,5 +613,54 @@ describe('session_before_fork code restore', () => {
     await t.handlers.get('session_before_fork')?.({ entryId: 'user0001' }, t.makeCtx({ entries: [forkEntry], hasUI: false, answers: [0] }))
 
     expect(t.selects).toEqual([])
+  })
+})
+
+describe('empty snapshots', () => {
+  /** Checkpoint an empty directory, then scaffold a file, as a fresh-project session does. */
+  async function emptyDirCheckpoint(t: Harness): Promise<string> {
+    const empty = mkdtempSync(join(tmpdir(), 'gcm-empty-'))
+    tempDirs.push(empty)
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx({ cwd: empty }))
+    await t.handlers.get('turn_start')?.({ turnIndex: 0 }, t.makeCtx({ cwd: empty }))
+    await t.handlers.get('turn_end')?.({ turnIndex: 0 }, t.makeCtx({ cwd: empty, branch: [userEntry] }))
+    writeFileSync(join(empty, 'scaffolded.txt'), 'new work\n')
+    return empty
+  }
+
+  it('rewinds to an empty snapshot as a no-op instead of failing', async () => {
+    const t = setup()
+    const empty = await emptyDirCheckpoint(t)
+
+    await rewind(t, { answers: [0, 0], branch: [userEntry] })
+
+    expect(t.notifications).toContain('[info] Rewind complete')
+    expect(t.notifications.some((n) => n.includes('restore failed'))).toBe(false)
+    expect(t.navigations).toEqual(['user0001'])
+    expect(existsSync(join(empty, 'scaffolded.txt'))).toBe(true)
+  })
+
+  it('skips the checkout before a fork when the snapshot is empty', async () => {
+    const t = setup()
+    await emptyDirCheckpoint(t)
+
+    await t.handlers.get('session_before_fork')?.({ entryId: 'user0001' }, t.makeCtx({ answers: [0] }))
+
+    expect(t.notifications.some((n) => n.includes('Restore failed'))).toBe(false)
+    expect(t.notifications.some((n) => n.includes('code left untouched'))).toBe(true)
+  })
+})
+
+describe('shadow repo init failure', () => {
+  it('notifies that checkpoints are disabled when the shadow repo cannot be created', async () => {
+    const t = setup()
+    chmodSync(hoisted.home, 0o555)
+    try {
+      await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx())
+    } finally {
+      chmodSync(hoisted.home, 0o755)
+    }
+
+    expect(t.notifications.some((n) => n.startsWith('[warning] Checkpoints disabled:'))).toBe(true)
   })
 })


### PR DESCRIPTION
Rewinding to a checkpoint taken in an empty (or fully gitignored) directory failed outright: checkout -f <ref> -- . errors on an empty tree, and the failure also skipped the conversation half of a combined restore. An empty snapshot now restores as a no-op with a notice, in /rewind and the fork prompt. A failed git init for the shadow repo is now reported once instead of silently disabling checkpoints for the session.