### PR TITLE
Cancel abandoned fetch bodies on redirects and error statuses

### DIFF
--- a/extensions/web.ts
+++ b/extensions/web.ts
@@ -194,6 +194,9 @@ async function fetchText(rawUrl: string, transport = httpFetch): Promise<{ text:
       userAgent: USER_AGENT,
     })
     if (response.status >= 300 && response.status < 400) {
+      // The hop's body is never read; without the cancel its socket stays held
+      // until the 20s abort timeout, once per hop.
+      void response.body?.cancel().catch(() => {})
       const location = response.headers.get('location')
       if (!location) throw new Error(`redirect without location from ${url.hostname}`)
       url = new URL(location, url)
@@ -202,7 +205,10 @@ async function fetchText(rawUrl: string, transport = httpFetch): Promise<{ text:
       if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new Error(`unsupported redirect scheme ${url.protocol} from ${rawUrl}`)
       continue
     }
-    if (!response.ok) throw new Error(`HTTP ${response.status} for ${url}`)
+    if (!response.ok) {
+      void response.body?.cancel().catch(() => {})
+      throw new Error(`HTTP ${response.status} for ${url}`)
+    }
     return { text: await readCapped(response), contentType: response.headers.get('content-type') ?? '' }
   }
   throw new Error(`too many redirects for ${rawUrl}`)

--- a/tests/web-more.test.ts
+++ b/tests/web-more.test.ts
@@ -414,3 +414,33 @@ describe('isPrivateAddress covers special-use ranges', () => {
     expect(isPrivateAddress('199.0.0.1')).toBe(false)
   })
 })
+
+describe('web_fetch releases abandoned bodies', () => {
+  it('cancels the body of a redirect hop instead of holding its socket', async () => {
+    let cancelled = false
+    const stream = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true
+      },
+    })
+    fetchMock.mockResolvedValueOnce(respond(stream, { status: 302, location: '/moved/here' })).mockResolvedValueOnce(respond('arrived', { contentType: 'text/plain' }))
+
+    await setup().fetchUrl('https://example.com/start')
+
+    expect(cancelled).toBe(true)
+  })
+
+  it('cancels the body of an error status before throwing', async () => {
+    let cancelled = false
+    const stream = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true
+      },
+    })
+    fetchMock.mockResolvedValue(respond(stream, { status: 500 }))
+
+    await expect(setup().fetchUrl('https://example.com/broken')).rejects.toThrow('HTTP 500')
+
+    expect(cancelled).toBe(true)
+  })
+})


### PR DESCRIPTION
fetchText moved on from 3xx hops and threw on non-ok statuses without cancelling response.body, so every such response held its socket for the remainder of its 20s abort window. A 5-hop redirect chain kept 5 sockets pinned; repeated fetches in one turn multiplied that.