### PR TITLE
Stop command substitution consuming dollar signs from arguments and output

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -86,12 +86,12 @@ export default function commandsExtension(pi: ExtensionAPI) {
     // fire-and-forget, so the restore would land before the agent ever read the tool
     // list, leaving the command running with everything enabled.
     if (parsed.allowedTools) {
-      const saved = pi.getActiveTools()
-      const granted = parsed.allowedTools.filter((tool) => saved.includes(tool))
-      // Only the first restriction in a turn knows the unrestricted set; a second
-      // command would otherwise record the first one's narrowed set as the thing to
-      // restore, and the tools the first command dropped would never come back.
-      pendingRestore ??= saved
+      // Only the first restriction in a turn sees the unrestricted set; a second
+      // command must grant and restore against that original set, or its own tools
+      // are intersected away by the first command's narrowing.
+      const original = pendingRestore ?? pi.getActiveTools()
+      pendingRestore = original
+      const granted = parsed.allowedTools.filter((tool) => original.includes(tool))
       // `allowed-tools: []` says no tools, and is honored. A non-empty list that
       // intersects to nothing named only tools pi has none of: that restriction cannot
       // be expressed, and applying it as "no tools" is not what the command asked for.

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -148,16 +148,21 @@ export function splitArgs(args: string): string[] {
   return out
 }
 
-/** Claude's substitutions: `$ARGUMENTS`, `$@`, `$1`..`$n`, `${n:-default}`. An
- * unfilled positional becomes empty rather than leaking its literal token. */
+/** Claude's substitutions: `$ARGUMENTS`, `$@`, `$1`..`$n`, `${n:-default}`, and `\$`
+ * for a literal dollar. An unfilled positional becomes empty rather than leaking its
+ * literal token. One pass with a replacer function: sequential string passes both
+ * interpreted `$&`-style metacharacters in the arguments and re-scanned substituted
+ * text, so `$` sequences the user typed were consumed as tokens. */
 export function substituteArgs(body: string, args: string): string {
   const parts = splitArgs(args)
-  return body
-    .replaceAll(/\$\{(\d+):-([^}]*)\}/g, (_m, index: string, fallback: string) => parts[Number(index) - 1] ?? fallback)
-    .replaceAll(/\$\{ARGUMENTS:-([^}]*)\}/g, (_m, fallback: string) => (args.trim() ? args.trim() : fallback))
-    .replaceAll(/\$ARGUMENTS\b/g, args.trim())
-    .replaceAll('$@', args.trim())
-    .replaceAll(/\$(\d+)/g, (_m, index: string) => parts[Number(index) - 1] ?? '')
+  const all = args.trim()
+  return body.replaceAll(/\\\$|\$\{(\d+):-([^}]*)\}|\$\{ARGUMENTS:-([^}]*)\}|\$ARGUMENTS\b|\$@|\$(\d+)/g, (token, index?: string, fallback?: string, argsFallback?: string, position?: string) => {
+    if (token === '\\$') return '$'
+    if (index !== undefined) return parts[Number(index) - 1] ?? fallback ?? ''
+    if (argsFallback !== undefined) return all || argsFallback
+    if (position !== undefined) return parts[Number(position) - 1] ?? ''
+    return all
+  })
 }
 
 /** `a/b/c.md` becomes Claude's `a:b:c`. */
@@ -239,12 +244,17 @@ export async function expandDynamicContent(body: string, cwd: string, exec: Comm
     bashMatch = bashPattern.exec(body)
   }
 
-  let expanded = body
+  // Splice by recorded position: a textual replace would interpret `$` sequences in
+  // the command's output and could hit an identical fenced copy of the span instead.
+  let expanded = ''
+  let cursor = 0
   for (const entry of commands) {
     const result = await exec(entry.command)
     const output = result.code === 0 ? result.stdout.trimEnd() : `(command failed: ${entry.command})\n${result.stderr.trim() || result.stdout.trim()}`
-    expanded = expanded.replace(entry.span, output)
+    expanded += body.slice(cursor, entry.index) + output
+    cursor = entry.index + entry.span.length
   }
+  expanded += body.slice(cursor)
 
   // Ranges are recomputed: command output can change offsets.
   const fencedAfter = fencedRanges(expanded)

--- a/tests/command-parse.test.ts
+++ b/tests/command-parse.test.ts
@@ -187,3 +187,30 @@ describe('expandDynamicContent', () => {
     expect(out).not.toContain('FILE_BODY')
   })
 })
+
+describe('dollar signs stay literal', () => {
+  it('keeps dollar sequences in arguments untouched', () => {
+    expect(substituteArgs('Fix this: $ARGUMENTS. Thanks.', 'costs $80, not $8')).toBe('Fix this: costs $80, not $8. Thanks.')
+    expect(substituteArgs('all: $ARGUMENTS', "the $' bug")).toBe("all: the $' bug")
+    expect(substituteArgs('all: $@', 'keep $& here')).toBe('all: keep $& here')
+    expect(substituteArgs('list: $ARGUMENTS', 'a $1 b')).toBe('list: a $1 b')
+    expect(substituteArgs('run: $1', "awk '{print $2}' file")).toBe('run: awk')
+  })
+
+  it('leaves a backslash-escaped dollar literal, dropping the backslash', () => {
+    expect(substituteArgs('price \\$1.00 and arg $1', 'x')).toBe('price $1.00 and arg x')
+  })
+
+  it('pastes command output verbatim even when it contains dollar sequences', async () => {
+    const exec = async () => ({ stdout: "IFS=$'\\n' read", stderr: '', code: 0, killed: false })
+    const out = await expandDynamicContent('diff: !`git diff`', tempDir(), exec)
+    expect(out).toBe("diff: IFS=$'\\n' read")
+  })
+
+  it('expands the live span, not an identical fenced example above it', async () => {
+    const body = 'Example:\n```\n!`git status`\n```\nNow really: !`git status`'
+    const exec = async () => ({ stdout: 'CLEAN', stderr: '', code: 0, killed: false })
+    const out = await expandDynamicContent(body, tempDir(), exec)
+    expect(out).toBe('Example:\n```\n!`git status`\n```\nNow really: CLEAN')
+  })
+})

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -202,3 +202,19 @@ describe('commands extension', () => {
     expect(s.commands.size).toBe(0)
   })
 })
+
+describe('allowed-tools with queued commands', () => {
+  it('grants the second command its tools from the pre-restriction set', async () => {
+    // Intersecting against the first command's narrowed set granted nothing, so the
+    // second command ran under the first one's restriction.
+    const cwd = tempDir()
+    writeCommand(cwd, 'a.md', '---\nallowed-tools: Read\n---\nLook.')
+    writeCommand(cwd, 'b.md', '---\nallowed-tools: Bash\n---\nRun.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('a')?.handler('', s.ctx)
+    await s.commands.get('b')?.handler('', s.ctx)
+
+    expect(s.activeTools()).toEqual(['bash'])
+  })
+})


### PR DESCRIPTION
substituteArgs ran five sequential replaceAll passes: string-form replacements interpreted $' and $& in the user's arguments, and later passes re-scanned substituted text, deleting things like dollar amounts ($80 -> empty positional). Now a single pass with a replacer function, plus the documented \$ literal escape. Bang-span output is spliced by recorded index instead of String.replace, which both interpreted $ sequences in stdout and could target an identical fenced example above the live span. Also: a second allowed-tools command in the same turn now grants against the pre-restriction tool set instead of the first command's narrowed one.