### PR TITLE
Refuse memory index writes when the index cannot be read

### DIFF
--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -93,7 +93,7 @@ export function saveMemory(dir: string, indexPath: string, name: string | undefi
   }
   fs.mkdirSync(dir, { recursive: true })
   fs.writeFileSync(path.join(dir, `${name}.md`), content)
-  fs.writeFileSync(indexPath, upsertIndexLine(index, name, description))
+  writeIndex(indexPath, upsertIndexLine(index, name, description))
   return { content: [{ type: 'text', text: `Saved memory ${name}.` }], details: {} }
 }
 
@@ -150,9 +150,29 @@ const MemoryParams = Type.Object({
 function readIndex(dir: string): string {
   try {
     return fs.readFileSync(path.join(dir, INDEX_FILE), 'utf-8')
+  } catch (error) {
+    // Only a missing file means an empty index. Treating any other failure as empty
+    // lets the next read-modify-write clobber every existing entry.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return ''
+    throw error
+  }
+}
+
+/** For display paths, where a transiently unreadable index should not break the
+ * session; the mutating paths go through readIndex and refuse instead. */
+function readIndexQuietly(dir: string): string {
+  try {
+    return readIndex(dir)
   } catch {
     return ''
   }
+}
+
+/** Replace the index through a rename so a crash mid-write cannot truncate it. */
+function writeIndex(indexPath: string, content: string): void {
+  const tmp = `${indexPath}.${process.pid}.tmp`
+  fs.writeFileSync(tmp, content)
+  fs.renameSync(tmp, indexPath)
 }
 
 export default function memoryExtension(pi: ExtensionAPI) {
@@ -161,14 +181,14 @@ export default function memoryExtension(pi: ExtensionAPI) {
   pi.on('session_start', async (_event, ctx) => {
     migrateLegacyStore(ctx.cwd)
     dir = memoryDir(ctx.cwd)
-    const count = readIndex(dir)
+    const count = readIndexQuietly(dir)
       .split('\n')
       .filter((l) => l.startsWith('- ')).length
     if (count > 0) ctx.ui.notify(`Memory: ${count} memories loaded`, 'info')
   })
 
   pi.on('before_agent_start', async (event) => {
-    const index = readIndex(dir)
+    const index = readIndexQuietly(dir)
     if (!index.trim()) return
     return {
       systemPrompt: `${event.systemPrompt}\n\n## Memory\n\nPersistent memories from earlier sessions (index):\n\n${capIndexForPrompt(index)}\nUse the memory tool with action "read" to load a memory's full content when relevant.`,
@@ -185,7 +205,11 @@ export default function memoryExtension(pi: ExtensionAPI) {
       const indexPath = path.join(dir, INDEX_FILE)
 
       if (params.action === 'save') {
-        return saveMemory(dir, indexPath, name, params.description, params.content)
+        try {
+          return saveMemory(dir, indexPath, name, params.description, params.content)
+        } catch (error) {
+          return { content: [{ type: 'text' as const, text: `Memory save failed: ${error instanceof Error ? error.message : String(error)}. The index was left untouched.` }], details: {} }
+        }
       }
 
       if (params.action === 'read') {
@@ -200,14 +224,22 @@ export default function memoryExtension(pi: ExtensionAPI) {
 
       if (params.action === 'delete') {
         if (!name) return { content: [{ type: 'text' as const, text: 'delete requires name.' }], details: {} }
+        // The index is read before anything is removed: refusing on a failed read
+        // must leave both the memory file and the index as they were.
+        let index: string
+        try {
+          index = readIndex(dir)
+        } catch (error) {
+          return { content: [{ type: 'text' as const, text: `Memory delete failed: ${error instanceof Error ? error.message : String(error)}. Nothing was deleted.` }], details: {} }
+        }
         fs.rmSync(path.join(dir, `${name}.md`), { force: true })
-        const remaining = removeIndexLine(readIndex(dir), name)
-        if (remaining) fs.writeFileSync(indexPath, remaining)
+        const remaining = removeIndexLine(index, name)
+        if (remaining) writeIndex(indexPath, remaining)
         else fs.rmSync(indexPath, { force: true })
         return { content: [{ type: 'text' as const, text: `Deleted memory ${name}.` }], details: {} }
       }
 
-      const index = readIndex(dir)
+      const index = readIndexQuietly(dir)
       return { content: [{ type: 'text' as const, text: index.trim() || 'No memories saved for this project yet.' }], details: {} }
     },
   })

--- a/tests/memory-actions.test.ts
+++ b/tests/memory-actions.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -85,5 +85,59 @@ describe('memory tool actions', () => {
     const result = (await handlers.get('before_agent_start')?.({ systemPrompt: 'BASE' }, {})) as { systemPrompt: string }
     expect(result.systemPrompt).toContain('## Memory')
     expect(result.systemPrompt).toContain('style')
+  })
+})
+
+describe('memory index robustness', () => {
+  const origHome = process.env.HOME
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME
+    else process.env.HOME = origHome
+  })
+
+  function setup() {
+    process.env.HOME = mkdtempSync(join(tmpdir(), 'mem-home-'))
+    const cwd = mkdtempSync(join(tmpdir(), 'mem-proj-'))
+    const handlers = new Map<string, Handler>()
+    let tool: Tool | undefined
+    memoryExtension({
+      on: (name: string, fn: Handler) => handlers.set(name, fn),
+      registerTool: (t: Tool) => {
+        tool = t
+      },
+    } as never)
+    if (!tool) throw new Error('memory tool not registered')
+    return { handlers, tool, cwd, dir: memoryDir(cwd) }
+  }
+
+  const start = async (handlers: Map<string, Handler>, cwd: string) => handlers.get('session_start')?.({}, { cwd, ui: { notify: () => {} } })
+
+  it('refuses to save while the index is unreadable instead of clobbering it', async () => {
+    const { handlers, tool, cwd, dir } = setup()
+    await start(handlers, cwd)
+    await tool.execute('1', { action: 'save', name: 'first', description: 'existing entry', content: 'kept' })
+
+    const indexPath = join(dir, 'MEMORY.md')
+    chmodSync(indexPath, 0o000)
+    const result = (await tool.execute('2', { action: 'save', name: 'second', description: 'new entry', content: 'other' })).content[0].text
+    chmodSync(indexPath, 0o644)
+
+    expect(result).not.toContain('Saved memory')
+    expect(readFileSync(indexPath, 'utf-8')).toContain('- [first](first.md):')
+  })
+
+  it('refuses to delete while the index is unreadable, keeping the memory file', async () => {
+    const { handlers, tool, cwd, dir } = setup()
+    await start(handlers, cwd)
+    await tool.execute('1', { action: 'save', name: 'keep', description: 'to survive', content: 'body' })
+
+    const indexPath = join(dir, 'MEMORY.md')
+    chmodSync(indexPath, 0o000)
+    const result = (await tool.execute('2', { action: 'delete', name: 'keep' })).content[0].text
+    chmodSync(indexPath, 0o644)
+
+    expect(result).not.toContain('Deleted')
+    expect(existsSync(join(dir, 'keep.md'))).toBe(true)
+    expect(readFileSync(indexPath, 'utf-8')).toContain('- [keep](keep.md):')
   })
 })


### PR DESCRIPTION
readIndex treated every failure as an empty index, so a transient EACCES/EMFILE/EBUSY during save rebuilt MEMORY.md with only the new entry, orphaning every other memory, and during delete removed the index entirely. Mutating actions now refuse with the error and change nothing; display paths stay lenient. Index writes go through temp+rename so a crash cannot truncate the file.