### PR TITLE
Tighten subagent child lifecycle

### DIFF
--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -19,8 +19,13 @@ export interface BackgroundRun {
   exitCode?: number
   output?: string
   turns: number
+  /** Last stderr bytes of a failed child; the only diagnostics a boot failure leaves. */
+  stderr?: string
   /** Set while running so the run can be cancelled; cleared on completion. */
   kill?: () => void
+  /** True until the child process actually closes: a cancelled child that ignores
+   * SIGTERM is still alive and must keep holding its concurrency slot. */
+  live?: boolean
   /** pi session the child ran under, so a follow-up can continue its context. */
   sessionId: string
   /** How the child was spawned, so a follow-up can repeat it with a new task. */
@@ -42,30 +47,66 @@ const runs = new Map<string, BackgroundRun>()
 /** Cap on simultaneously running background children. */
 export const MAX_BACKGROUND_RUNS = 8
 
+/** Finished runs kept for status listings and resume; older ones are evicted so a
+ * long session's registry (each entry holds its final output) cannot grow forever. */
+export const MAX_FINISHED_RUNS = 20
+
+/** Grace between the cancel SIGTERM and the SIGKILL that ends a child ignoring it. */
+const CANCEL_KILL_GRACE_MS = 5000
+
+/** Bytes of stderr kept per run, enough for the boot error without buffering logs. */
+const STDERR_TAIL_CHARS = 2048
+
 export function activeBackgroundRuns(): number {
-  return [...runs.values()].filter((run) => run.state === 'running').length
+  return [...runs.values()].filter((run) => run.live || run.state === 'running').length
 }
 
-/** Extract the final assistant text and turn count from a pi --mode json stdout stream. */
-export function parseFinalOutputFromJsonl(jsonl: string): { text: string; turns: number } {
+function evictFinishedRuns(): void {
+  const finished = [...runs.values()].filter((run) => !run.live && run.state !== 'running')
+  for (const stale of finished.slice(0, Math.max(0, finished.length - MAX_FINISHED_RUNS))) runs.delete(stale.id)
+}
+
+/** Line-by-line parser keeping only the last assistant text and a turn count, so a
+ * long run's JSONL stdout never accumulates whole in the parent's memory. */
+export function createJsonlOutputParser(): { push: (chunk: string) => void; flush: () => { text: string; turns: number } } {
+  let buffer = ''
   let text = ''
   let turns = 0
-  for (const line of jsonl.split('\n')) {
-    if (!line.trim()) continue
+  const takeLine = (raw: string): void => {
+    if (!raw.trim()) return
     let event: { type?: string; message?: { role?: string; content?: Array<{ type: string; text?: string }> } }
     try {
-      event = JSON.parse(line)
+      event = JSON.parse(raw)
     } catch {
-      continue
+      return
     }
-    if (event.type !== 'message_end' || event.message?.role !== 'assistant') continue
+    if (event.type !== 'message_end' || event.message?.role !== 'assistant') return
     turns++
     // The complete text of the last assistant message, matching getFinalOutput on the
     // foreground path so a multi-part message reads the same in both.
     const parts = (event.message.content ?? []).filter((p) => p.type === 'text' && p.text).map((p) => p.text as string)
     if (parts.length > 0) text = parts.join('\n')
   }
-  return { text, turns }
+  return {
+    push(chunk) {
+      buffer += chunk
+      const lines = buffer.split('\n')
+      buffer = lines.pop() ?? ''
+      for (const line of lines) takeLine(line)
+    },
+    flush() {
+      takeLine(buffer)
+      buffer = ''
+      return { text, turns }
+    },
+  }
+}
+
+/** Extract the final assistant text and turn count from a pi --mode json stdout stream. */
+export function parseFinalOutputFromJsonl(jsonl: string): { text: string; turns: number } {
+  const parser = createJsonlOutputParser()
+  parser.push(jsonl)
+  return parser.flush()
 }
 
 export function formatStatus(all: Iterable<Pick<BackgroundRun, 'id' | 'agent' | 'task' | 'state' | 'turns' | 'exitCode'>>): string {
@@ -100,15 +141,22 @@ export function backgroundRun(id: string): BackgroundRun | undefined {
 /** Re-spawn a finished run's session with a new task. The child is started with the
  * same --session-id, so it continues with everything it already saw rather than
  * re-deriving context the parent would have to repeat. */
-export function resumeBackgroundRun(id: string, task: string, onComplete: (run: BackgroundRun) => void): 'resumed' | 'still-running' | 'unknown' {
+export function resumeBackgroundRun(id: string, task: string, onComplete: (run: BackgroundRun) => void): 'resumed' | 'still-running' | 'at-capacity' | 'unknown' {
   const run = runs.get(id)
   if (!run) return 'unknown'
-  if (run.state === 'running') return 'still-running'
-  const args = withRebuiltPrompt(run.spawn).map((arg) => (arg.startsWith('Task: ') ? `Task: ${task}` : arg))
+  if (run.state === 'running' || run.live) return 'still-running'
+  // A resume spawns a child like a fresh start does, so it counts against the cap.
+  if (activeBackgroundRuns() >= MAX_BACKGROUND_RUNS) return 'at-capacity'
+  // Persisted so the rebuild happens once: rebuilding per resume leaked one temp
+  // prompt dir every follow-up.
+  const rebuilt = withRebuiltPrompt(run.spawn)
+  run.spawn = { ...run.spawn, args: rebuilt }
+  const args = rebuilt.map((arg) => (arg.startsWith('Task: ') ? `Task: ${task}` : arg))
   run.state = 'running'
   run.task = task
   run.output = undefined
   run.exitCode = undefined
+  run.stderr = undefined
   driveRun(run, { ...run.spawn, args }, onComplete)
   return 'resumed'
 }
@@ -156,25 +204,41 @@ function driveRun(run: BackgroundRun, invocation: BackgroundSpawn, onComplete: (
   const proc = spawn(invocation.command, invocation.args, {
     cwd: invocation.cwd,
     shell: false,
-    stdio: ['ignore', 'pipe', 'ignore'],
+    stdio: ['ignore', 'pipe', 'pipe'],
     // Its own group, so cancelling reaches any grandchild the agent spawned.
     detached: true,
     // The marker lets the child's subagent tool refuse to nest further.
     env: { ...process.env, PI_CODE_SUBAGENT: '1' },
   })
-  run.kill = () => {
+  run.live = true
+  const killGroup = (signal: NodeJS.Signals): void => {
     try {
-      process.kill(-proc.pid!, 'SIGTERM')
+      process.kill(-proc.pid!, signal)
     } catch {
-      proc.kill('SIGTERM')
+      try {
+        proc.kill(signal)
+      } catch {
+        // already gone
+      }
     }
   }
-  let stdout = ''
+  run.kill = () => {
+    killGroup('SIGTERM')
+    // A child ignoring SIGTERM would hold its cap slot and process forever.
+    const escalate = setTimeout(() => killGroup('SIGKILL'), CANCEL_KILL_GRACE_MS)
+    escalate.unref()
+    proc.once('close', () => clearTimeout(escalate))
+  }
+  // Parsed as it streams: buffering the whole JSONL replays every tool result echoed
+  // by the child through the parent's memory for the life of the run.
+  const parser = createJsonlOutputParser()
+  let stderrTail = ''
   // Node fires both 'error' and 'close' on a spawn failure (ENOENT); complete once.
   let completed = false
   const complete = (): void => {
     if (completed) return
     completed = true
+    evictFinishedRuns()
     // A run outlives the session that started it, and pi's loader wires assertActive()
     // into every runtime call, so notifying a disposed session throws. This fires from
     // the child's 'close'/'error' listener, where nothing upstream catches: an escaping
@@ -187,27 +251,33 @@ function driveRun(run: BackgroundRun, invocation: BackgroundSpawn, onComplete: (
       // the session that asked for this run is gone
     }
   }
-  proc.stdout.on('data', (data) => {
-    stdout += data.toString()
-  })
+  proc.stdout.on('data', (data) => parser.push(data.toString()))
   // An 'error' on a stream with no listener is rethrown by EventEmitter, and this one
   // belongs to a detached child, so a pipe read failure would exit pi the same way an
   // unguarded completion would. The foreground runner guards its streams the same way.
   proc.stdout.on('error', () => {})
+  proc.stderr?.on('data', (data) => {
+    stderrTail = (stderrTail + data.toString()).slice(-STDERR_TAIL_CHARS)
+  })
+  proc.stderr?.on('error', () => {})
   proc.on('close', (code) => {
-    const { text, turns } = parseFinalOutputFromJsonl(stdout)
+    const { text, turns } = parser.flush()
     run.kill = undefined
+    run.live = false
     // A cancelled run keeps that state: its non-zero exit is the cancellation.
     if (run.state !== 'cancelled') run.state = code === 0 ? 'done' : 'failed'
     run.exitCode = code ?? 0
     run.output = text
     run.turns = turns
+    run.stderr = stderrTail.trim() || undefined
     complete()
   })
-  proc.on('error', () => {
+  proc.on('error', (error) => {
     run.kill = undefined
+    run.live = false
     run.state = 'failed'
     run.exitCode = 1
+    run.stderr = stderrTail.trim() || error.message
     complete()
   })
 }

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -28,7 +28,7 @@ import { isProjectApproved, isProjectApprovedSilently } from '../internal/projec
 import { SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
 import { skillDirs } from '../skills.js'
 import { type AgentConfig, type AgentScope, discoverAgents, resolveModelAlias, withPreloadedSkills } from './agents.js'
-import { activeBackgroundRuns, backgroundStatusText, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
+import { activeBackgroundRuns, backgroundRun, backgroundStatusText, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
 
 const MAX_PARALLEL_TASKS = 8
 const MAX_CONCURRENCY = 4
@@ -343,6 +343,9 @@ async function runSingleAgentInner(options: RunAgentOptions): Promise<SingleResu
         cwd: cwd ?? defaultCwd,
         shell: false,
         stdio: ['ignore', 'pipe', 'pipe'],
+        // Its own group, so an abort reaches grandchildren too: killing only the
+        // direct child orphans a build or dev server the agent started.
+        detached: true,
         // The marker lets the child's subagent tool refuse to nest further.
         env: { ...process.env, PI_CODE_SUBAGENT: '1' },
       })
@@ -401,19 +404,24 @@ async function runSingleAgentInner(options: RunAgentOptions): Promise<SingleResu
         resolve(1)
       })
 
+      const killGroup = (sig: NodeJS.Signals): void => {
+        try {
+          process.kill(-proc.pid!, sig)
+        } catch {
+          try {
+            proc.kill(sig)
+          } catch {
+            /* already gone */
+          }
+        }
+      }
       if (signal) {
         onAbort = () => {
           wasAborted = true
-          proc.kill('SIGTERM')
+          killGroup('SIGTERM')
           // proc.killed only reports that the signal was sent, not that the child died. Escalate
           // on a timer that the 'close' handler clears once the child has actually exited.
-          killTimer = setTimeout(() => {
-            try {
-              proc.kill('SIGKILL')
-            } catch {
-              /* already gone */
-            }
-          }, 5000)
+          killTimer = setTimeout(() => killGroup('SIGKILL'), 5000)
         }
         if (signal.aborted) onAbort()
         else signal.addEventListener('abort', onAbort, { once: true })
@@ -498,17 +506,25 @@ type ChainStepParam = Static<typeof ChainItem>
 type TaskItemParam = Static<typeof TaskItem>
 
 /** The completion notice a background run sends when it finishes. */
-export function backgroundCompletionText(run: { id: string; agent: string; state: string; turns: number; output?: string }): string {
+export function backgroundCompletionText(run: { id: string; agent: string; state: string; turns: number; output?: string; stderr?: string }): string {
   const output = capForContext(run.output ?? '') || '(no output)'
-  return `Background subagent run ${run.id} (${run.agent}) ${run.state} after ${run.turns} turns.\n\n${output}`
+  // A child that dies at boot writes its reason only to stderr; without this the
+  // notice reads "failed after 0 turns ... (no output)" with nothing to act on.
+  const diagnostics = run.state === 'failed' && run.stderr ? `\n\nstderr tail:\n${capForContext(run.stderr)}` : ''
+  return `Background subagent run ${run.id} (${run.agent}) ${run.state} after ${run.turns} turns.\n\n${output}${diagnostics}`
 }
 
 /** What to tell the model about a resume request. */
-export function resumeResultText(id: string, task: string | undefined, onComplete: (run: { id: string; agent: string; state: string; turns: number; output?: string }) => void): string {
+export function resumeResultText(id: string, task: string | undefined, onComplete: (run: { id: string; agent: string; state: string; turns: number; output?: string; stderr?: string }) => void, onResumed?: (run: { id: string; agent: string }) => void): string {
   if (!task) return 'Pass task with resume: the follow-up needs an instruction.'
   const outcome = resumeBackgroundRun(id, task, onComplete)
-  if (outcome === 'resumed') return `Resumed background run ${id} with the follow-up task; a notification will arrive on completion.`
+  if (outcome === 'resumed') {
+    const run = backgroundRun(id)
+    if (run) onResumed?.({ id: run.id, agent: run.agent })
+    return `Resumed background run ${id} with the follow-up task; a notification will arrive on completion.`
+  }
   if (outcome === 'still-running') return `Background run ${id} is still running; wait for it or cancel it first.`
+  if (outcome === 'at-capacity') return `Background run cap reached (${MAX_BACKGROUND_RUNS} concurrent); wait for a run to finish before resuming ${id}.`
   return `Unknown background run: ${id}.\n\n${backgroundStatusText()}`
 }
 
@@ -1108,8 +1124,10 @@ function renderParallelResult(results: SingleResult[], expanded: boolean, theme:
 }
 
 export default function subagentExtension(pi: ExtensionAPI) {
-  const notifyBackgroundCompletion = (run: { id: string; agent: string; state: string; turns: number; output?: string }): void => {
+  const notifyBackgroundCompletion = (run: { id: string; agent: string; state: string; turns: number; output?: string; stderr?: string }): void => {
     // Runs through driveRun's guard, same as the background-mode callback above.
+    // The stop event fires here too, so SubagentStop hooks see resumed runs end.
+    pi.events.emit(SUBAGENT_CHANNEL, { phase: 'stop', agentType: run.agent, agentId: run.id })
     pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
   }
 
@@ -1166,7 +1184,7 @@ export default function subagentExtension(pi: ExtensionAPI) {
         })
 
       if (params.resume) {
-        return { content: [{ type: 'text', text: resumeResultText(params.resume, params.task, notifyBackgroundCompletion) }], details: makeDetails('single')([]) }
+        return { content: [{ type: 'text', text: resumeResultText(params.resume, params.task, notifyBackgroundCompletion, (run) => pi.events.emit(SUBAGENT_CHANNEL, { phase: 'start', agentType: run.agent, agentId: run.id })) }], details: makeDetails('single')([]) }
       }
 
       if (params.cancel) {

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { existsSync, rmSync } from 'node:fs'
+import { dirname } from 'node:path'
 
-import { type BackgroundRun, formatStatus, parseFinalOutputFromJsonl } from '../extensions/subagent/background.ts'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { activeBackgroundRuns, type BackgroundRun, type BackgroundSpawn, backgroundStatusText, cancelBackgroundRun, formatStatus, parseFinalOutputFromJsonl, resumeBackgroundRun, startBackgroundRun } from '../extensions/subagent/background.ts'
 
 describe('background subagent helpers', () => {
   it('parses the final assistant text and turn count from jsonl', () => {
@@ -26,5 +30,129 @@ describe('background subagent helpers', () => {
     expect(text).toContain('bg-1 scout: running')
     expect(text).toContain('bg-2 worker: done (exit 0, 3 turns)')
     expect(formatStatus([])).toContain('No background runs')
+  })
+})
+
+const spawnMock = vi.hoisted(() => vi.fn())
+vi.mock('node:child_process', async (importOriginal) => ({ ...(await importOriginal<object>()), spawn: spawnMock }))
+
+class FakeProc extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  kill = vi.fn()
+}
+
+const children: FakeProc[] = []
+
+beforeEach(() => {
+  children.length = 0
+  spawnMock.mockReset()
+  spawnMock.mockImplementation(() => {
+    const child = new FakeProc()
+    children.push(child)
+    return child
+  })
+})
+
+const spec = (over: Partial<BackgroundSpawn> = {}): BackgroundSpawn => ({ command: 'pi', args: ['--mode', 'json', 'Task: t'], cwd: '/w', ...over })
+
+describe('background run lifecycle', () => {
+  it('reports the final text of a stdout stream whose chunks split lines', () => {
+    let done: BackgroundRun | undefined
+    startBackgroundRun('scout', 'find', spec(), (run) => {
+      done = run
+    })
+    const child = children.at(-1)!
+    const l1 = JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text: 'first' }] } })
+    const l2 = JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text: 'final answer' }] } })
+    const whole = `${l1}\n${l2}\n`
+    child.stdout.emit('data', whole.slice(0, 25))
+    child.stdout.emit('data', whole.slice(25))
+    child.emit('close', 0)
+
+    expect(done?.state).toBe('done')
+    expect(done?.output).toBe('final answer')
+    expect(done?.turns).toBe(2)
+  })
+
+  it('keeps a bounded stderr tail for a failed child', () => {
+    let done: BackgroundRun | undefined
+    startBackgroundRun('scout', 'boot', spec(), (run) => {
+      done = run
+    })
+    const child = children.at(-1)!
+    child.stderr.emit('data', 'x'.repeat(5000))
+    child.stderr.emit('data', 'model id not resolvable')
+    child.emit('close', 1)
+
+    expect(done?.state).toBe('failed')
+    expect(done?.stderr).toContain('model id not resolvable')
+    expect((done?.stderr ?? '').length).toBeLessThanOrEqual(2048)
+  })
+
+  it('holds the cap slot for a cancelled child until it dies, then escalates to SIGKILL', () => {
+    vi.useFakeTimers()
+    try {
+      const id = startBackgroundRun('scout', 'hang', spec(), () => {})
+      const child = children.at(-1)!
+      const before = activeBackgroundRuns()
+
+      expect(cancelBackgroundRun(id!)).toBe('cancelled')
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+      // The state flipped, but the process is still alive and holds its slot.
+      expect(activeBackgroundRuns()).toBe(before)
+
+      vi.advanceTimersByTime(5000)
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+
+      child.emit('close', 143)
+      expect(activeBackgroundRuns()).toBe(before - 1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('evicts the oldest finished runs beyond the retention cap', () => {
+    for (let i = 0; i < 25; i++) {
+      startBackgroundRun('scout', `job ${i}`, spec(), () => {})
+      children.at(-1)!.emit('close', 0)
+    }
+    const finished = backgroundStatusText()
+      .split('\n')
+      .filter((line) => line.includes('done (exit'))
+    expect(finished.length).toBeLessThanOrEqual(20)
+  })
+
+  it('refuses to resume while the running cap is full', () => {
+    let finished: BackgroundRun | undefined
+    startBackgroundRun('scout', 'early', spec(), (run) => {
+      finished = run
+    })
+    children.at(-1)!.emit('close', 0)
+
+    const live: FakeProc[] = []
+    for (let i = 0; i < 8; i++) {
+      startBackgroundRun('scout', `fill ${i}`, spec(), () => {})
+      live.push(children.at(-1)!)
+    }
+    expect(resumeBackgroundRun(finished!.id, 'again', () => {})).toBe('at-capacity')
+    for (const child of live) child.emit('close', 0)
+  })
+
+  it('rebuilds the prompt file once and reuses it across resumes', () => {
+    const id = startBackgroundRun('scout', 'one', spec({ args: ['--append-system-prompt', '/nonexistent/prompt.md', 'Task: one'], promptBody: 'PERSONA' }), () => {})
+    children.at(-1)!.emit('close', 0)
+
+    expect(resumeBackgroundRun(id!, 'two', () => {})).toBe('resumed')
+    const firstArgs = spawnMock.mock.calls.at(-1)![1] as string[]
+    const promptPath = firstArgs[firstArgs.indexOf('--append-system-prompt') + 1]
+    expect(existsSync(promptPath)).toBe(true)
+    children.at(-1)!.emit('close', 0)
+
+    expect(resumeBackgroundRun(id!, 'three', () => {})).toBe('resumed')
+    const secondArgs = spawnMock.mock.calls.at(-1)![1] as string[]
+    expect(secondArgs[secondArgs.indexOf('--append-system-prompt') + 1]).toBe(promptPath)
+    children.at(-1)!.emit('close', 0)
+    rmSync(dirname(promptPath), { recursive: true, force: true })
   })
 })

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -562,7 +562,7 @@ describe('startBackgroundRun', () => {
       {
         command: 'pi',
         args: ['--mode', 'json'],
-        options: { cwd: '/work/dir', shell: false, stdio: ['ignore', 'pipe', 'ignore'], detached: true, env: expect.objectContaining({ PI_CODE_SUBAGENT: '1' }) },
+        options: { cwd: '/work/dir', shell: false, stdio: ['ignore', 'pipe', 'pipe'], detached: true, env: expect.objectContaining({ PI_CODE_SUBAGENT: '1' }) },
       },
     ])
   })

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -15,6 +15,7 @@ const backgroundStatusTextMock = vi.hoisted(() => vi.fn(() => 'No background run
 const cancelBackgroundRunMock = vi.hoisted(() => vi.fn())
 const resumeBackgroundRunMock = vi.hoisted(() => vi.fn())
 const activeBackgroundRunsMock = vi.hoisted(() => vi.fn(() => 0))
+const backgroundRunMock = vi.hoisted(() => vi.fn())
 
 vi.mock('node:child_process', async (importOriginal) => ({ ...(await importOriginal<object>()), spawn: spawnMock }))
 vi.mock('../extensions/subagent/agents.js', async (importOriginal) => ({
@@ -27,6 +28,7 @@ vi.mock('../extensions/subagent/background.js', () => ({
   resumeBackgroundRun: resumeBackgroundRunMock,
   startBackgroundRun: startBackgroundRunMock,
   activeBackgroundRuns: activeBackgroundRunsMock,
+  backgroundRun: backgroundRunMock,
   MAX_BACKGROUND_RUNS: 8,
 }))
 
@@ -755,11 +757,42 @@ describe('resumeResultText', () => {
     resumeBackgroundRunMock.mockReturnValue('still-running')
     expect(resumeResultText('bg-1', 'follow up', noop)).toContain('still running')
 
+    resumeBackgroundRunMock.mockReturnValue('at-capacity')
+    expect(resumeResultText('bg-1', 'follow up', noop)).toContain('cap reached')
+
     resumeBackgroundRunMock.mockReturnValue('unknown')
     backgroundStatusTextMock.mockReturnValue('LISTING')
     const unknown = resumeResultText('bg-9', 'follow up', noop)
     expect(unknown).toContain('Unknown background run: bg-9')
     expect(unknown).toContain('LISTING')
+  })
+
+  it('reports a resumed run to the lifecycle callback', async () => {
+    const { resumeResultText } = await import('../extensions/subagent/index.ts')
+    resumeBackgroundRunMock.mockReturnValue('resumed')
+    backgroundRunMock.mockReturnValue({ id: 'bg-1', agent: 'scout' })
+    const started: unknown[] = []
+
+    resumeResultText(
+      'bg-1',
+      'follow up',
+      () => {},
+      (run) => started.push(run),
+    )
+
+    expect(started).toEqual([{ id: 'bg-1', agent: 'scout' }])
+  })
+})
+
+describe('backgroundCompletionText diagnostics', () => {
+  it('appends the stderr tail for a failed run and omits it for a clean one', async () => {
+    const { backgroundCompletionText } = await import('../extensions/subagent/index.ts')
+    const failed = backgroundCompletionText({ id: 'bg-1', agent: 'scout', state: 'failed', turns: 0, stderr: 'unknown model id x' })
+    expect(failed).toContain('stderr tail:')
+    expect(failed).toContain('unknown model id x')
+
+    const done = backgroundCompletionText({ id: 'bg-2', agent: 'scout', state: 'done', turns: 3, output: 'all good', stderr: 'noise' })
+    expect(done).not.toContain('stderr tail:')
   })
 })
 
@@ -1173,5 +1206,28 @@ describe('parallel mode', () => {
     await execute('c1', { tasks: [{ agent: 'scout', task: 'alpha', cwd: '/pkg/a' }] }, undefined, undefined, trustedCtx)
 
     expect(spawnCalls[0].options.cwd).toBe('/pkg/a')
+  })
+})
+
+describe('foreground abort process group', () => {
+  it('spawns the child detached and signals its whole group on abort', async () => {
+    const controller = new AbortController()
+    script('inspect', { stdout: [say('too late')], delay: 30 })
+    const groupKills: Array<[unknown, unknown]> = []
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, sig?: string) => {
+      groupKills.push([pid, sig])
+      return true
+    }) as never)
+    try {
+      const pending = execute('c1', { agent: 'scout', task: 'inspect' }, controller.signal, undefined, trustedCtx)
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      expect((spawnCalls[0].options as { detached?: boolean }).detached).toBe(true)
+      ;(spawnedChildren[0] as { pid?: number }).pid = 424242
+      controller.abort()
+      await expect(pending).rejects.toThrow('Subagent was aborted')
+      expect(groupKills).toContainEqual([-424242, 'SIGTERM'])
+    } finally {
+      killSpy.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
## Summary

Several lifecycle gaps around subagent children, all found in the codebase review.

Background runs accumulated the child's raw JSONL stdout into one string for the whole run (tens to hundreds of MB for a long audit, times up to 8 concurrent runs) and the module registry never evicted finished entries. stdout is now parsed line by line, keeping only the final text and turn count, and the registry retains the 20 most recent finished runs.

A background child that died at boot reported 'failed after 0 turns ... (no output)' with stderr set to ignore; a bounded 2KB stderr tail is now captured and appended to the completion notice for failed runs.

Cancel sent one SIGTERM with no escalation and freed the concurrency slot immediately, so a TERM-ignoring child leaked past the cap; cancel now escalates to a process-group SIGKILL after 5s and the run holds its slot until the child actually closes.

Foreground children were spawned without detached and an abort killed only the direct pi child, orphaning anything it had started (builds, dev servers); they now get their own process group and the abort signals the group, mirroring the background path.

Resume rebuilt the prompt temp file on every follow-up without recording the new path (one leaked 0600 temp dir per resume), skipped the MAX_BACKGROUND_RUNS check, and never emitted SubagentStart/Stop events; all three fixed.