### PR TITLE
Release failed MCP clients and track transport closes

### DIFF
--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -482,8 +482,24 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           const count = registerTools(name, config, client, tools)
           subscribeToToolChanges(name, config, client)
           status.set(name, { state: 'connected', tools: count })
+          // A server that dies mid-session would otherwise stay "connected" in /mcp
+          // while every call fails with the SDK's bare "Not connected"; flip the
+          // status and free the name so a later session start can reconnect it.
+          client.onclose = () => {
+            if (clients.get(name) !== client) return
+            clients.delete(name)
+            status.set(name, { state: 'disconnected', tools: 0 })
+          }
         } catch (error) {
           status.set(name, { state: `failed: ${error instanceof Error ? error.message : String(error)}`, tools: 0 })
+          // Connected but failed after (tool listing hung or errored): left in the
+          // map, the client idles its process for the whole session and the
+          // duplicate-name guard blocks the name for every later attempt.
+          const leaked = clients.get(name)
+          if (leaked) {
+            clients.delete(name)
+            void leaked.close().catch(() => {})
+          }
         }
       }),
     )
@@ -503,16 +519,15 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     return true
   }
 
-  let userConnected = false
   let projectConnected = false
 
   pi.on('session_start', async (_event, ctx) => {
     // Connecting spawns processes and opens sockets, so it belongs here rather than in
     // the factory: pi runs the factory for invocations that never start a session.
-    if (!userConnected) {
-      userConnected = true
-      await connectServers(loadUserScope(os.homedir(), ctx.cwd))
-    }
+    // Names still connected are filtered out, so a later session start only retries
+    // servers that failed or whose transport dropped, without duplicate-name warnings.
+    const userServers = Object.fromEntries(Object.entries(loadUserScope(os.homedir(), ctx.cwd)).filter(([name]) => !clients.has(name)))
+    if (Object.keys(userServers).length > 0) await connectServers(userServers)
     // A project .mcp.json can run arbitrary commands on connect, so only honor it once
     // the project is trusted. Per-server settings refine that: disabled servers never
     // connect, servers the user consented to individually connect without the

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -1237,3 +1237,43 @@ describe('aggregate tool-output budget', () => {
     ])
   })
 })
+
+describe('mcp client lifecycle', () => {
+  it('closes and releases a client whose tool listing fails', async () => {
+    hoisted.control.listTools = async () => {
+      throw new Error('boom')
+    }
+    const harness = await setupStarted({ user: { flaky: { command: 'ok' } } })
+
+    expect(await statusLinesOf(harness)).toEqual(['flaky: failed: boom (0 tools)'])
+    // Closed at failure time; a client left in the map would idle its process for
+    // the whole session and block the name for every later scope.
+    expect(hoisted.closed).toHaveLength(1)
+
+    await harness.shutdown()
+    expect(hoisted.closed).toHaveLength(1)
+  })
+
+  it('reconnects a name whose first connection failed after connect', async () => {
+    hoisted.control.listTools = async () => {
+      throw new Error('boom')
+    }
+    const harness = await setupStarted({ user: { flaky: { command: 'ok' } } })
+    withTools([{ name: 'go' }])
+    await harness.sessionStart()
+
+    expect(harness.toolNames()).toEqual(['flaky_go'])
+    expect(await statusLinesOf(harness)).toEqual(['flaky: connected (1 tools)'])
+  })
+
+  it('flips a server to disconnected when its transport closes mid-session', async () => {
+    withTools([{ name: 'go' }])
+    const harness = await setupStarted({ user: { live: { command: 'ok' } } })
+    expect(await statusLinesOf(harness)).toEqual(['live: connected (1 tools)'])
+
+    const client = hoisted.clients.at(-1) as { onclose?: () => void } | undefined
+    client?.onclose?.()
+
+    expect(await statusLinesOf(harness)).toEqual(['live: disconnected (0 tools)'])
+  })
+})


### PR DESCRIPTION
Three related lifecycle gaps in mcp.ts. A client whose tools/list hung or errored stayed in the clients map with its process alive all session, and the duplicate-name guard then blocked the name permanently; the catch now closes and releases it. A server that died mid-session kept showing connected (N tools) in /mcp while every call failed with the SDK's bare Not connected; client.onclose now flips it to disconnected and frees the name. And session_start no longer latches the user scope on first attempt: it retries servers that are not currently connected (connected names are filtered, so healthy sessions are a no-op).