### PR TITLE
Run matching hooks in parallel and surface spawn failures

### DIFF
--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -78,6 +78,8 @@ export interface HookRunResult {
   stderr: string
   /** The hook was killed at its timeout, so its exit code carries no verdict. */
   timedOut: boolean
+  /** The process errored before delivering a verdict (spawn failure, EIO). */
+  spawnFailed?: boolean
 }
 export type HookRunner = (command: string, payload: unknown, timeoutMs: number, projectDir?: string) => Promise<HookRunResult>
 
@@ -265,7 +267,9 @@ export const runHookCommand: HookRunner = (command, payload, timeoutMs, projectD
       if (stderr.length < MAX_HOOK_OUTPUT) stderr += chunk
     })
     child.on('close', (code) => finish({ code: code ?? 0, stdout, stderr, timedOut: false }))
-    child.on('error', () => finish({ code: 0, stdout, stderr, timedOut: false }))
+    // Marked rather than silently read as a clean run: under fd exhaustion a
+    // deny-list guard that never spawned would otherwise pass as an allow.
+    child.on('error', (error) => finish({ code: 0, stdout, stderr: stderr || error.message, timedOut: false, spawnFailed: true }))
     // A hook that exits without reading stdin (e.g. `exit 2`) closes the pipe first,
     // so ignore EPIPE on this write rather than crashing the host process.
     child.stdin?.on('error', () => {})
@@ -294,21 +298,42 @@ function replaceRecord(target: Record<string, unknown>, next: Record<string, unk
   Object.assign(target, next)
 }
 
-/** Run PreToolUse hooks for a tool; the first blocking verdict wins. For MCP tools the
- * matcher sees both the pi name and the Claude alias, and the payload reports the alias,
- * which is the name a Claude-written hook script expects in tool_name. A hook's
- * hookSpecificOutput.updatedInput replaces the tool input in place before the permission
- * decision applies, and later hooks see the rewritten input in their payload. */
+/** Claude surfaces a hook error notice and the action proceeds; silence would read a
+ * guard that never ran as a clean allow. */
+function surfaceHookFailures(commands: HookCommand[], results: HookRunResult[], notify?: SystemMessageSink): void {
+  if (!notify) return
+  for (const [i, result] of results.entries()) {
+    if (result.spawnFailed) notify(`Hook failed to run: ${commands[i].command}: ${result.stderr.trim() || 'unknown error'}`)
+  }
+}
+
+/** Run PreToolUse hooks for a tool, in parallel as Claude does; the first blocking
+ * verdict in config order wins. For MCP tools the matcher sees both the pi name and
+ * the Claude alias, and the payload reports the alias, which is the name a
+ * Claude-written hook script expects in tool_name. Every hook sees the original
+ * tool input; hookSpecificOutput.updatedInput replaces the input in place as each
+ * hook completes, so with several rewrites the last to finish takes effect, which
+ * is Claude's documented (non-deterministic) behavior. */
 export async function runPreToolUse(config: HooksConfig, toolName: string, toolInput: unknown, runner: HookRunner, claudeName?: string, onSystemMessage?: SystemMessageSink): Promise<HookDecision> {
   const names = claudeName ? [toolName, claudeName] : [toolName]
-  for (const command of matchingCommands(config.PreToolUse, names)) {
-    const result = await runner(command.command, { hook_event_name: 'PreToolUse', tool_name: claudeName ?? toolName, tool_input: toolInput }, timeoutMs(command))
+  const commands = matchingCommands(config.PreToolUse, names)
+  const results = await Promise.all(
+    commands.map((command) =>
+      runner(command.command, { hook_event_name: 'PreToolUse', tool_name: claudeName ?? toolName, tool_input: toolInput }, timeoutMs(command)).then((result) => {
+        const updated = tryParseJson(result.stdout)?.hookSpecificOutput?.updatedInput
+        if (isRecord(updated) && isRecord(toolInput)) replaceRecord(toolInput, updated)
+        return result
+      }),
+    ),
+  )
+  surfaceHookFailures(commands, results, onSystemMessage)
+  for (const [i, result] of results.entries()) {
     // A killed hook never reached its verdict, and SIGKILL leaves a null exit code that
     // would otherwise read as a clean allow. Fail closed instead.
-    if (result.timedOut) return { block: true, reason: `Hook timed out after ${timeoutMs(command)}ms: ${command.command}` }
-    if (onSystemMessage) surfaceSystemMessages([result], onSystemMessage)
-    const updated = tryParseJson(result.stdout)?.hookSpecificOutput?.updatedInput
-    if (isRecord(updated) && isRecord(toolInput)) replaceRecord(toolInput, updated)
+    if (result.timedOut) return { block: true, reason: `Hook timed out after ${timeoutMs(commands[i])}ms: ${commands[i].command}` }
+  }
+  if (onSystemMessage) surfaceSystemMessages(results, onSystemMessage)
+  for (const result of results) {
     const decision = interpretHookResult(result.code, result.stdout, result.stderr)
     if (decision.block) return decision
   }
@@ -343,14 +368,19 @@ function promptContext(stdout: string): string {
   return stdout.trim()
 }
 
-/** Run UserPromptSubmit hooks: the first blocking verdict wins; otherwise their
- * additional context is concatenated for injection ahead of the prompt. */
+/** Run UserPromptSubmit hooks, in parallel as Claude does: the first blocking
+ * verdict in config order wins; otherwise their additional context is concatenated
+ * in config order for injection ahead of the prompt. */
 export async function runUserPromptSubmit(config: HooksConfig, prompt: string, runner: HookRunner, onSystemMessage?: SystemMessageSink): Promise<PromptDecision> {
+  const commands = matchingCommands(config.UserPromptSubmit, 'UserPromptSubmit')
+  const results = await Promise.all(commands.map((command) => runner(command.command, { hook_event_name: 'UserPromptSubmit', prompt }, timeoutMs(command))))
+  surfaceHookFailures(commands, results, onSystemMessage)
+  for (const [i, result] of results.entries()) {
+    if (result.timedOut) return { block: true, reason: `Hook timed out after ${timeoutMs(commands[i])}ms: ${commands[i].command}`, context: '' }
+  }
+  if (onSystemMessage) surfaceSystemMessages(results, onSystemMessage)
   const contexts: string[] = []
-  for (const command of matchingCommands(config.UserPromptSubmit, 'UserPromptSubmit')) {
-    const result = await runner(command.command, { hook_event_name: 'UserPromptSubmit', prompt }, timeoutMs(command))
-    if (result.timedOut) return { block: true, reason: `Hook timed out after ${timeoutMs(command)}ms: ${command.command}`, context: '' }
-    if (onSystemMessage) surfaceSystemMessages([result], onSystemMessage)
+  for (const result of results) {
     const decision = interpretHookResult(result.code, result.stdout, result.stderr)
     if (decision.block) return { block: true, reason: decision.reason, context: '' }
     const context = promptContext(result.stdout)

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -6,7 +6,7 @@ import { PassThrough } from 'node:stream'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import hooksExtension, { type HookRunner, interpretHookResult, loadHooks, matchingCommands, runHookCommand, runPreToolUse } from '../extensions/hooks.ts'
+import hooksExtension, { type HookRunner, interpretHookResult, loadHooks, matchingCommands, runHookCommand, runPreToolUse, runUserPromptSubmit } from '../extensions/hooks.ts'
 
 /**
  * Hook commands must never reach a real shell from this suite, so `spawn` is
@@ -231,14 +231,14 @@ describe('runHookCommand process wiring', () => {
     expect(result.stdout.length).toBeLessThan(1_800_000)
   })
 
-  it('resolves as a clean run when the process fails to spawn', async () => {
+  it('marks a run whose process fails to spawn instead of reporting a clean allow', async () => {
     script('missing', { error: new Error('spawn /bin/sh ENOENT') })
-    expect(await runHookCommand('missing', {}, 5000)).toEqual({ code: 0, stdout: '', stderr: '', timedOut: false })
+    expect(await runHookCommand('missing', {}, 5000)).toEqual({ code: 0, stdout: '', stderr: 'spawn /bin/sh ENOENT', timedOut: false, spawnFailed: true })
   })
 
   it('keeps output already received when the process then errors', async () => {
     script('half', { stdout: ['partial'], error: new Error('EIO') })
-    expect(await runHookCommand('half', {}, 5000)).toEqual({ code: 0, stdout: 'partial', stderr: '', timedOut: false })
+    expect(await runHookCommand('half', {}, 5000)).toEqual({ code: 0, stdout: 'partial', stderr: 'EIO', timedOut: false, spawnFailed: true })
   })
 
   it('swallows an EPIPE from a hook that exits without reading stdin', async () => {
@@ -374,7 +374,7 @@ describe('interpretHookResult defaults and precedence', () => {
 })
 
 describe('runPreToolUse hook sequencing', () => {
-  it('returns the first blocking verdict and skips the remaining hooks', async () => {
+  it('returns the first blocking verdict; every hook still runs (parallel launch)', async () => {
     const run: string[] = []
     const runner: HookRunner = async (command) => {
       run.push(command)
@@ -382,7 +382,7 @@ describe('runPreToolUse hook sequencing', () => {
     }
     const config = { PreToolUse: [{ hooks: [{ command: 'first' }, { command: 'second' }, { command: 'third' }] }] }
     expect(await runPreToolUse(config, 'bash', {}, runner)).toEqual({ block: true, reason: 'denied by second' })
-    expect(run).toEqual(['first', 'second'])
+    expect(run).toEqual(['first', 'second', 'third'])
   })
 
   it('allows the tool when every matching hook passes', async () => {
@@ -411,18 +411,6 @@ describe('runPreToolUse updatedInput', () => {
     expect(await runPreToolUse(config, 'bash', input, runner)).toEqual({ block: false })
     // Claude documents updatedInput as replacing the whole tool_input: timeout is dropped.
     expect(input).toEqual({ command: 'echo safe' })
-  })
-
-  it('lets a later hook see an earlier updatedInput in its payload', async () => {
-    const seen: unknown[] = []
-    const runner: HookRunner = async (command, payload) => {
-      seen.push(structuredClone((payload as { tool_input: unknown }).tool_input))
-      const stdout = command === 'first' ? JSON.stringify({ hookSpecificOutput: { updatedInput: { a: 2 } } }) : ''
-      return { code: 0, stdout, stderr: '', timedOut: false }
-    }
-    const two = { PreToolUse: [{ hooks: [{ command: 'first' }, { command: 'second' }] }] }
-    await runPreToolUse(two, 'bash', { a: 1 }, runner)
-    expect(seen).toEqual([{ a: 1 }, { a: 2 }])
   })
 
   it('applies updatedInput even when the same hook denies', async () => {
@@ -1076,5 +1064,72 @@ describe('hooks MCP tool aliases', () => {
     ext.emitMcpTools('junk')
     await ext.toolCall('github_create_issue', {})
     expect(commandsRun()).toEqual([])
+  })
+})
+
+describe('hook execution parallelism', () => {
+  it('launches every matching PreToolUse hook before any completes', async () => {
+    // Claude runs matching hooks in parallel; serial execution paid each hook's
+    // latency in sequence on every tool call.
+    const launched: string[] = []
+    let release: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const runner: HookRunner = async (command) => {
+      launched.push(command)
+      await gate
+      return { code: 0, stdout: '', stderr: '', timedOut: false }
+    }
+    const two = { PreToolUse: [{ hooks: [{ command: 'slow' }, { command: 'also-slow' }] }] }
+    const pending = runPreToolUse(two, 'bash', { a: 1 }, runner)
+    expect(launched).toEqual(['slow', 'also-slow'])
+    release()
+    expect(await pending).toEqual({ block: false })
+  })
+
+  it('every parallel hook sees the original tool input; updatedInput still lands', async () => {
+    const seen: unknown[] = []
+    const runner: HookRunner = async (command, payload) => {
+      seen.push(structuredClone((payload as { tool_input: unknown }).tool_input))
+      const stdout = command === 'first' ? JSON.stringify({ hookSpecificOutput: { updatedInput: { a: 2 } } }) : ''
+      return { code: 0, stdout, stderr: '', timedOut: false }
+    }
+    const two = { PreToolUse: [{ hooks: [{ command: 'first' }, { command: 'second' }] }] }
+    const input = { a: 1 }
+    await runPreToolUse(two, 'bash', input, runner)
+    expect(seen).toEqual([{ a: 1 }, { a: 1 }])
+    expect(input).toEqual({ a: 2 })
+  })
+
+  it('launches every matching UserPromptSubmit hook before any completes', async () => {
+    const launched: string[] = []
+    let release: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const runner: HookRunner = async (command) => {
+      launched.push(command)
+      await gate
+      return { code: 0, stdout: 'ctx', stderr: '', timedOut: false }
+    }
+    const two = { UserPromptSubmit: [{ hooks: [{ command: 'one' }, { command: 'two' }] }] }
+    const pending = runUserPromptSubmit(two, 'hello', runner)
+    expect(launched).toEqual(['one', 'two'])
+    release()
+    expect((await pending).context).toBe('ctx\nctx')
+  })
+})
+
+describe('hook spawn failures', () => {
+  it('surfaces a spawn failure through the system message sink and proceeds', async () => {
+    // Claude shows a hook error notice and the action proceeds; a silent code-0
+    // meant a deny-list guard that never ran read as a clean allow.
+    const runner: HookRunner = async () => ({ code: 0, stdout: '', stderr: 'spawn /bin/sh ENOENT', timedOut: false, spawnFailed: true })
+    const messages: string[] = []
+    const config = { PreToolUse: [{ hooks: [{ command: 'guard.sh' }] }] }
+    const decision = await runPreToolUse(config, 'bash', { a: 1 }, runner, undefined, (m) => messages.push(m))
+    expect(decision).toEqual({ block: false })
+    expect(messages.some((m) => m.includes('guard.sh') && m.includes('ENOENT'))).toBe(true)
   })
 })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -208,6 +208,7 @@ describe('runPreToolUse on a timed-out hook', () => {
 
     expect(decision.block).toBe(true)
     expect(decision.reason).toContain('guard.sh')
-    expect(run).toEqual(['guard.sh'])
+    // Parallel launch, as Claude runs hooks: the sibling was already in flight.
+    expect(run).toEqual(['guard.sh', 'second.sh'])
   })
 })


### PR DESCRIPTION
Two Claude-compat gaps in hooks.ts, both verified against the current hooks docs. Matching PreToolUse/UserPromptSubmit hooks ran serially (the other events already used Promise.all), so three 500ms hooks added 1.5s to every tool call and a hung hook stacked its timeout on top of the others; the docs say matching hooks run in parallel, every hook sees the original input, and multiple updatedInput rewrites are last-to-finish-wins rather than chained. Both paths now launch in parallel, keeping fail-closed timeouts and first-block-wins in config order. Separately, a hook that failed to spawn (EMFILE, EACCES) resolved as a clean code-0 run, silently skipping deny-list guards; the result now carries spawnFailed and is surfaced as a notice while the action proceeds, per Claude's documented error handling.