### PR TITLE
Send model.display_name in the statusline payload

### DIFF
--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -104,6 +104,7 @@ export default function statusLine(pi: ExtensionAPI) {
   /** The stdin payload per Claude's documented statusline contract. */
   function buildPayload(ctx: ExtensionContext): Record<string, unknown> {
     const usage = ctx.getContextUsage() ?? { tokens: null, contextWindow: 0, percent: null }
+    const model = ctx.model as { id?: string; name?: string } | undefined
     // Same gate as the config read above: an unapproved project's style is not applied,
     // so reporting it here would describe a style the session is not using.
     const styleName = readActiveStyleName(settingsFiles(ctx.cwd, os.homedir(), projectApproved))
@@ -111,7 +112,9 @@ export default function statusLine(pi: ExtensionAPI) {
       session_id: ctx.sessionManager.getSessionId(),
       cwd: ctx.cwd,
       workspace: { current_dir: ctx.cwd, project_dir: ctx.cwd },
-      model: { id: (ctx.model as { id?: string } | undefined)?.id ?? '' },
+      // Both fields, per Claude's documented contract: published statusline scripts
+      // read .model.display_name and render the literal "null" when it is missing.
+      model: { id: model?.id ?? '', display_name: model?.name ?? model?.id ?? '' },
       cost: { total_cost_usd: sessionCost(ctx) },
       context_window: { context_window_size: usage.contextWindow, used_percentage: usage.percent, total_input_tokens: usage.tokens },
       permission_mode: permissionMode,

--- a/tests/status-line-command.test.ts
+++ b/tests/status-line-command.test.ts
@@ -89,7 +89,7 @@ const setup = (cwd: string) => {
     hasUI: true,
     isProjectTrusted: () => true,
     thinkingLevel: 'high',
-    model: { id: 'gpt-oss:20b' },
+    model: { id: 'gpt-oss:20b', name: 'GPT-OSS 20B' },
     getContextUsage: () => ({ tokens: 1000, contextWindow: 131072, percent: 0.8 }),
     ui: { theme: { fg: (_c: string, t: string) => t }, setStatus: (_k: string, text: string | undefined) => status.push(text), notify: () => {}, confirm: async () => true },
     sessionManager: { getBranch: () => [], getSessionId: () => 'sess-9', getSessionFile: () => '/tmp/sess-9.jsonl' },
@@ -113,6 +113,9 @@ describe('statusLine command contract', () => {
     expect(payload.session_id).toBe('sess-9')
     expect(payload.cwd).toBe(cwd)
     expect((payload.model as { id: string }).id).toBe('gpt-oss:20b')
+    // Claude's documented payload carries both; published statusline scripts read
+    // .model.display_name and rendered the literal string "null" without it.
+    expect((payload.model as { display_name: string }).display_name).toBe('GPT-OSS 20B')
     expect((payload.context_window as { used_percentage: number }).used_percentage).toBe(0.8)
     expect(status.at(-1)).toBe(' CTX 42% | $0.10 ')
   })
@@ -213,5 +216,19 @@ describe('statusLine concurrency and compaction', () => {
     const afterShutdown = hoisted.runs.length
     await vi.advanceTimersByTimeAsync(5000)
     expect(hoisted.runs.length).toBe(afterShutdown)
+  })
+})
+
+describe('statusLine model payload', () => {
+  it('falls back to the model id when pi reports no display name', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'ok', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, { ...ctx, model: { id: 'bare-id' } })
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect((hoisted.runs[0].payload as { model: { display_name: string } }).model.display_name).toBe('bare-id')
   })
 })


### PR DESCRIPTION
The stdin payload only carried model.id, and Claude's own documented statusline example (cited in this file's header) reads .model.display_name, so scripts copied from the docs rendered the literal string null in the footer. Sourced from pi's model name, falling back to the id.