### PR TITLE
Dedupe context imports only after a successful read

### DIFF
--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -110,11 +110,14 @@ function readImport(target: string, fromDir: string, home: string, allowedRoots:
     return null
   }
   if (seen.has(real)) return null
-  seen.add(real)
   if (!isUnder(real, allowedRoots)) return null
   try {
     // real may be a directory (EISDIR) or vanish after the realpath (ENOENT/EACCES).
-    return { real, body: fs.readFileSync(real, 'utf-8') }
+    const body = fs.readFileSync(real, 'utf-8')
+    // Only a consumed file dedupes: marking a blocked or unreadable target seen
+    // would let one reader's failure suppress the import for a later, allowed one.
+    seen.add(real)
+    return { real, body }
   } catch {
     return null
   }

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -271,3 +271,19 @@ describe('user config is off limits to project context files', () => {
     expect(handler.map((f) => f.body)).toEqual(['project notes'])
   })
 })
+
+describe('blocked imports and dedupe', () => {
+  it('does not let a blocked import suppress the same file for a later allowed reader', () => {
+    // A project context file references a home file it may not read; the user's own
+    // config, processed later with home in its roots, must still get it.
+    const home = tempDir()
+    const project = tempDir()
+    writeFileSync(join(home, 'style.md'), 'STYLE RULES')
+    const seen = new Set<string>()
+
+    expect(collectImports('@~/style.md', project, home, [project], seen)).toEqual([])
+
+    const allowed = collectImports('@~/style.md', home, home, [home], seen)
+    expect(allowed.map((f) => f.body)).toEqual(['STYLE RULES'])
+  })
+})


### PR DESCRIPTION
readImport added a target to the seen set before the allowed-roots check, so a project CLAUDE.md referencing a home file it may not read poisoned the dedupe set and the user's own config, processed later with home in its roots, silently lost the import. The mark now lands only after a successful read.