### PR TITLE
Expand Claude Code parity with MCP prompts, model-invocable commands, /hooks, and /tasks

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -7,12 +7,29 @@
  * subdirectories (`frontend/build.md` is `/frontend:build`), `$ARGUMENTS` and
  * positional substitution, `` !`cmd` `` bash output, `@file` inlining, and the
  * `allowed-tools`, `argument-hint` and `model` frontmatter (`model` switches the
- * session model for the command's turn via `pi.setModel`, restored on turn_end).
+ * session model for the command's run via `pi.setModel`, restored on agent_end).
  * `shell: powershell` runs a command's injected spans through PowerShell when a
  * pwsh binary is installed, falling back to /bin/sh so the command still works
- * without one. `disable-model-invocation` is parsed but not applied yet.
+ * without one.
  *
- * A project command body is repository-controlled text that can now run shell
+ * Commands are also exposed to the model through a `slash_command` tool
+ * (Claude's SlashCommand tool), listing every discovered command whose file
+ * does not set `disable-model-invocation: true`. Only the command files this
+ * extension discovers are listed: pi built-ins and pi-code's own UI commands
+ * are user surfaces, not model surfaces. The model path is expansion only: the
+ * expanded body comes back as the tool result (sendUserMessage would spawn a
+ * second turn), `allowed-tools`/`disallowed-tools`/`model:` are not applied
+ * (applying them from inside a tool call would narrow the running batch and
+ * scope unrelated parallel tool calls, and the agent_end restore would lift
+ * the grant before the next model step could rely on it), and `!` spans are
+ * never executed on the model's demand: pi has no permission engine to gate
+ * repo-authored shell, so each span is replaced with Claude's
+ * "[shell command execution disabled by policy]" placeholder. The same
+ * placeholder is applied on every path when the `disableSkillShellExecution`
+ * settings key is set (user settings always, project settings when trusted,
+ * managed-settings.json as policy).
+ *
+ * A project command body is repository-controlled text that can run shell
  * commands and read files, so project commands load only once the project is
  * approved. That closes the "skills / commands are not trust-gated" limitation
  * for commands; skills remain pi-loader territory.
@@ -24,13 +41,15 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI, ExtensionCommandContext } from '@earendil-works/pi-coding-agent'
+import { Type } from 'typebox'
 
 import { matchesBashRules } from './internal/bash-rules.js'
-import { type DiscoveredCommand, discoverCommandFiles, expandDynamicContent, type ParsedCommand, parseCommandFile, resolvePowershellBinary, spanExec, substituteArgsDetailed, substituteVars } from './internal/command-file.js'
+import { type CommandExec, type DiscoveredCommand, discoverCommandFiles, expandDynamicContent, type ParsedCommand, parseCommandFile, resolvePowershellBinary, spanExec, substituteArgsDetailed, substituteVars } from './internal/command-file.js'
+import { readManagedSettings } from './internal/managed-settings.js'
 import { matchesPathRules } from './internal/path-rules.js'
 import { type InstalledPlugin, installedPlugins } from './internal/plugins.js'
 import { isProjectApproved } from './internal/project-approval.js'
-import { findNearestDir, repoRoot } from './internal/project-root.js'
+import { findNearestDir, findNearestFile, repoRoot } from './internal/project-root.js'
 
 type PathRuleTool = 'read' | 'edit' | 'write'
 
@@ -38,6 +57,7 @@ type PathRuleTool = 'read' | 'edit' | 'write'
 interface ModelLike {
   id: string
   name?: string
+  contextWindow?: number
 }
 
 /** Resolve a command's `model:` frontmatter to an available model. Claude accepts a
@@ -118,18 +138,169 @@ export function pluginCommands(plugins: InstalledPlugin[]): DiscoveredCommand[] 
   return found
 }
 
+/** Claude's replacement text for a `!` span it refuses to execute. */
+export const SHELL_DISABLED_PLACEHOLDER = '[shell command execution disabled by policy]'
+
+type CommandPlugin = NonNullable<DiscoveredCommand['plugin']>
+
+/**
+ * Whether `disableSkillShellExecution` is set: the Claude settings key that
+ * replaces every `` !`cmd` `` and ```` ```! ```` span in skills and custom
+ * commands with SHELL_DISABLED_PLACEHOLDER instead of executing it. Read from
+ * user settings always, the project's settings.json/settings.local.json only
+ * when the project is trusted, and managed-settings.json as policy. Any layer
+ * setting it true wins: a repository's `false` must not lift the user's or the
+ * organization's policy, so this fails closed rather than last-file-wins.
+ */
+export function shellExecutionDisabled(cwd: string, home: string, trusted: boolean): boolean {
+  if (readManagedSettings().disableSkillShellExecution === true) return true
+  const files = [path.join(home, '.claude', 'settings.json')]
+  if (trusted) {
+    for (const name of ['settings.json', 'settings.local.json']) {
+      files.push(findNearestFile(cwd, path.join('.claude', name)) ?? path.join(cwd, '.claude', name))
+    }
+  }
+  return files.some((file) => {
+    try {
+      return (JSON.parse(fs.readFileSync(file, 'utf-8')) as Record<string, unknown>).disableSkillShellExecution === true
+    } catch {
+      return false // missing or invalid file: not a policy statement
+    }
+  })
+}
+
+/** The ${CLAUDE_*} substitution sources for one command invocation. */
+function commandVars(ctx: { cwd: string }, filePath: string, plugin?: CommandPlugin): Record<string, string | undefined> {
+  const varCtx = ctx as unknown as VarContext
+  return {
+    CLAUDE_SESSION_ID: varCtx.sessionManager?.getSessionId?.(),
+    CLAUDE_EFFORT: varCtx.thinkingLevel,
+    CLAUDE_SKILL_DIR: path.dirname(filePath),
+    CLAUDE_PROJECT_DIR: repoRoot(ctx.cwd) ?? ctx.cwd,
+    CLAUDE_PLUGIN_ROOT: plugin?.root,
+    CLAUDE_PLUGIN_DATA: plugin?.dataDir,
+  }
+}
+
+/** The exec seam expandCommand runs spans through; pi itself satisfies it. */
+interface SpanRunner {
+  exec(command: string, args: string[], options?: { cwd?: string; timeout?: number }): Promise<{ stdout: string; stderr: string; code: number }>
+}
+
+/**
+ * A command body expanded to the text a turn (or a tool result) carries:
+ * argument and named substitution, ${CLAUDE_*} and plugin variables, `!` spans
+ * and `@file` inlining, plus Claude's `ARGUMENTS:` append when the body never
+ * read what was passed. Throws when an injected span fails, so a caller never
+ * sees a half-expanded body. With `allowShell: false` no span executes at all;
+ * each is replaced by SHELL_DISABLED_PLACEHOLDER, which is how both the model
+ * path and the disableSkillShellExecution setting keep repo-authored shell
+ * from running.
+ */
+export async function expandCommand(runner: SpanRunner, parsed: ParsedCommand, args: string, ctx: { cwd: string }, filePath: string, plugin?: CommandPlugin, options?: { allowShell?: boolean }): Promise<string> {
+  const projectRoot = repoRoot(ctx.cwd) ?? ctx.cwd
+  const vars = commandVars(ctx, filePath, plugin)
+  const { text: withArgs, consumed } = substituteArgsDetailed(parsed.body, args, parsed.argumentNames ?? [])
+  // `${user_config.KEY}` is a plugin-command variable only; leave it literal in an
+  // ordinary command so a body that happens to contain the syntax is not stripped.
+  const substituted = substituteVars(withArgs, vars)
+  const withVars = plugin ? substituted.replace(/\$\{user_config\.([A-Za-z0-9_]+)\}/g, (_, key: string) => plugin.userConfig?.[key] ?? '') : substituted
+
+  const exec: CommandExec =
+    (options?.allowShell ?? true)
+      ? async (script) => {
+          // Hooks get CLAUDE_PROJECT_DIR, and a command's shell span is the same kind of
+          // project-scoped script. pi.exec takes no env, so it is set in the script.
+          // stderr merges into stdout, as the Bash tool runs these for Claude. The
+          // resolver is passed by its imported binding so tests can stub the lookup.
+          const run = spanExec(parsed.shell, projectRoot, script, resolvePowershellBinary)
+          const result = await runner.exec(run.command, run.args, { cwd: ctx.cwd, timeout: BASH_TIMEOUT_MS })
+          // pwsh cannot merge a native command's stderr in-script (spanExec sets
+          // mergeStreams), so it is appended here; the sh script merges via 2>&1.
+          const stdout = run.mergeStreams ? result.stdout + result.stderr : result.stdout
+          return { stdout, stderr: result.stderr, code: result.code }
+        }
+      : async () => ({ stdout: SHELL_DISABLED_PLACEHOLDER, stderr: '', code: 0 })
+  let expanded = await expandDynamicContent(withVars, ctx.cwd, exec)
+
+  // Claude appends the raw arguments when the command never read them, so what
+  // the user typed still reaches the model.
+  if (args.trim().length > 0 && !consumed) expanded += `\n\nARGUMENTS: ${args.trim()}`
+  return expanded
+}
+
+export interface SlashCommandEntry {
+  name: string
+  description: string
+  argumentHint?: string
+}
+
+/** One listed command's cap inside the tool description, as Claude cuts an
+ * oversized description rather than dropping the command. */
+const ENTRY_CHAR_CAP = 1536
+
+/** Claude's default character budget for the SlashCommand tool description. */
+const DEFAULT_TOOL_CHAR_BUDGET = 15_000
+
+/** The description budget: SLASH_COMMAND_TOOL_CHAR_BUDGET when set, else about
+ * 1% of the model's context window (1% of the tokens at ~4 characters per token
+ * is window / 25), else Claude's documented default. */
+export function slashCommandBudget(contextWindow: number | undefined, env: Record<string, string | undefined> = process.env): number {
+  const override = Number.parseInt(env.SLASH_COMMAND_TOOL_CHAR_BUDGET ?? '', 10)
+  if (Number.isInteger(override) && override > 0) return override
+  if (contextWindow && contextWindow > 0) return Math.floor(contextWindow / 25)
+  return DEFAULT_TOOL_CHAR_BUDGET
+}
+
+/** The slash_command tool description: usage framing plus the budgeted command
+ * list, each entry `/name - description (argument-hint)`. */
+export function slashCommandToolDescription(commands: SlashCommandEntry[], budget: number): string {
+  const lines: string[] = []
+  let used = 0
+  let omitted = 0
+  for (const command of commands) {
+    const entry = `/${command.name} - ${command.description}${command.argumentHint ? ` (${command.argumentHint})` : ''}`.slice(0, ENTRY_CHAR_CAP)
+    if (used + entry.length + 1 > budget) {
+      omitted++
+      continue // a shorter later entry may still fit the remaining budget
+    }
+    used += entry.length + 1
+    lines.push(entry)
+  }
+  if (omitted > 0) lines.push(`(${omitted} more ${omitted === 1 ? 'command was' : 'commands were'} omitted: raise SLASH_COMMAND_TOOL_CHAR_BUDGET to list them)`)
+  return ["Execute a custom slash command on the user's behalf. The command expands to instructions for you to follow in this conversation.", '', 'Available commands:', ...lines].join('\n')
+}
+
 export default function commandsExtension(pi: ExtensionAPI) {
   const registered = new Set<string>()
-  /** Tool set to put back once the turn a restricted command drove has ended. */
+  /** Every command file discovered for the current session, by name, for the
+   * slash_command tool to resolve against. Rebuilt on each session_start (a resume,
+   * fork, or new session can land on a different project) so the model never resolves
+   * a command left over from a previous project's session. Kept fresh even for names
+   * already registered. */
+  const discovered = new Map<string, DiscoveredCommand>()
+  /** pi has no unregister, so the slash_command tool registers once per process. */
+  let toolRegistered = false
+  /** The session_start approval decision, reused for per-invocation settings reads. */
+  let projectApproved = false
+  /** Tool set to put back once the run a restricted command drove has ended. */
   let pendingRestore: string[] | undefined
-  /** `Bash(...)` scopes enforced while that turn runs; lifted with the restriction. */
+  /** `Bash(...)` scopes enforced while that run lasts; lifted with the restriction. */
   let pendingBashRules: string[] | undefined
   /** Read/Edit path scopes enforced the same way, per pi file tool. */
   let pendingPathRules: Partial<Record<PathRuleTool, string[]>> | undefined
-  /** The session model to restore after a command's `model:` override drove its turn. */
+  /** The session model to restore after a command's `model:` override drove its run. */
   let pendingModelRestore: ModelLike | undefined
 
-  pi.on('turn_end', async () => {
+  // Claude's contract is "the grant clears when you send your next message", and
+  // pi's turn_end fires after every assistant step: restoring there stripped a
+  // multi-step command's tool and model scoping as soon as its first tool batch
+  // came back. agent_end is not the end either: it fires once per agent loop, ahead
+  // of an automatic retry, an auto-compaction-and-retry, or a Stop-hook continuation,
+  // so restoring there lifts the scoping before that continued run executes.
+  // agent_settled fires exactly once, after the run has fully settled and no such
+  // continuation remains, which is the grant's true clearing point.
+  pi.on('agent_settled', async () => {
     pendingBashRules = undefined
     pendingPathRules = undefined
     if (pendingModelRestore) {
@@ -165,37 +336,13 @@ export default function commandsExtension(pi: ExtensionAPI) {
     }
   })
 
-  async function runCommand(parsed: ParsedCommand, args: string, ctx: ExtensionCommandContext, filePath: string, plugin?: { root: string; dataDir: string; userConfig?: Record<string, string> }): Promise<void> {
+  async function runCommand(parsed: ParsedCommand, args: string, ctx: ExtensionCommandContext, filePath: string, plugin?: CommandPlugin): Promise<void> {
     const varCtx = ctx as unknown as VarContext
-    const projectRoot = repoRoot(ctx.cwd) ?? ctx.cwd
-    const vars: Record<string, string | undefined> = {
-      CLAUDE_SESSION_ID: varCtx.sessionManager?.getSessionId?.(),
-      CLAUDE_EFFORT: varCtx.thinkingLevel,
-      CLAUDE_SKILL_DIR: path.dirname(filePath),
-      CLAUDE_PROJECT_DIR: projectRoot,
-      CLAUDE_PLUGIN_ROOT: plugin?.root,
-      CLAUDE_PLUGIN_DATA: plugin?.dataDir,
-    }
-    const { text: withArgs, consumed } = substituteArgsDetailed(parsed.body, args, parsed.argumentNames ?? [])
-    // `${user_config.KEY}` is a plugin-command variable only; leave it literal in an
-    // ordinary command so a body that happens to contain the syntax is not stripped.
-    const substituted = substituteVars(withArgs, vars)
-    const withVars = plugin ? substituted.replace(/\$\{user_config\.([A-Za-z0-9_]+)\}/g, (_, key: string) => plugin.userConfig?.[key] ?? '') : substituted
+    const vars = commandVars(ctx, filePath, plugin)
 
     let expanded: string
     try {
-      expanded = await expandDynamicContent(withVars, ctx.cwd, async (script) => {
-        // Hooks get CLAUDE_PROJECT_DIR, and a command's shell span is the same kind of
-        // project-scoped script. pi.exec takes no env, so it is set in the script.
-        // stderr merges into stdout, as the Bash tool runs these for Claude. The
-        // resolver is passed by its imported binding so tests can stub the lookup.
-        const run = spanExec(parsed.shell, projectRoot, script, resolvePowershellBinary)
-        const result = await pi.exec(run.command, run.args, { cwd: ctx.cwd, timeout: BASH_TIMEOUT_MS })
-        // pwsh cannot merge a native command's stderr in-script (spanExec sets
-        // mergeStreams), so it is appended here; the sh script merges via 2>&1.
-        const stdout = run.mergeStreams ? result.stdout + result.stderr : result.stdout
-        return { stdout, stderr: result.stderr, code: result.code }
-      })
+      expanded = await expandCommand(pi, parsed, args, ctx, filePath, plugin, { allowShell: !shellExecutionDisabled(ctx.cwd, os.homedir(), projectApproved) })
     } catch (error) {
       // A failed injected command aborts the invocation; the model never sees a
       // half-expanded body. The notify carries Claude's failure message format.
@@ -203,12 +350,8 @@ export default function commandsExtension(pi: ExtensionAPI) {
       return
     }
 
-    // Claude appends the raw arguments when the command never read them, so what
-    // the user typed still reaches the model.
-    if (args.trim().length > 0 && !consumed) expanded += `\n\nARGUMENTS: ${args.trim()}`
-
-    // allowed-tools restricts the turn the command drives, and the previous set is
-    // restored when that turn ends. Restoring inline does not work: sendUserMessage is
+    // allowed-tools restricts the run the command drives, and the previous set is
+    // restored when that run ends. Restoring inline does not work: sendUserMessage is
     // fire-and-forget, so the restore would land before the agent ever read the tool
     // list, leaving the command running with everything enabled.
     if (parsed.allowedTools) {
@@ -243,9 +386,9 @@ export default function commandsExtension(pi: ExtensionAPI) {
       const disallowed = parsed.disallowedTools
       pi.setActiveTools(pi.getActiveTools().filter((tool) => !disallowed.includes(tool)))
     }
-    // Claude's `model:` frontmatter overrides the model for this turn only, then the
-    // session model resumes; restore happens on turn_end like the tool-set restore.
-    // Applied before sendUserMessage so the turn it drives runs on the new model.
+    // Claude's `model:` frontmatter overrides the model for this run only, then the
+    // session model resumes; restore happens on agent_settled like the tool-set restore.
+    // Applied before sendUserMessage so the run it drives happens on the new model.
     const target = resolveCommandModel(parsed.model, varCtx.modelRegistry?.getAvailable() ?? [])
     if (target && varCtx.model && target.id !== varCtx.model.id) {
       pendingModelRestore = pendingModelRestore ?? varCtx.model
@@ -256,20 +399,33 @@ export default function commandsExtension(pi: ExtensionAPI) {
 
   pi.on('session_start', async (_event, ctx) => {
     const trusted = await isProjectApproved(ctx)
+    projectApproved = trusted
+    // A resume/fork/new session can switch projects in-process. pi cannot unregister a
+    // command or re-describe the slash_command tool, so a name registered in an earlier
+    // project keeps its user-path binding and the tool description stays frozen at the
+    // first session's list; that is a pi limitation. What must not persist is the map
+    // the model resolves against, so it is rebuilt from scratch here: a stale command
+    // from a previous project resolves to "unknown" rather than being expanded.
+    discovered.clear()
     // Plugins are user-installed and enabled by user settings; a checked-out repo
     // must not silently flip which code-bearing plugins run, so enablement is
     // user-scoped and never reads the project settings chain (see installedPlugins).
     const plugins = pluginCommands(installedPlugins(os.homedir()))
+    const invocable: SlashCommandEntry[] = []
     for (const command of [...collectCommands(commandDirs(ctx.cwd, os.homedir(), trusted)), ...plugins]) {
-      // pi has no unregister, so a command already registered this process keeps its
-      // original file binding; re-registering would only add a numbered duplicate.
-      if (registered.has(command.name)) continue
       let parsed: ParsedCommand
       try {
         parsed = parseCommandFile(fs.readFileSync(command.filePath, 'utf-8'))
       } catch {
         continue // an unreadable command file must not take down session start
       }
+      discovered.set(command.name, command)
+      // A user-only command stays off the tool description; it is still in the
+      // map so a model attempt gets the explicit refusal, not "unknown command".
+      if (!parsed.disableModelInvocation) invocable.push({ name: command.name, description: parsed.description, argumentHint: parsed.argumentHint })
+      // pi has no unregister, so a command already registered this process keeps its
+      // original file binding; re-registering would only add a numbered duplicate.
+      if (registered.has(command.name)) continue
       registered.add(command.name)
       pi.registerCommand(command.name, {
         description: parsed.argumentHint ? `${parsed.description} ${parsed.argumentHint}` : parsed.description,
@@ -285,5 +441,42 @@ export default function commandsExtension(pi: ExtensionAPI) {
         },
       })
     }
+
+    // Claude's SlashCommand tool, registered only when there is something for the
+    // model to call: an empty tool would spend context saying "nothing available".
+    if (toolRegistered || invocable.length === 0) return
+    toolRegistered = true
+    pi.registerTool({
+      name: 'slash_command',
+      label: 'SlashCommand',
+      description: slashCommandToolDescription(invocable, slashCommandBudget((ctx as unknown as VarContext).model?.contextWindow)),
+      parameters: Type.Object({ command: Type.String({ description: 'The command to run with args, e.g. "/deploy staging"' }) }),
+      async execute(_toolCallId, params, _signal, _onUpdate, execCtx) {
+        const line = params.command.trim().replace(/^\//, '')
+        const space = line.search(/\s/)
+        const name = space === -1 ? line : line.slice(0, space)
+        const args = space === -1 ? '' : line.slice(space + 1).trim()
+        // pi marks a tool result as an error only when execute() throws, so the
+        // failure paths below throw rather than return.
+        const command = discovered.get(name)
+        if (!name || !command) throw new Error(`Unknown command: /${name || params.command}. Only the custom commands listed in the slash_command tool description can be run.`)
+        // Live-edit parity with the user path: re-read on every invocation, so a
+        // just-added disable-model-invocation takes effect immediately too.
+        let current: ParsedCommand
+        try {
+          current = parseCommandFile(fs.readFileSync(command.filePath, 'utf-8'))
+        } catch {
+          throw new Error(`/${name}: the command file could not be read (${command.filePath}).`)
+        }
+        if (current.disableModelInvocation) {
+          throw new Error(`/${name} is user-only (disable-model-invocation: true) and was not run. Do not reproduce this command's steps or try to achieve its effect another way; only the user can invoke it.`)
+        }
+        // Expansion only, never sendUserMessage (that would spawn a second turn):
+        // the tool result is the channel, and frontmatter scoping stays user-path
+        // territory (see the header).
+        const expanded = await expandCommand(pi, current, args, execCtx, command.filePath, command.plugin, { allowShell: false })
+        return { content: [{ type: 'text' as const, text: `Contents of /${name} (expanded):\n\n${expanded}` }], details: {} }
+      },
+    })
   })
 }

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -43,7 +43,10 @@
  *
  * Config is merged from ~/.claude/settings.json (always) plus the project's
  * .claude/settings.json and settings.local.json (only when the project is
- * trusted, since hooks execute arbitrary shell). Matchers follow Claude's rule:
+ * trusted, since hooks execute arbitrary shell). Claude's `disableAllHooks`
+ * setting (managed settings or any honored file in that chain) short-circuits
+ * the load entirely, so no event fires any hook; /hooks prints the resolved
+ * chain per event with each entry's source settings file. Matchers follow Claude's rule:
  * `*`/empty match all, plain names are exact (with `|`/`,` list separators), and
  * anything with other regex characters is an unanchored regex. Claude matchers
  * are PascalCase (`Bash`); pi tool names are lowercase (`bash`), so comparison
@@ -60,6 +63,7 @@ import type { Api, Model } from '@earendil-works/pi-ai'
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
 import { runAgent } from './internal/agent-run.js'
 import { INSTRUCTIONS_CHANNEL, isInstructionLoadEvent } from './internal/instruction-events.js'
+import { readManagedSettings } from './internal/managed-settings.js'
 import { isMcpToolAliases, MCP_TOOLS_CHANNEL } from './internal/mcp-alias.js'
 import { callMcpTool } from './internal/mcp-call.js'
 import { completeText } from './internal/model-complete.js'
@@ -94,7 +98,7 @@ interface HookCommand {
   model?: string
   systemPrompt?: string
 }
-interface HookMatcher {
+export interface HookMatcher {
   matcher?: string
   hooks: HookCommand[]
 }
@@ -133,7 +137,26 @@ export function hookFiles(cwd: string, home: string, trusted: boolean): string[]
   return files
 }
 
-export function loadHooks(files: string[]): HooksConfig {
+/** Claude's `disableAllHooks` setting: the escape hatch a user reaches for when a
+ * hook misbehaves, so it is honored before any hook runs. Disabled when managed
+ * settings or ANY file in the settings chain sets it to `true`; deliberately not
+ * last-file-wins, since a repository file re-enabling the hooks the user just
+ * disabled in their own settings would defeat the escape hatch. The chain itself
+ * already gates project files on trust (see hookFiles). */
+export function readDisableAllHooks(files: string[], managed: Record<string, unknown> = readManagedSettings()): boolean {
+  if (managed.disableAllHooks === true) return true
+  for (const file of files) {
+    try {
+      const parsed: unknown = JSON.parse(fs.readFileSync(file, 'utf-8'))
+      if (isRecord(parsed) && parsed.disableAllHooks === true) return true
+    } catch {
+      // missing or invalid file: skip
+    }
+  }
+  return false
+}
+
+export function loadHooks(files: string[], sources?: Map<HookMatcher, string>): HooksConfig {
   const config: HooksConfig = {}
   for (const file of files) {
     let raw: string
@@ -142,12 +165,12 @@ export function loadHooks(files: string[]): HooksConfig {
     } catch {
       continue
     }
-    mergeHooksJson(config, raw, file)
+    mergeHooksJson(config, raw, file, sources)
   }
   return config
 }
 
-function mergeHooksJson(config: HooksConfig, raw: string, source: string): void {
+function mergeHooksJson(config: HooksConfig, raw: string, source: string, sources?: Map<HookMatcher, string>): void {
   let parsed: { hooks?: HooksConfig }
   try {
     parsed = JSON.parse(raw)
@@ -161,26 +184,30 @@ function mergeHooksJson(config: HooksConfig, raw: string, source: string): void 
     // the tool_call handler, and pi turns that into an error result, so every tool
     // call for the rest of the session failed with an opaque type error.
     const usable = matchers.filter((entry) => isUsableMatcher(entry, source, event))
-    if (usable.length > 0) config[event] = [...(config[event] ?? []), ...usable]
+    if (usable.length === 0) continue
+    config[event] = [...(config[event] ?? []), ...usable]
+    // Each parse produces fresh entry objects, so object identity keys the /hooks
+    // viewer's source attribution without touching the entries themselves.
+    for (const entry of usable) sources?.set(entry, source)
   }
 }
 
 /** Each enabled plugin's hooks (hooks/hooks.json, or wherever the manifest points),
  * with ${CLAUDE_PLUGIN_ROOT}/${CLAUDE_PLUGIN_DATA} substituted before parsing so a
  * hook can name its bundled scripts by real path. */
-export function loadPluginHooks(config: HooksConfig, plugins: InstalledPlugin[]): void {
+export function loadPluginHooks(config: HooksConfig, plugins: InstalledPlugin[], sources?: Map<HookMatcher, string>): void {
   for (const plugin of plugins) {
     const declared = plugin.manifest.hooks
     // An inline hooks object; an array is not a valid hooks map (it would parse to
     // numeric event keys), so it falls through to the default path rather than
     // silently registering nothing.
     if (declared !== null && typeof declared === 'object' && !Array.isArray(declared)) {
-      mergeHooksJson(config, substitutePluginVars(JSON.stringify({ hooks: declared }), plugin), `${plugin.name} (plugin.json)`)
+      mergeHooksJson(config, substitutePluginVars(JSON.stringify({ hooks: declared }), plugin), `${plugin.name} (plugin.json)`, sources)
       continue
     }
     const file = path.resolve(plugin.root, typeof declared === 'string' ? declared : path.join('hooks', 'hooks.json'))
     try {
-      mergeHooksJson(config, substitutePluginVars(fs.readFileSync(file, 'utf-8'), plugin), file)
+      mergeHooksJson(config, substitutePluginVars(fs.readFileSync(file, 'utf-8'), plugin), file, sources)
     } catch {
       // a plugin without hooks contributes nothing
     }
@@ -270,6 +297,42 @@ export function matchingCommands(matchers: HookMatcher[] | undefined, names: str
     }
   }
   return result
+}
+
+/** A hook entry's display identity for the /hooks viewer: the command for shell
+ * hooks, otherwise the type-qualified url / prompt / server:tool. A missing field
+ * is named rather than hidden, since a misconfigured entry is exactly what the
+ * viewer exists to surface. */
+function hookIdentity(hook: HookCommand | null | undefined): string {
+  // A hand-edited settings file can leave a null (or otherwise empty) entry in a
+  // hooks array; name it rather than let it crash the viewer that exists to surface
+  // exactly this kind of misconfiguration.
+  const record: Partial<HookCommand> = hook ?? {}
+  const type = record.type ?? 'command'
+  if (type === 'http') return `http: ${record.url ?? record.command ?? '(missing url)'}`
+  if (type === 'prompt' || type === 'agent') return `${type}: ${record.prompt ?? record.command ?? '(missing prompt)'}`
+  if (type === 'mcp_tool') return `mcp_tool: ${record.server ?? '(missing server)'}:${record.tool ?? '(missing tool)'}`
+  return `command: ${record.command ?? '(missing command)'}`
+}
+
+/** Render the resolved hooks config as a readable per-event summary for /hooks:
+ * one line per configured hook with its matcher, identity and, when known, the
+ * settings file it came from. Pure formatting of already-resolved data. */
+export function formatHooksSummary(config: HooksConfig, sources?: Map<HookMatcher, string>): string {
+  const lines: string[] = []
+  for (const [event, matchers] of Object.entries(config)) {
+    const entryLines: string[] = []
+    for (const entry of matchers) {
+      const matcher = entry.matcher || '*'
+      const source = sources?.get(entry)
+      for (const hook of entry.hooks ?? []) {
+        entryLines.push(`  [${matcher}] ${hookIdentity(hook)}${source ? ` (${source})` : ''}`)
+      }
+    }
+    if (entryLines.length > 0) lines.push(`${event}:`, ...entryLines)
+  }
+  if (lines.length === 0) return 'No hooks configured. Add a "hooks" section to ~/.claude/settings.json or .claude/settings.json.'
+  return lines.join('\n')
 }
 
 function tryParseJson(text: string): { hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string; additionalContext?: string; updatedInput?: unknown }; decision?: string; reason?: string; continue?: boolean; stopReason?: string; systemMessage?: string } | undefined {
@@ -652,6 +715,10 @@ export default function hooksExtension(pi: ExtensionAPI) {
   let pendingSessionContext: string[] = []
   let stopHookActive = false
   let sessionCtx: ExtensionContext | undefined
+  /** Claude's disableAllHooks escape hatch was set somewhere in the honored chain. */
+  let hooksDisabled = false
+  /** Which settings file each resolved entry came from, for the /hooks viewer. */
+  const hookSources = new Map<HookMatcher, string>()
   /** Claude sends session_id, transcript_path, cwd and effort on every payload. */
   const commonPayload = (ctx: ExtensionContext): Record<string, unknown> => {
     const common: Record<string, unknown> = { session_id: ctx.sessionManager.getSessionId(), cwd: ctx.cwd, permission_mode: permissionMode }
@@ -728,10 +795,20 @@ export default function hooksExtension(pi: ExtensionAPI) {
     // referencing $CLAUDE_PROJECT_DIR/.claude/hooks/helper.sh must resolve from a
     // subdirectory session too.
     projectDir = repoRoot(ctx.cwd) ?? ctx.cwd
-    config = loadHooks(hookFiles(ctx.cwd, os.homedir(), trusted))
+    const files = hookFiles(ctx.cwd, os.homedir(), trusted)
+    hookSources.clear()
+    // The disableAllHooks escape hatch, checked before any config loads: with no
+    // config resolved, no event, plugin hooks included, can fire a hook.
+    hooksDisabled = readDisableAllHooks(files)
+    if (hooksDisabled) {
+      config = {}
+      pendingSessionContext = []
+      return
+    }
+    config = loadHooks(files, hookSources)
     // Plugins are user-installed and enabled by user settings (see installedPlugins),
     // so a checked-out repo cannot toggle which code-bearing plugin hooks run.
-    loadPluginHooks(config, installedPlugins(os.homedir()))
+    loadPluginHooks(config, installedPlugins(os.homedir()), hookSources)
     // "reload" re-fires in-process with the same conversation and would double-run hooks;
     // a fork is a genuine session begin, which Claude reports as source "fork".
     if (event.reason === 'reload') return
@@ -868,5 +945,19 @@ export default function hooksExtension(pi: ExtensionAPI) {
     const reason = claudeSpelling(SESSION_END_REASON, event.reason)
     const results = await runNotifyHooks(matchingCommands(config.SessionEnd, reason.names), { hook_event_name: 'SessionEnd', reason: reason.value }, boundRunner(ctx))
     surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
+  })
+
+  // Claude's /hooks manages hook configuration; pi-code's is a viewer: hook failures
+  // are otherwise opaque, so showing the resolved chain per event, with the settings
+  // file each entry came from, is the debugging surface.
+  pi.registerCommand('hooks', {
+    description: 'Show the hook configuration resolved from settings',
+    handler: async (_args, ctx) => {
+      if (hooksDisabled) {
+        ctx.ui.notify('All hooks are disabled by the disableAllHooks setting.', 'info')
+        return
+      }
+      ctx.ui.notify(formatHooksSummary(config, hookSources), 'info')
+    },
   })
 }

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -66,6 +66,10 @@ const CLAUDE_TOOL_MAP: Record<string, string> = {
   task: 'subagent',
   askuserquestion: 'question',
   exitplanmode: 'plan_mode_complete',
+  // Claude's name for the tool this package registers so the model can run user slash
+  // commands; without it `allowed-tools: SlashCommand` matched nothing and the grant
+  // could neither keep nor drop the tool.
+  slashcommand: 'slash_command',
 }
 
 /**
@@ -193,6 +197,14 @@ const text = (value: unknown): string => {
   return typeof value === 'number' || typeof value === 'boolean' ? String(value) : ''
 }
 
+/** YAML's affirmative boolean spellings. Claude documents `disable-model-invocation:
+ * true`, but a command file is hand-written YAML where `yes`, `on`, and `1` are all
+ * ordinary spellings of true, and pi's parser hands those back as the raw string or
+ * number rather than a boolean. A flag that gates a command off from the model has to
+ * honor them, or a command the user marked off-limits is silently offered to it. */
+const YAML_TRUE = new Set(['true', 'yes', 'on', 'y', '1'])
+const isFlagEnabled = (value: unknown): boolean => value === true || YAML_TRUE.has(text(value).toLowerCase())
+
 /** Claude writes `argument-hint: [pr]`, which YAML reads as a list; render it back. */
 const hint = (value: unknown): string => (Array.isArray(value) ? `[${value.join(', ')}]` : text(value))
 
@@ -233,7 +245,7 @@ export function parseCommandFile(content: string): ParsedCommand {
     disallowedTools: parseToolGrants(frontmatter['disallowed-tools'])?.tools,
     shell: SHELLS.has(shell) ? shell : undefined,
     model: text(frontmatter.model) || undefined,
-    disableModelInvocation: disable === true || text(disable) === 'true',
+    disableModelInvocation: isFlagEnabled(disable),
     body,
   }
 }

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -16,6 +16,17 @@
  * Values support ${VAR} / ${VAR:-default} interpolation, connect and per-call timeouts
  * honor MCP_TIMEOUT / MCP_TOOL_TIMEOUT, and a stdio server receives only the SDK's default
  * environment plus its own `env` block, not the whole process environment.
+ *
+ * Servers advertising the `prompts` capability get their prompts registered as Claude's
+ * /mcp__<server>__<prompt> slash commands (names normalized dashes/spaces to underscores,
+ * args space-separated and mapped positionally); the prompt result drives a turn via
+ * sendUserMessage, exactly how custom slash commands do. Servers advertising `resources`
+ * make the global list_mcp_resources / read_mcp_resource tools available, mirroring
+ * Claude's automatic resource tools. Resource and prompt output rides the same
+ * mapContent/capForContext budget as tool output. That budget is byte/line based
+ * (pi's DEFAULT_MAX_BYTES in the shared output guard); Claude's MAX_MCP_OUTPUT_TOKENS
+ * is a token budget and cannot be folded into it without making the guard token-aware,
+ * so the byte cap stands in for it.
  */
 
 import { execFile } from 'node:child_process'
@@ -32,8 +43,9 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js' // 
 import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/websocket.js'
-import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
+import { PromptListChangedNotificationSchema, ResourceListChangedNotificationSchema, ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
 import { Type } from 'typebox'
+import { splitArgs } from './internal/command-file.js'
 import { MCP_TOOLS_CHANNEL, type McpToolAlias } from './internal/mcp-alias.js'
 import { setMcpToolCaller } from './internal/mcp-call.js'
 import { FileOAuthProvider, openBrowser, startCallbackServer, waitForAuthCode } from './internal/mcp-oauth.js'
@@ -61,7 +73,9 @@ const callTimeoutMs = (): number => envTimeout('MCP_TOOL_TIMEOUT', DEFAULT_CALL_
 // pi's own built-ins (read, bash, edit, ...) cannot be produced and are not listed.
 // These are pi-code's own tools, and mcp.ts registers before the extensions owning
 // them, so without this guard a server named `web` would replace the SSRF-checked fetch.
-const RESERVED_NAMES = new Set(['web_fetch', 'web_search', 'plan_mode_complete'])
+// The resource tools are this extension's own globals; a server named `list` or `read`
+// must not take their names either.
+const RESERVED_NAMES = new Set(['web_fetch', 'web_search', 'plan_mode_complete', 'list_mcp_resources', 'read_mcp_resource'])
 
 export interface StdioServerConfig {
   type?: 'stdio'
@@ -317,6 +331,52 @@ export function warnOnTypelessUrl(name: string, config: ServerConfig): void {
 
 export function formatToolName(server: string, tool: string): string {
   return `${server}_${tool}`.replaceAll('-', '_')
+}
+
+/** Claude exposes server prompts as /mcp__<server>__<prompt> slash commands. Both
+ * names normalize like formatToolName, extended to spaces: dashes and spaces each
+ * become an underscore. */
+export function formatPromptCommandName(server: string, prompt: string): string {
+  const normalize = (name: string): string => name.replace(/[\s-]/g, '_')
+  return `mcp__${normalize(server)}__${normalize(prompt)}`
+}
+
+export interface McpPromptArgumentInfo {
+  name: string
+  description?: string
+  required?: boolean
+}
+
+export interface McpPromptInfo {
+  name: string
+  description?: string
+  arguments?: McpPromptArgumentInfo[]
+}
+
+/** Claude passes prompt arguments space-separated after the command. Tokens map
+ * positionally onto the declared arguments, split the way slash-command args are
+ * (quoted runs stay together); the last declared argument absorbs any trailing
+ * tokens so free text at the end is not silently dropped. Declared arguments with
+ * no token are omitted, and the server enforces its own `required`. */
+export function mapPromptArguments(declared: ReadonlyArray<{ name: string }> | undefined, args: string): Record<string, string> {
+  const tokens = splitArgs(args)
+  const names = (declared ?? []).map((argument) => argument.name)
+  const mapped: Record<string, string> = {}
+  for (let index = 0; index < names.length && index < tokens.length; index++) {
+    mapped[names[index]] = index === names.length - 1 ? tokens.slice(index).join(' ') : tokens[index]
+  }
+  return mapped
+}
+
+/** The content blocks a getPrompt result injects. Each message carries one content
+ * block; the blocks ride the same mapContent budget as tool output, and image blocks
+ * are carried through rather than dropped, since sendUserMessage accepts them and a
+ * vision prompt is worthless flattened to text. An empty message list yields no
+ * blocks, and messages that carry only empty text yield none either, so the caller
+ * can skip the turn rather than drive it on an empty or sentinel message. */
+export function promptMessageContent(messages: ReadonlyArray<{ content: unknown }>): ToolContent[] {
+  if (messages.length === 0) return []
+  return mapContent(messages.map((message) => message.content as McpContentBlock)).filter((block) => block.type !== 'text' || block.text.trim() !== '')
 }
 
 export function normalizeSchema(schema: unknown): object {
@@ -603,6 +663,17 @@ async function listAllTools(client: Client): Promise<McpToolInfo[]> {
   return tools
 }
 
+async function listAllPrompts(client: Client): Promise<McpPromptInfo[]> {
+  const prompts: McpPromptInfo[] = []
+  let cursor: string | undefined
+  do {
+    const page = await client.listPrompts({ cursor })
+    prompts.push(...page.prompts)
+    cursor = page.nextCursor
+  } while (cursor)
+  return prompts
+}
+
 export default async function mcpExtension(pi: ExtensionAPI) {
   const clients = new Map<string, Client>()
   const status = new Map<string, { state: string; tools: number }>()
@@ -662,6 +733,169 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     return count
   }
 
+  // Prompt command name -> the server and prompt that own it, so a refresh re-listing
+  // the same prompt is told apart both from a cross-server collision and from a second
+  // prompt on the same server whose name normalizes to the one already taken (e.g.
+  // `deploy-prod` and `deploy_prod`), mirroring `registered` for tools.
+  const registeredPrompts = new Map<string, { server: string; prompt: string }>()
+
+  /** Register a slash command for every not-yet-registered prompt of a server. pi has
+   * no command unregister, so, like tools, a withdrawn prompt keeps its registration
+   * and surfaces the server's own error when invoked; an edit to a prompt's declared
+   * arguments only lands on new names, since an existing command keeps its binding. */
+  function registerPrompts(name: string, client: Client, prompts: McpPromptInfo[]): void {
+    for (const prompt of prompts) {
+      const commandName = formatPromptCommandName(name, prompt.name)
+      const owner = registeredPrompts.get(commandName)
+      if (owner) {
+        if (owner.server === name && owner.prompt === prompt.name) continue // a refresh re-listing the same prompt
+        console.warn(`pi-code-mcp: skipping colliding prompt command ${commandName}`)
+        continue
+      }
+      registeredPrompts.set(commandName, { server: name, prompt: prompt.name })
+      const hint = (prompt.arguments ?? []).map((argument) => (argument.required ? `<${argument.name}>` : `[${argument.name}]`)).join(' ')
+      const base = prompt.description ?? `MCP prompt ${prompt.name} from ${name}`
+      pi.registerCommand(commandName, {
+        description: hint ? `${base} ${hint}` : base,
+        handler: async (args, ctx) => {
+          try {
+            const promptArgs = mapPromptArguments(prompt.arguments, args)
+            const params: { name: string; arguments?: Record<string, string> } = { name: prompt.name }
+            if (Object.keys(promptArgs).length > 0) params.arguments = promptArgs
+            const budget = callTimeoutMs()
+            const result = await withTimeout(client.getPrompt(params, { timeout: budget }), budget, commandName)
+            // The prompt drives a turn exactly the way a custom slash command does
+            // (see commands.ts), carrying its image blocks through. A prompt that
+            // yields no content is reported rather than sent as an empty turn.
+            const content = promptMessageContent(result.messages)
+            if (content.length === 0) {
+              ctx.ui.notify(`${commandName}: prompt returned no content`, 'info')
+              return
+            }
+            pi.sendUserMessage(content)
+          } catch (error) {
+            ctx.ui.notify(`${commandName}: ${error instanceof Error ? error.message : String(error)}`, 'error')
+          }
+        },
+      })
+    }
+  }
+
+  /** Claude exposes prompts as slash commands only for servers advertising the
+   * prompts capability; a listing failure loses the prompts, not the server. */
+  async function connectPrompts(name: string, client: Client): Promise<void> {
+    if (!client.getServerCapabilities()?.prompts) return
+    try {
+      registerPrompts(name, client, await withTimeout(listAllPrompts(client), connectTimeoutMs(), `list prompts ${name}`))
+    } catch (error) {
+      console.warn(`pi-code-mcp: prompt listing failed for ${name}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+  /** Mirror of subscribeToToolChanges for the prompt list: a newly announced prompt
+   * registers without a restart, a withdrawn one keeps its registration. */
+  function subscribeToPromptChanges(name: string, client: Client): void {
+    try {
+      client.setNotificationHandler(PromptListChangedNotificationSchema, async () => {
+        try {
+          registerPrompts(name, client, await withTimeout(listAllPrompts(client), connectTimeoutMs(), `list prompts ${name}`))
+        } catch (error) {
+          console.warn(`pi-code-mcp: prompt refresh failed for ${name}: ${error instanceof Error ? error.message : String(error)}`)
+        }
+      })
+    } catch {
+      // a transport or client without notification support simply never refreshes
+    }
+  }
+
+  /** Servers currently connected that advertise the resources capability. */
+  const resourceServers = (): Array<[string, Client]> => [...clients.entries()].filter(([, client]) => Boolean(client.getServerCapabilities()?.resources))
+
+  let resourceToolsRegistered = false
+
+  /** Claude auto-provides tools to list and read MCP resources when servers support
+   * them. Registered once, globally, the first time a connected server advertises the
+   * resources capability: the tools span servers, taking the server name as an
+   * argument, so per-server registration would only produce duplicates. Listings are
+   * fetched live on every call, so a resources list_changed needs no cache
+   * invalidation; its handler only re-checks this gate (see subscribeToResourceChanges). */
+  function ensureResourceTools(): void {
+    if (resourceToolsRegistered || resourceServers().length === 0) return
+    resourceToolsRegistered = true
+    pi.registerTool({
+      name: 'list_mcp_resources',
+      label: 'List MCP resources',
+      description: 'List available resources and resource templates from connected MCP servers. Optionally filter to a single server by name.',
+      parameters: Type.Object({ server: Type.Optional(Type.String({ description: 'Only list resources from this server' })) }),
+      async execute(_id, params) {
+        const filter = typeof (params as { server?: unknown }).server === 'string' && (params as { server: string }).server.length > 0 ? (params as { server: string }).server : undefined
+        if (filter && !clients.has(filter)) throw new Error(`MCP server "${filter}" is not connected`)
+        const entries: Array<Record<string, unknown>> = []
+        for (const [name, client] of resourceServers()) {
+          if (filter && name !== filter) continue
+          const budget = callTimeoutMs()
+          try {
+            let cursor: string | undefined
+            do {
+              const page = await withTimeout(client.listResources({ cursor }, { timeout: budget }), budget, `list resources ${name}`)
+              for (const resource of page.resources) entries.push({ server: name, uri: resource.uri, name: resource.name, ...(resource.description ? { description: resource.description } : {}), ...(resource.mimeType ? { mimeType: resource.mimeType } : {}) })
+              cursor = page.nextCursor
+            } while (cursor)
+          } catch (error) {
+            // One server failing must not empty the whole listing; surface it inline.
+            entries.push({ server: name, error: error instanceof Error ? error.message : String(error) })
+          }
+          try {
+            let cursor: string | undefined
+            do {
+              const page = await withTimeout(client.listResourceTemplates({ cursor }, { timeout: budget }), budget, `list resource templates ${name}`)
+              for (const template of page.resourceTemplates) entries.push({ server: name, uriTemplate: template.uriTemplate, name: template.name, ...(template.description ? { description: template.description } : {}), ...(template.mimeType ? { mimeType: template.mimeType } : {}) })
+              cursor = page.nextCursor
+            } while (cursor)
+          } catch {
+            // Templates are optional: a server with the resources capability but no
+            // templates answers method-not-found, which is not worth reporting.
+          }
+        }
+        return { content: mapContent([{ type: 'text', text: JSON.stringify(entries, null, 2) }]), details: {} }
+      },
+    })
+    pi.registerTool({
+      name: 'read_mcp_resource',
+      label: 'Read MCP resource',
+      description: 'Read a resource from a connected MCP server by URI.',
+      parameters: Type.Object({ server: Type.String({ description: 'The MCP server name' }), uri: Type.String({ description: 'The resource URI to read' }) }),
+      async execute(_id, params) {
+        const { server, uri } = params as { server: string; uri: string }
+        const client = clients.get(server)
+        if (!client) throw new Error(`MCP server "${server}" is not connected`)
+        const budget = callTimeoutMs()
+        const result = await withTimeout(client.readResource({ uri }, { timeout: budget }), budget, `read ${uri}`)
+        const blocks = (result.contents as Array<{ uri: string; text?: string; blob?: string; mimeType?: string }>).map((entry): McpContentBlock => {
+          if (typeof entry.text === 'string') return { type: 'resource', resource: { uri: entry.uri, text: entry.text } }
+          if (entry.blob && entry.mimeType?.startsWith('image/')) return { type: 'image', data: entry.blob, mimeType: entry.mimeType }
+          // Non-image binary has no useful text form; a placeholder beats megabytes
+          // of base64 reaching the model as JSON.
+          return { type: 'text', text: `[Binary resource ${entry.uri} (${entry.mimeType ?? 'unknown type'})]` }
+        })
+        return { content: mapContent(blocks), details: {} }
+      },
+    })
+  }
+
+  /** Resource listings are fetched live per call, so the notification has no cache to
+   * invalidate; re-checking the registration gate covers a server whose capabilities
+   * settled after the connect-time check. */
+  function subscribeToResourceChanges(client: Client): void {
+    try {
+      client.setNotificationHandler(ResourceListChangedNotificationSchema, async () => {
+        ensureResourceTools()
+      })
+    } catch {
+      // a transport or client without notification support simply never refreshes
+    }
+  }
+
   /** Claude refreshes tools on a server's list_changed notification. pi has no
    * unregister, so a withdrawn tool keeps its registration and surfaces the server's
    * own error when called; a newly announced one is registered without a restart. */
@@ -708,6 +942,12 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           const tools = await withTimeout(listAllTools(client), connectTimeoutMs(), `list tools ${name}`)
           const count = registerTools(name, config, client, tools)
           subscribeToToolChanges(name, config, client)
+          // Prompts and resources are additive surfaces: their failures warn (inside
+          // connectPrompts) rather than flipping a tool-serving server to failed.
+          await connectPrompts(name, client)
+          subscribeToPromptChanges(name, client)
+          ensureResourceTools()
+          subscribeToResourceChanges(client)
           status.set(name, { state: 'connected', tools: count })
           // A server that dies mid-session would otherwise stay "connected" in /mcp
           // while every call fails with the SDK's bare "Not connected"; flip the

--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -9,6 +9,8 @@
  * analogue, off the shared bus), and on the optional `refreshInterval` timer
  * (minimum 1s). A project-defined command is arbitrary shell, so project settings
  * count only once the project is already approved, read without prompting.
+ * Claude's `disableAllHooks` setting turns the configured command off too, and
+ * the built-in segment stands in.
  *
  * Without a configured statusLine, the built-in segment shows turn state plus
  * running session cost, summed from per-message usage on the current branch so it
@@ -24,7 +26,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
 
-import { hookFiles, runHookCommand } from './hooks.js'
+import { hookFiles, readDisableAllHooks, runHookCommand } from './hooks.js'
 import { isPlanModeState, PLAN_MODE_CHANNEL } from './internal/plan-mode-state.js'
 import { isProjectApprovedSilently } from './internal/project-approval.js'
 import { readActiveStyleName, settingsFiles } from './output-styles.js'
@@ -271,7 +273,10 @@ export default function statusLine(pi: ExtensionAPI) {
     // the keys meant for it. An undecided project simply skips project settings.
     const trusted = isProjectApprovedSilently(ctx)
     projectApproved = trusted
-    config = readStatusLineConfig(hookFiles(ctx.cwd, os.homedir(), trusted))
+    const files = hookFiles(ctx.cwd, os.homedir(), trusted)
+    // Claude's disableAllHooks also turns off the custom statusLine command; the
+    // built-in segment still renders as the fallback.
+    config = readDisableAllHooks(files) ? undefined : readStatusLineConfig(files)
     if (config?.refreshInterval) {
       refreshTimer = setInterval(() => scheduleRefresh(), config.refreshInterval * 1000)
     }

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -30,8 +30,8 @@ import { repoRoot } from '../internal/project-root.js'
 import { SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
 import { autoMemoryEnabled, capIndexForPrompt, INDEX_MAX_BYTES, INDEX_MAX_LINES, memorySettingsFiles, readMemorySettings } from '../memory.js'
 import { skillDirs } from '../skills.js'
-import { type AgentConfig, type AgentMemoryScope, type AgentScope, discoverAgents, resolveModelAlias, withPreloadedSkills } from './agents.js'
-import { activeBackgroundRuns, backgroundRun, backgroundStatusText, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
+import { type AgentConfig, type AgentMemoryScope, type AgentScope, type AgentSource, discoverAgents, resolveModelAlias, withPreloadedSkills } from './agents.js'
+import { activeBackgroundRuns, type BackgroundRun, backgroundRun, backgroundStatusText, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
 
 const MAX_PARALLEL_TASKS = 8
 const MAX_CONCURRENCY = 4
@@ -557,6 +557,65 @@ export function cancelResultText(id: string): string {
   return `Unknown background run: ${id}.\n\n${backgroundStatusText()}`
 }
 
+/** The registry fields the /tasks listing prints. */
+type BackgroundRunView = Pick<BackgroundRun, 'id' | 'agent' | 'task' | 'state' | 'turns' | 'output' | 'stderr'>
+
+const TASK_PREVIEW_CHARS = 60
+const TAIL_PREVIEW_CHARS = 200
+
+/** Truncate to at most `max` codepoints, iterating by codepoint so a multi-byte
+ * character on the boundary is never cut into a lone surrogate. Returns the whole
+ * string when it already fits, so a caller can tell it did not clip. */
+function clipCodepoints(text: string, max: number): string {
+  const points = Array.from(text)
+  return points.length > max ? points.slice(0, max).join('') : text
+}
+
+/** A one-line tail of what a run last said: the stderr tail for a failure (the only
+ * diagnostics a boot failure leaves), the latest assistant text otherwise. */
+function runOutputTail(run: BackgroundRunView): string | undefined {
+  const stderrTail = run.state === 'failed' ? run.stderr?.trim() : undefined
+  const raw = (stderrTail || run.output)?.trim()
+  if (!raw) return undefined
+  const last = raw.split('\n').at(-1)?.trim() ?? ''
+  const shortened = clipCodepoints(last, TAIL_PREVIEW_CHARS)
+  const clipped = shortened === last ? last : `${shortened}...`
+  return stderrTail ? `stderr: ${clipped}` : clipped
+}
+
+/** The /tasks listing: one line per background run, plus the short output tail the
+ * registry's own status lines omit. A pure formatter so it tests against a plain list. */
+export function tasksStatusText(runs: ReadonlyArray<BackgroundRunView>): string {
+  if (runs.length === 0) return 'No background subagent runs in this session.'
+  return runs
+    .map((run) => {
+      const label = run.state === 'running' ? 'running' : `${run.state} (${run.turns} turn${run.turns === 1 ? '' : 's'})`
+      const head = `${run.id} ${run.agent}: ${label} - ${clipCodepoints(run.task, TASK_PREVIEW_CHARS)}`
+      const tail = runOutputTail(run)
+      return tail ? `${head}\n  ${tail}` : head
+    })
+    .join('\n')
+}
+
+/** Listing order for /agents: lowest to highest precedence, matching how discovery
+ * lets a later source win a name clash. */
+const AGENT_SOURCE_ORDER: ReadonlyArray<AgentSource> = ['builtin', 'plugin', 'user', 'project']
+
+const AGENTS_DIR_HINT = 'Add agents as markdown files under ~/.claude/agents (user) or .claude/agents (project).'
+
+/** The /agents listing: the discovered roster grouped by source, with file paths.
+ * A pure formatter so it tests against a sample roster. */
+export function agentsListText(agents: ReadonlyArray<Pick<AgentConfig, 'name' | 'source' | 'filePath'>>): string {
+  if (agents.length === 0) return `No agents discovered.\n${AGENTS_DIR_HINT}`
+  const sections: string[] = []
+  for (const source of AGENT_SOURCE_ORDER) {
+    const group = agents.filter((agent) => agent.source === source)
+    if (group.length === 0) continue
+    sections.push(`${source}:\n${group.map((agent) => `  ${agent.name} - ${agent.filePath}`).join('\n')}`)
+  }
+  return `${sections.join('\n')}\n\n${AGENTS_DIR_HINT}`
+}
+
 /** Everything a mode handler needs from the surrounding execute() call. */
 interface ModeContext {
   agents: AgentConfig[]
@@ -729,7 +788,7 @@ function removeTmpPrompt(tmpPrompt: { dir: string; filePath: string } | undefine
   }
 }
 
-async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConfig[], defaultCwd: string, pi: ExtensionAPI, makeDetails: MakeDetails, skillRoots: string[], availableModels: ReadonlyArray<{ id: string }>, projectApproved: boolean): Promise<ToolResult> {
+async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConfig[], defaultCwd: string, pi: ExtensionAPI, makeDetails: MakeDetails, skillRoots: string[], availableModels: ReadonlyArray<{ id: string }>, projectApproved: boolean, onStarted?: (id: string) => void): Promise<ToolResult> {
   const task = params.task
   const agentName = params.agent
   if (!task || !agentName) {
@@ -775,6 +834,7 @@ async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConf
     removeTmpPrompt(tmpPrompt)
     return backgroundCapResult(makeDetails)
   }
+  onStarted?.(id)
   pi.events.emit(SUBAGENT_CHANNEL, { phase: 'start', agentType: agent.name, agentId: id })
   return {
     content: [{ type: 'text', text: `Started background run ${id} (${agent.name}). A notification will arrive on completion; check progress with {status: true}.` }],
@@ -1249,6 +1309,21 @@ function renderParallelResult(results: SingleResult[], expanded: boolean, theme:
 }
 
 export default function subagentExtension(pi: ExtensionAPI) {
+  // /tasks resolves these against the registry at print time. background.ts owns the
+  // run records but does not enumerate them, so the ids started here are remembered;
+  // a run the registry has since evicted simply drops out of the listing.
+  const startedBackgroundRuns = new Set<string>()
+
+  // The registry self-caps and evicts old runs, so an id kept here after its record is
+  // gone is dead weight. Drop those on every add, bounding the set to the registry's
+  // live capacity rather than letting it grow for the whole session.
+  const rememberBackgroundRun = (id: string): void => {
+    for (const known of startedBackgroundRuns) {
+      if (!backgroundRun(known)) startedBackgroundRuns.delete(known)
+    }
+    startedBackgroundRuns.add(id)
+  }
+
   const notifyBackgroundCompletion = (run: { id: string; agent: string; state: string; turns: number; output?: string; stderr?: string }): void => {
     // Runs through driveRun's guard, same as the background-mode callback above.
     // The stop event fires here too, so SubagentStop hooks see resumed runs end.
@@ -1344,7 +1419,11 @@ export default function subagentExtension(pi: ExtensionAPI) {
         })
 
       if (params.resume) {
-        return { content: [{ type: 'text', text: resumeResultText(params.resume, params.task, notifyBackgroundCompletion, (run) => pi.events.emit(SUBAGENT_CHANNEL, { phase: 'start', agentType: run.agent, agentId: run.id })) }], details: makeDetails('single')([]) }
+        const onResumed = (run: { id: string; agent: string }): void => {
+          rememberBackgroundRun(run.id)
+          pi.events.emit(SUBAGENT_CHANNEL, { phase: 'start', agentType: run.agent, agentId: run.id })
+        }
+        return { content: [{ type: 'text', text: resumeResultText(params.resume, params.task, notifyBackgroundCompletion, onResumed) }], details: makeDetails('single')([]) }
       }
 
       if (params.cancel) {
@@ -1385,7 +1464,7 @@ export default function subagentExtension(pi: ExtensionAPI) {
       // unavailable tier still falls back to the session model.
       const availableModels = ctx.modelRegistry?.getAvailable?.() ?? []
 
-      if (params.background) return runBackgroundMode(params, agents, ctx.cwd, pi, makeDetails, skillRoots, availableModels, projectApproved)
+      if (params.background) return runBackgroundMode(params, agents, ctx.cwd, pi, makeDetails, skillRoots, availableModels, projectApproved, (id) => rememberBackgroundRun(id))
 
       const mode: ModeContext = { agents, defaultCwd: ctx.cwd, signal, onUpdate, makeDetails, skillRoots, availableModels, projectApproved, onPhase: (phase, agentType, agentId) => pi.events.emit(SUBAGENT_CHANNEL, { phase, agentType, agentId }) }
 
@@ -1424,6 +1503,26 @@ export default function subagentExtension(pi: ExtensionAPI) {
 
       const text = result.content[0]
       return new Text(text?.type === 'text' ? text.text : '(no output)', 0, 0)
+    },
+  })
+
+  // Claude's /tasks: background-run status at a glance, returning immediately without
+  // interrupting the agent; the only other way to see these is to ask the model.
+  pi.registerCommand('tasks', {
+    description: 'Show background subagent runs',
+    handler: async (_args, ctx) => {
+      const runs = [...startedBackgroundRuns].map((id) => backgroundRun(id)).filter((run): run is BackgroundRun => run !== undefined)
+      ctx.ui.notify(tasksStatusText(runs), 'info')
+    },
+  })
+
+  // Claude's /agents: the discovered roster with sources and paths. Approval is read
+  // silently, like the roster above: project agents list only once the project is trusted.
+  pi.registerCommand('agents', {
+    description: 'List discovered subagents and where they come from',
+    handler: async (_args, ctx) => {
+      const { agents } = discoverAgents(ctx.cwd, isProjectApprovedSilently(ctx) ? 'both' : 'user')
+      ctx.ui.notify(agentsListText(agents), 'info')
     },
   })
 }

--- a/tests/command-parse.test.ts
+++ b/tests/command-parse.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { commandNameFor, discoverCommandFiles, expandDynamicContent, parseCommandFile, powershellQuote, resolvePowershellBinary, spanExec, substituteArgs, substituteVars } from '../extensions/internal/command-file.ts'
+import { commandNameFor, discoverCommandFiles, expandDynamicContent, normalizeToolName, parseCommandFile, powershellQuote, resolvePowershellBinary, spanExec, substituteArgs, substituteVars } from '../extensions/internal/command-file.ts'
 
 const dirs: string[] = []
 const tempDir = (): string => {
@@ -146,6 +146,25 @@ describe('parseCommandFile', () => {
     expect(parsed.description).toBe('Summarize the diff.')
     expect(parsed.allowedTools).toBeUndefined()
     expect(parsed.disableModelInvocation).toBe(false)
+  })
+
+  it('honors the YAML truthy spellings of disable-model-invocation, not just literal true', () => {
+    // pi's frontmatter parser hands `yes`/`on` back as strings and `1` as a number,
+    // so a flag that gates a user-only command off from the model must treat them all
+    // as true; missing any of them silently exposes the command the user marked off.
+    for (const value of ['true', 'True', 'yes', 'YES', 'on', '1', 'y']) {
+      expect(parseCommandFile(`---\ndisable-model-invocation: ${value}\n---\nx`).disableModelInvocation).toBe(true)
+    }
+    for (const value of ['false', 'no', 'off', '0', 'maybe']) {
+      expect(parseCommandFile(`---\ndisable-model-invocation: ${value}\n---\nx`).disableModelInvocation).toBe(false)
+    }
+  })
+
+  it('maps Claude SlashCommand onto the registered slash_command tool so the grant lands', () => {
+    // Without this a command's `allowed-tools: SlashCommand` matched no pi tool and the
+    // grant could neither keep nor drop the model's slash-command tool.
+    expect(normalizeToolName('SlashCommand')).toBe('slash_command')
+    expect(normalizeToolName('slashcommand')).toBe('slash_command')
   })
 
   it('reads arguments, disallowed-tools and shell frontmatter', () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,10 +1,12 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import commandsExtension, { collectCommands, commandDirs } from '../extensions/commands.ts'
+import commandsExtension, { collectCommands, commandDirs, expandCommand, SHELL_DISABLED_PLACEHOLDER, shellExecutionDisabled, slashCommandBudget, slashCommandToolDescription } from '../extensions/commands.ts'
+import { parseCommandFile } from '../extensions/internal/command-file.js'
+import { setManagedSettingsPath } from '../extensions/internal/managed-settings.ts'
 
 const hoisted = vi.hoisted(() => ({ home: '', pwshBinary: undefined as string | undefined }))
 vi.mock('node:os', async (importOriginal) => {
@@ -40,6 +42,7 @@ beforeEach(() => {
 afterEach(() => {
   if (savedAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR
   else process.env.PI_CODING_AGENT_DIR = savedAgentDir
+  setManagedSettingsPath()
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
 })
 
@@ -75,9 +78,18 @@ describe('collectCommands', () => {
   })
 })
 
+interface RegisteredTool {
+  name: string
+  label: string
+  description: string
+  parameters: unknown
+  execute: (id: string, params: { command: string }, signal?: unknown, onUpdate?: unknown, ctx?: unknown) => Promise<{ content: Array<{ type: string; text: string }> }>
+}
+
 const setup = (cwd: string, trusted = true) => {
   const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>()
   const commands = new Map<string, { description?: string; handler: (args: string, ctx: unknown) => Promise<void> }>()
+  const tools = new Map<string, RegisteredTool>()
   const sent: string[] = []
   const toolSets: string[][] = []
   const notices: string[] = []
@@ -87,6 +99,7 @@ const setup = (cwd: string, trusted = true) => {
   const pi = {
     on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn),
     registerCommand: (name: string, spec: { description?: string; handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, spec),
+    registerTool: (tool: RegisteredTool) => tools.set(tool.name, tool),
     exec: async (file: string, args: string[], opts?: { timeout?: number; env?: Record<string, string> }) => {
       execCalls.push({ file, args, shell: args[1], timeout: opts?.timeout, env: opts?.env })
       return { stdout: `ran:${args[1]}`, ...execResult }
@@ -126,7 +139,7 @@ const setup = (cwd: string, trusted = true) => {
       },
     },
   }
-  return { handlers, commands, sent, toolSets, notices, execCalls, ctx, modelSets, activeTools: () => active, failExec: (result: { stderr: string; code: number }) => Object.assign(execResult, result) }
+  return { handlers, commands, tools, sent, toolSets, notices, execCalls, ctx, modelSets, activeTools: () => active, failExec: (result: { stderr: string; code: number }) => Object.assign(execResult, result) }
 }
 
 describe('commands extension', () => {
@@ -178,7 +191,7 @@ describe('commands extension', () => {
     expect(s.execCalls[0].shell).toContain('pwd')
   })
 
-  it('keeps the restriction in place for the turn, restoring only when it ends', async () => {
+  it('keeps the restriction in place for the run, restoring only when it ends', async () => {
     const cwd = tempDir()
     writeCommand(cwd, 'safe.md', '---\nallowed-tools: Read\n---\nLook only.')
     const s = setup(cwd)
@@ -187,11 +200,47 @@ describe('commands extension', () => {
 
     // sendUserMessage is fire-and-forget, so restoring inside the handler would put
     // the full set back before the agent ever read it: the restriction must outlive
-    // the handler and end with the turn.
+    // the handler and end with the agent run.
     expect(s.toolSets[0]).toEqual(['read'])
     expect(s.activeTools()).toEqual(['read'])
 
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
+    expect(s.activeTools()).toEqual(['bash', 'read', 'edit', 'write'])
+  })
+
+  it('keeps the restriction through a mid-run turn_end, since pi fires one per assistant step', async () => {
+    // Claude's contract is "the grant clears when you send your next message". pi's
+    // turn_end fires after every assistant step, so restoring there stripped a
+    // multi-step command's scoping right after step one.
+    const cwd = tempDir()
+    writeCommand(cwd, 'safe.md', '---\nallowed-tools: Read\n---\nLook only.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('safe')?.handler('', s.ctx)
+
     await s.handlers.get('turn_end')?.({}, s.ctx)
+    expect(s.activeTools()).toEqual(['read'])
+
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
+    expect(s.activeTools()).toEqual(['bash', 'read', 'edit', 'write'])
+  })
+
+  it('keeps the scoping across an agent_end loop boundary and lifts it only once the run has settled', async () => {
+    // agent_end fires once per agent loop, ahead of an automatic retry, an auto-
+    // compaction-and-retry, or a Stop-hook continuation. Restoring there would lift
+    // the command's scoping while that continued run is still to come, so the restore
+    // is bound to agent_settled, which fires only after the run has fully settled.
+    const cwd = tempDir()
+    writeCommand(cwd, 'safe.md', '---\nallowed-tools: Read\n---\nLook only.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('safe')?.handler('', s.ctx)
+    expect(s.activeTools()).toEqual(['read'])
+
+    await s.handlers.get('agent_end')?.({}, s.ctx)
+    expect(s.activeTools()).toEqual(['read'])
+
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
     expect(s.activeTools()).toEqual(['bash', 'read', 'edit', 'write'])
   })
 
@@ -239,7 +288,7 @@ describe('commands extension', () => {
     await s.handlers.get('session_start')?.({}, s.ctx)
     await s.commands.get('a')?.handler('', s.ctx)
     await s.commands.get('b')?.handler('', s.ctx)
-    await s.handlers.get('turn_end')?.({}, s.ctx)
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
 
     expect(s.activeTools()).toEqual(['bash', 'read', 'edit', 'write'])
   })
@@ -254,7 +303,7 @@ describe('commands extension', () => {
 })
 
 describe('command model frontmatter', () => {
-  it('switches to the command model for the turn and restores it on turn_end', async () => {
+  it('switches to the command model for the run and restores it on agent_settled', async () => {
     const cwd = tempDir()
     writeCommand(cwd, 'deep.md', '---\nmodel: opus\n---\nThink hard.')
     const s = setup(cwd)
@@ -262,7 +311,10 @@ describe('command model frontmatter', () => {
     await s.commands.get('deep')?.handler('', s.ctx)
     // opus fuzzy-matches claude-opus-5 among the available models.
     expect(s.modelSets).toEqual(['claude-opus-5'])
+    // A mid-run turn_end must not restore: a multi-step command keeps its model.
     await s.handlers.get('turn_end')?.({}, s.ctx)
+    expect(s.modelSets).toEqual(['claude-opus-5'])
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
     // Restored to the session model.
     expect(s.modelSets).toEqual(['claude-opus-5', 'gemma4'])
   })
@@ -277,11 +329,11 @@ describe('command model frontmatter', () => {
     await s.handlers.get('session_start')?.({}, s.ctx)
     await s.commands.get('f')?.handler('', s.ctx)
     expect(s.modelSets.at(-1)).toBe('claude-fable-5')
-    await s.handlers.get('turn_end')?.({}, s.ctx)
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
     const before = s.modelSets.length
     await s.commands.get('exact')?.handler('', s.ctx)
     expect(s.modelSets.at(-1)).toBe('claude-opus-5')
-    await s.handlers.get('turn_end')?.({}, s.ctx)
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
     const afterExact = s.modelSets.length
     await s.commands.get('inh')?.handler('', s.ctx)
     await s.commands.get('none')?.handler('', s.ctx)
@@ -378,7 +430,7 @@ describe('claude variables and skill frontmatter wiring', () => {
     expect(s.sent[1]).toBe('Deploy prod now.')
   })
 
-  it('removes disallowed-tools for the turn and restores them after', async () => {
+  it('removes disallowed-tools for the run and restores them after', async () => {
     const cwd = tempDir()
     writeCommand(cwd, 'ro.md', '---\ndisallowed-tools: Edit, Write\n---\nLook, do not touch.')
     const s = setup(cwd)
@@ -386,7 +438,7 @@ describe('claude variables and skill frontmatter wiring', () => {
     await s.commands.get('ro')?.handler('', s.ctx)
 
     expect(s.activeTools()).toEqual(['bash', 'read'])
-    await s.handlers.get('turn_end')?.({}, s.ctx)
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
     expect(s.activeTools()).toEqual(['bash', 'read', 'edit', 'write'])
   })
 
@@ -532,14 +584,19 @@ describe('allowed-tools argument scopes', () => {
     expect(await s.handlers.get('tool_call')?.({ toolName: 'read', input: { path: 'x' } }, s.ctx)).toBeUndefined()
   })
 
-  it('stops enforcing when the turn ends', async () => {
+  it('stops enforcing when the run ends, not on a mid-run turn_end', async () => {
     const cwd = tempDir()
     writeCommand(cwd, 'stage.md', '---\nallowed-tools: Bash(git add:*)\n---\nStage it.')
     const s = setup(cwd)
     await s.handlers.get('session_start')?.({}, s.ctx)
     await s.commands.get('stage')?.handler('', s.ctx)
-    await s.handlers.get('turn_end')?.({}, s.ctx)
 
+    // A second assistant step is still inside the command's run: the scope holds.
+    await s.handlers.get('turn_end')?.({}, s.ctx)
+    const blocked = (await s.handlers.get('tool_call')?.({ toolName: 'bash', input: { command: 'rm -rf /' } }, s.ctx)) as { block?: boolean }
+    expect(blocked?.block).toBe(true)
+
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
     expect(await s.handlers.get('tool_call')?.({ toolName: 'bash', input: { command: 'rm -rf /' } }, s.ctx)).toBeUndefined()
   })
 
@@ -595,7 +652,7 @@ describe('allowed-tools argument scopes', () => {
     const write = (await s.handlers.get('tool_call')?.({ toolName: 'write', input: { path: 'src/evil.ts' } }, s.ctx)) as { block?: boolean }
     expect(write?.block).toBe(true)
 
-    await s.handlers.get('turn_end')?.({}, s.ctx)
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
     expect(await s.handlers.get('tool_call')?.({ toolName: 'read', input: { path: 'src/secret.ts' } }, s.ctx)).toBeUndefined()
   })
 
@@ -625,5 +682,269 @@ describe('allowed-tools with queued commands', () => {
     await s.commands.get('b')?.handler('', s.ctx)
 
     expect(s.activeTools()).toEqual(['bash'])
+  })
+})
+
+const stubRunner = () => {
+  const calls: string[] = []
+  return {
+    calls,
+    exec: async (_file: string, args: string[]) => {
+      calls.push(args[1])
+      return { stdout: `ran:${args[1]}`, stderr: '', code: 0, killed: false }
+    },
+  }
+}
+
+describe('expandCommand', () => {
+  it('produces exactly what the user path sends for the same invocation', async () => {
+    const cwd = tempDir()
+    const file = join(cwd, '.claude', 'commands', 'par.md')
+    writeCommand(cwd, 'par.md', '---\nargument-hint: [target]\n---\nBuild $0 in ${CLAUDE_PROJECT_DIR}: !`git status`')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('par')?.handler('web', s.ctx)
+
+    const parsed = parseCommandFile(readFileSync(file, 'utf-8'))
+    const out = await expandCommand(stubRunner(), parsed, 'web', s.ctx as { cwd: string }, file)
+    expect(s.sent).toHaveLength(1)
+    expect(out).toBe(s.sent[0])
+  })
+
+  it('appends ARGUMENTS when the body never reads the passed args', async () => {
+    const cwd = tempDir()
+    const out = await expandCommand(stubRunner(), parseCommandFile('Deploy now.'), 'prod', { cwd }, join(cwd, 'd.md'))
+    expect(out).toBe('Deploy now.\n\nARGUMENTS: prod')
+  })
+
+  it('throws on a span failure instead of returning a half-expanded body', async () => {
+    const cwd = tempDir()
+    const failing = { exec: async () => ({ stdout: '', stderr: 'boom', code: 2, killed: false }) }
+    await expect(expandCommand(failing, parseCommandFile('x: !`bad`'), '', { cwd }, join(cwd, 'f.md'))).rejects.toThrow(/bad[\s\S]*boom/)
+  })
+
+  it('replaces every shell span with the policy placeholder when shell is disallowed', async () => {
+    const cwd = tempDir()
+    const runner = stubRunner()
+    const parsed = parseCommandFile('status: !`git status`\n```!\nrm -rf /\n```\ndone')
+    const out = await expandCommand(runner, parsed, '', { cwd }, join(cwd, 's.md'), undefined, { allowShell: false })
+    expect(runner.calls).toEqual([])
+    expect(out).toBe(`status: ${SHELL_DISABLED_PLACEHOLDER}\n${SHELL_DISABLED_PLACEHOLDER}\ndone`)
+  })
+})
+
+describe('slashCommandBudget', () => {
+  it('prefers the env override, then ~1% of the context window, then the default', () => {
+    expect(slashCommandBudget(200_000, { SLASH_COMMAND_TOOL_CHAR_BUDGET: '4000' })).toBe(4000)
+    // 1% of the window's tokens at ~4 chars per token is window / 25.
+    expect(slashCommandBudget(200_000, {})).toBe(8000)
+    expect(slashCommandBudget(undefined, {})).toBe(15_000)
+  })
+
+  it('ignores a malformed or non-positive env value', () => {
+    expect(slashCommandBudget(undefined, { SLASH_COMMAND_TOOL_CHAR_BUDGET: 'lots' })).toBe(15_000)
+    expect(slashCommandBudget(undefined, { SLASH_COMMAND_TOOL_CHAR_BUDGET: '0' })).toBe(15_000)
+  })
+})
+
+describe('slashCommandToolDescription', () => {
+  it('lists each command as /name - description (argument-hint)', () => {
+    const text = slashCommandToolDescription(
+      [
+        { name: 'deploy', description: 'Deploy it', argumentHint: '[env]' },
+        { name: 'lint', description: 'Lint the tree' },
+      ],
+      15_000,
+    )
+    expect(text).toContain('/deploy - Deploy it ([env])')
+    expect(text).toContain('/lint - Lint the tree')
+  })
+
+  it('caps one entry at 1536 characters', () => {
+    const text = slashCommandToolDescription([{ name: 'big', description: 'x'.repeat(4000) }], 15_000)
+    const entry = text.split('\n').find((line) => line.startsWith('/big')) ?? ''
+    expect(entry).toHaveLength(1536)
+  })
+
+  it('drops entries past the overall budget and says so', () => {
+    const commands = [
+      { name: 'a', description: 'first command' },
+      { name: 'b', description: 'x'.repeat(300) },
+    ]
+    const text = slashCommandToolDescription(commands, 60)
+    expect(text).toContain('/a - first command')
+    expect(text).not.toContain('/b')
+    expect(text).toContain('omitted')
+  })
+})
+
+describe('slash_command tool', () => {
+  it('registers the tool listing only model-invocable commands', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'deploy.md', '---\ndescription: Deploy it\nargument-hint: [env]\n---\nDeploy $0.')
+    writeCommand(cwd, 'secret.md', '---\ndescription: User only\ndisable-model-invocation: true\n---\nSecret steps.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    const tool = s.tools.get('slash_command')
+    expect(tool).toBeDefined()
+    expect(tool?.label).toBe('SlashCommand')
+    expect(tool?.description).toContain('/deploy - Deploy it ([env])')
+    expect(tool?.description).not.toContain('/secret')
+  })
+
+  it('does not register the tool when every command is user-only, or none exist', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'secret.md', '---\ndisable-model-invocation: true\n---\nSecret steps.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    expect(s.tools.has('slash_command')).toBe(false)
+
+    const empty = setup(tempDir())
+    await empty.handlers.get('session_start')?.({}, empty.ctx)
+    expect(empty.tools.has('slash_command')).toBe(false)
+  })
+
+  it('expands a command into the tool result without spawning a user turn', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'deploy.md', '---\ndescription: Deploy it\n---\nDeploy $0 from ${CLAUDE_PROJECT_DIR}.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    const result = await s.tools.get('slash_command')?.execute('t1', { command: '/deploy staging' }, undefined, undefined, s.ctx)
+    expect(result?.content[0].text).toBe(`Contents of /deploy (expanded):\n\nDeploy staging from ${cwd}.`)
+    // The tool result is the channel; sendUserMessage would spawn a second turn.
+    expect(s.sent).toEqual([])
+  })
+
+  it('re-reads the file on invocation so a live edit takes effect', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'deploy.md', 'Old body.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    writeCommand(cwd, 'deploy.md', 'New body.')
+
+    const result = await s.tools.get('slash_command')?.execute('t1', { command: '/deploy' }, undefined, undefined, s.ctx)
+    expect(result?.content[0].text).toContain('New body.')
+  })
+
+  it('refuses a disable-model-invocation command and says not to reproduce it', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'ok.md', 'Fine.')
+    writeCommand(cwd, 'secret.md', '---\ndisable-model-invocation: true\n---\nSecret steps.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    await expect(s.tools.get('slash_command')?.execute('t1', { command: '/secret' }, undefined, undefined, s.ctx)).rejects.toThrow(/user-only[\s\S]*reproduce/)
+    expect(s.sent).toEqual([])
+  })
+
+  it('honors disable-model-invocation added by a live edit after registration', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'deploy.md', 'Deploy.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    writeCommand(cwd, 'deploy.md', '---\ndisable-model-invocation: true\n---\nDeploy.')
+
+    await expect(s.tools.get('slash_command')?.execute('t1', { command: '/deploy' }, undefined, undefined, s.ctx)).rejects.toThrow(/user-only/)
+  })
+
+  it('never runs a shell span for a model invocation, substituting the placeholder', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'ctx.md', 'Fine.')
+    writeCommand(cwd, 'st.md', 'status: !`git status`')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    const result = await s.tools.get('slash_command')?.execute('t1', { command: '/st' }, undefined, undefined, s.ctx)
+    expect(s.execCalls).toEqual([])
+    expect(result?.content[0].text).toContain(SHELL_DISABLED_PLACEHOLDER)
+    expect(result?.content[0].text).not.toContain('ran:')
+  })
+
+  it('rejects an unknown command name', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'ok.md', 'Fine.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    await expect(s.tools.get('slash_command')?.execute('t1', { command: '/nope now' }, undefined, undefined, s.ctx)).rejects.toThrow(/nope/)
+  })
+
+  it("drops a previous project's commands from the model path on a session switch", async () => {
+    // A resume or fork can land on a different project in-process, firing session_start
+    // again with a new cwd. The model must not be able to run a command that belonged
+    // to the project it just left, so the resolution set is rebuilt each session_start.
+    const cwdA = tempDir()
+    writeCommand(cwdA, 'deploy-a.md', 'Deploy project A.')
+    const s = setup(cwdA)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    const runA = await s.tools.get('slash_command')?.execute('t1', { command: '/deploy-a' }, undefined, undefined, s.ctx)
+    expect(runA?.content[0].text).toContain('Deploy project A.')
+
+    const cwdB = tempDir()
+    writeCommand(cwdB, 'deploy-b.md', 'Deploy project B.')
+    const ctxB = { ...s.ctx, cwd: cwdB }
+    await s.handlers.get('session_start')?.({}, ctxB)
+
+    // The project A command no longer resolves for the model after the switch.
+    await expect(s.tools.get('slash_command')?.execute('t1', { command: '/deploy-a' }, undefined, undefined, ctxB)).rejects.toThrow(/Unknown command/)
+    const runB = await s.tools.get('slash_command')?.execute('t1', { command: '/deploy-b' }, undefined, undefined, ctxB)
+    expect(runB?.content[0].text).toContain('Deploy project B.')
+  })
+
+  it('leaves the user path running spans as before', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'st.md', 'status: !`git status`')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('st')?.handler('', s.ctx)
+
+    expect(s.execCalls).toHaveLength(1)
+    expect(s.sent[0]).toContain('git status')
+  })
+})
+
+describe('disableSkillShellExecution', () => {
+  const writeSettings = (dir: string, settings: Record<string, unknown>): void => {
+    mkdirSync(join(dir, '.claude'), { recursive: true })
+    writeFileSync(join(dir, '.claude', 'settings.json'), JSON.stringify(settings))
+  }
+
+  it('reads user settings always and project settings only when trusted', () => {
+    const cwd = tempDir()
+    expect(shellExecutionDisabled(cwd, hoisted.home, true)).toBe(false)
+    writeSettings(cwd, { disableSkillShellExecution: true })
+    expect(shellExecutionDisabled(cwd, hoisted.home, true)).toBe(true)
+    expect(shellExecutionDisabled(cwd, hoisted.home, false)).toBe(false)
+    writeSettings(hoisted.home, { disableSkillShellExecution: true })
+    expect(shellExecutionDisabled(tempDir(), hoisted.home, false)).toBe(true)
+  })
+
+  it('cannot be re-enabled by a lower layer once the user disabled it', () => {
+    // Fail closed: a trusted repository's `false` must not lift the user's policy.
+    const cwd = tempDir()
+    writeSettings(hoisted.home, { disableSkillShellExecution: true })
+    writeSettings(cwd, { disableSkillShellExecution: false })
+    expect(shellExecutionDisabled(cwd, hoisted.home, true)).toBe(true)
+  })
+
+  it('honors the managed policy file', () => {
+    const managed = join(tempDir(), 'managed-settings.json')
+    writeFileSync(managed, JSON.stringify({ disableSkillShellExecution: true }))
+    setManagedSettingsPath(managed)
+    expect(shellExecutionDisabled(tempDir(), hoisted.home, false)).toBe(true)
+  })
+
+  it('replaces spans with the placeholder on the user path when set', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, { disableSkillShellExecution: true })
+    writeCommand(cwd, 'st.md', 'status: !`git status`\n```!\npwd\n```')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('st')?.handler('', s.ctx)
+
+    expect(s.execCalls).toEqual([])
+    expect(s.sent[0]).toBe(`status: ${SHELL_DISABLED_PLACEHOLDER}\n${SHELL_DISABLED_PLACEHOLDER}`)
   })
 })

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -134,11 +134,15 @@ beforeEach(() => {
   hoisted.live.length = 0
   hoisted.behaviors.clear()
   hoisted.home = tempDir('hooks-home-')
+  // Hermetic managed settings: session_start reads disableAllHooks from the managed
+  // path, which must never resolve to this machine's real policy file.
+  setManagedSettingsPath(join(hoisted.home, 'managed-settings.json'))
 })
 
 afterEach(() => {
   if (savedAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR
   else process.env.PI_CODING_AGENT_DIR = savedAgentDir
+  setManagedSettingsPath(undefined)
 
   // Release any child scripted to hang so its pending promise never leaks into the next test.
   for (const child of hoisted.live.splice(0)) child.emit('close', 0)
@@ -158,10 +162,12 @@ const setupExtension = () => {
   const handlers = new Map<string, Handler>()
   const busHandlers = new Map<string, (data: unknown) => void>()
   const sent: Array<{ message: unknown; options: unknown }> = []
+  const commands = new Map<string, { description?: string; handler: (args: string, ctx: unknown) => Promise<void> }>()
   hooksExtension({
     on: (name: string, fn: Handler) => handlers.set(name, fn),
     events: { on: (channel: string, fn: (data: unknown) => void) => busHandlers.set(channel, fn), emit: () => {} },
     sendMessage: (message: unknown, options: unknown) => sent.push({ message, options }),
+    registerCommand: (name: string, spec: { description?: string; handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, spec),
   } as never)
   const handler = (name: string): Handler => {
     const found = handlers.get(name)
@@ -177,6 +183,12 @@ const setupExtension = () => {
   }
   return {
     registered: [...handlers.keys()],
+    commands: [...commands.keys()],
+    runCommand: (name: string, args = '') => {
+      const spec = commands.get(name)
+      if (!spec) throw new Error(`hooks extension did not register /${name}`)
+      return spec.handler(args, defaultCtx)
+    },
     notes,
     sent,
     sessionStart: (reason: string, ctx: Record<string, unknown>) => handler('session_start')({ reason }, { ...defaultCtx, ...ctx }),
@@ -1357,6 +1369,118 @@ describe('hook execution parallelism', () => {
     expect(launched).toEqual(['one', 'two'])
     release()
     expect((await pending).context).toBe('ctx\nctx')
+  })
+})
+
+describe('disableAllHooks', () => {
+  const trustedCtx = { isProjectTrusted: () => true, hasUI: true, ui: { confirm: async () => true } }
+
+  it('runs no SessionStart hook and injects no context when user settings set it', async () => {
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ disableAllHooks: true, hooks: { SessionStart: [{ hooks: [{ command: 'home-session' }] }] } }))
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    expect(commandsRun()).toEqual([])
+    await expect(ext.beforeAgentStart()).resolves.toBeUndefined()
+  })
+
+  it('does not fire a configured PreToolUse hook on a tool call', async () => {
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ disableAllHooks: true, hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'guard' }] }] } }))
+    script('guard', { stderr: ['denied'], code: 2 })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    expect(await ext.toolCall('bash', { command: 'ls' })).toBeUndefined()
+    expect(commandsRun()).toEqual([])
+  })
+
+  it('honors the key from trusted project settings, disabling user hooks too', async () => {
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'home-pre' }] }] })
+    const project = tempDir('hooks-proj-')
+    mkdirSync(join(project, '.claude'), { recursive: true })
+    writeFileSync(join(project, '.claude', 'settings.local.json'), JSON.stringify({ disableAllHooks: true }))
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: project, ...trustedCtx })
+    await ext.toolCall('bash', {})
+    expect(commandsRun()).toEqual([])
+  })
+
+  it('ignores the key in an untrusted project settings file', async () => {
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'home-pre' }] }] })
+    const project = tempDir('hooks-proj-')
+    mkdirSync(join(project, '.claude'), { recursive: true })
+    writeFileSync(join(project, '.claude', 'settings.json'), JSON.stringify({ disableAllHooks: true }))
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: project })
+    await ext.toolCall('bash', {})
+    expect(commandsRun()).toEqual(['home-pre'])
+  })
+
+  it('honors the key from managed settings', async () => {
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'home-pre' }] }] })
+    writeFileSync(join(hoisted.home, 'managed-settings.json'), JSON.stringify({ disableAllHooks: true }))
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.toolCall('bash', {})
+    expect(commandsRun()).toEqual([])
+  })
+
+  it('loads no plugin hooks either', async () => {
+    const root = join(hoisted.home, '.claude', 'plugins', 'cache', 'market', 'fmt', '1.0.0')
+    mkdirSync(join(root, 'hooks'), { recursive: true })
+    writeFileSync(join(root, 'hooks', 'hooks.json'), JSON.stringify({ hooks: { PostToolUse: [{ matcher: 'Write', hooks: [{ command: '${CLAUDE_PLUGIN_ROOT}/scripts/format.sh' }] }] } }))
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ disableAllHooks: true, enabledPlugins: { fmt: true } }))
+
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.toolResult('write', { input: { path: 'a.ts' } })
+    expect(commandsRun()).toEqual([])
+  })
+})
+
+describe('/hooks command', () => {
+  it('registers the hooks viewer command', () => {
+    expect(setupExtension().commands).toContain('hooks')
+  })
+
+  it('prints the resolved chain grouped by event with matcher, identity and source file', async () => {
+    writeSettings(hoisted.home, 'settings.json', {
+      PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'guard.sh' }] }],
+      Stop: [{ hooks: [{ type: 'prompt', prompt: 'done?' }] }],
+    })
+    const project = tempDir('hooks-proj-')
+    writeSettings(project, 'settings.json', { PostToolUse: [{ matcher: 'Edit|Write', hooks: [{ command: 'fmt.sh' }] }] })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: project, isProjectTrusted: () => true, hasUI: true, ui: { confirm: async () => true } })
+
+    await ext.runCommand('hooks')
+
+    expect(ext.notes).toHaveLength(1)
+    const { msg, level } = ext.notes[0]
+    expect(level).toBe('info')
+    expect(msg).toContain('PreToolUse:')
+    expect(msg).toContain(`  [Bash] command: guard.sh (${join(hoisted.home, '.claude', 'settings.json')})`)
+    expect(msg).toContain('PostToolUse:')
+    expect(msg).toContain(`  [Edit|Write] command: fmt.sh (${join(project, '.claude', 'settings.json')})`)
+    expect(msg).toContain('Stop:')
+    expect(msg).toContain('  [*] prompt: done?')
+  })
+
+  it('notes when no hooks are configured', async () => {
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.runCommand('hooks')
+    expect(ext.notes[0].msg).toContain('No hooks configured')
+  })
+
+  it('reports the disabled state when disableAllHooks is set', async () => {
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ disableAllHooks: true, hooks: { PreToolUse: [{ hooks: [{ command: 'guard' }] }] } }))
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.runCommand('hooks')
+    expect(ext.notes[0].msg).toContain('disableAllHooks')
   })
 })
 

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { type HookRunner, hookFiles, interpretHookResult, lastAssistantText, loadHooks, matchingCommands, runAgentHook, runHookCommand, runHttpHook, runMcpToolHook, runPreToolUse, runPromptHook } from '../extensions/hooks.ts'
+import { formatHooksSummary, type HookRunner, hookFiles, interpretHookResult, lastAssistantText, loadHooks, matchingCommands, readDisableAllHooks, runAgentHook, runHookCommand, runHttpHook, runMcpToolHook, runPreToolUse, runPromptHook } from '../extensions/hooks.ts'
 import { setAgentRunner } from '../extensions/internal/agent-run.ts'
 import { setMcpToolCaller } from '../extensions/internal/mcp-call.ts'
 import { setCompleteBackend } from '../extensions/internal/model-complete.ts'
@@ -244,6 +244,92 @@ describe('loadHooks', () => {
     const config = loadHooks([a, join(dir, 'absent.json'), broken, b])
     expect(config.PreToolUse).toHaveLength(2)
     expect(config.PreToolUse.map((m) => m.matcher)).toEqual(['Bash', 'Edit'])
+  })
+
+  it('records the source settings file for each merged entry', () => {
+    const dir = tempDir()
+    const a = join(dir, 'a.json')
+    const b = join(dir, 'b.json')
+    writeFileSync(a, JSON.stringify({ hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'one' }] }] } }))
+    writeFileSync(b, JSON.stringify({ hooks: { PreToolUse: [{ matcher: 'Edit', hooks: [{ command: 'two' }] }] } }))
+
+    const sources = new Map()
+    const config = loadHooks([a, b], sources)
+    expect(sources.get(config.PreToolUse[0])).toBe(a)
+    expect(sources.get(config.PreToolUse[1])).toBe(b)
+  })
+})
+
+describe('readDisableAllHooks', () => {
+  it('is false when no settings file sets it or files are missing', () => {
+    const dir = tempDir()
+    const file = join(dir, 'settings.json')
+    writeFileSync(file, JSON.stringify({ hooks: {} }))
+    expect(readDisableAllHooks([file, join(dir, 'absent.json')], {})).toBe(false)
+  })
+
+  it('is true when any file in the chain sets it, and a later false cannot re-enable', () => {
+    // The escape hatch reading: a repository file must not be able to turn back on
+    // the hooks a user settings file just disabled.
+    const dir = tempDir()
+    const user = join(dir, 'user.json')
+    const local = join(dir, 'local.json')
+    writeFileSync(user, JSON.stringify({ disableAllHooks: true }))
+    writeFileSync(local, JSON.stringify({ disableAllHooks: false }))
+    expect(readDisableAllHooks([user, local], {})).toBe(true)
+    expect(readDisableAllHooks([local], {})).toBe(false)
+  })
+
+  it('ignores non-boolean truthy values and malformed files', () => {
+    const dir = tempDir()
+    const junk = join(dir, 'junk.json')
+    const broken = join(dir, 'broken.json')
+    writeFileSync(junk, JSON.stringify({ disableAllHooks: 'yes' }))
+    writeFileSync(broken, '{not json')
+    expect(readDisableAllHooks([junk, broken], {})).toBe(false)
+  })
+
+  it('honors a managed-settings disableAllHooks with no chain file setting it', () => {
+    expect(readDisableAllHooks([], { disableAllHooks: true })).toBe(true)
+    expect(readDisableAllHooks([], { disableAllHooks: false })).toBe(false)
+  })
+})
+
+describe('formatHooksSummary', () => {
+  it('groups hooks by event with matcher, identity and source settings file', () => {
+    const preA = { matcher: 'Bash', hooks: [{ command: 'guard.sh' }] }
+    const preB = {
+      hooks: [
+        { type: 'http', url: 'https://ci.example/hook' },
+        { type: 'mcp_tool', server: 'gh', tool: 'lint' },
+      ],
+    }
+    const stop = { matcher: '*', hooks: [{ type: 'prompt', prompt: 'done yet?' }] }
+    const config = { PreToolUse: [preA, preB], Stop: [stop] }
+    const sources = new Map<object, string>([
+      [preA, '/home/.claude/settings.json'],
+      [preB, '/proj/.claude/settings.json'],
+    ])
+
+    expect(formatHooksSummary(config as never, sources as never)).toBe(['PreToolUse:', '  [Bash] command: guard.sh (/home/.claude/settings.json)', '  [*] http: https://ci.example/hook (/proj/.claude/settings.json)', '  [*] mcp_tool: gh:lint (/proj/.claude/settings.json)', 'Stop:', '  [*] prompt: done yet?'].join('\n'))
+  })
+
+  it('shows an agent hook by its prompt and a typeless entry as a command', () => {
+    const text = formatHooksSummary({
+      Stop: [{ hooks: [{ type: 'agent', prompt: 'verify the tests ran' }, { command: 'notify.sh' }] }],
+    } as never)
+    expect(text).toContain('  [*] agent: verify the tests ran')
+    expect(text).toContain('  [*] command: notify.sh')
+  })
+
+  it('notes when no hooks are configured, including for entries with empty hook lists', () => {
+    expect(formatHooksSummary({})).toContain('No hooks configured')
+    expect(formatHooksSummary({ PreToolUse: [{ matcher: 'Bash', hooks: [] }] } as never)).toContain('No hooks configured')
+  })
+
+  it('names a null hook entry instead of crashing the viewer', () => {
+    const text = formatHooksSummary({ PreToolUse: [{ matcher: 'Bash', hooks: [null] }] } as never)
+    expect(text).toContain('  [Bash] command: (missing command)')
   })
 })
 

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -40,6 +40,21 @@ interface CallResult {
   isError?: boolean
 }
 
+interface PromptDef {
+  name: string
+  description?: string
+  arguments?: Array<{ name: string; description?: string; required?: boolean }>
+}
+
+interface PromptPage {
+  prompts: PromptDef[]
+  nextCursor?: string
+}
+
+interface PromptResult {
+  messages: Array<{ role: string; content: Record<string, unknown> }>
+}
+
 const hoisted = vi.hoisted(() => {
   const state = {
     home: '',
@@ -53,6 +68,12 @@ const hoisted = vi.hoisted(() => {
       listTools: (args: { cursor?: string }, client: ClientRecord) => Promise<ListPage>
       callTool: (args: { name: string; arguments: unknown }, client: ClientRecord) => Promise<CallResult>
       close: (client: ClientRecord) => Promise<void>
+      getServerCapabilities: (client: ClientRecord) => Record<string, unknown> | undefined
+      listPrompts: (args: { cursor?: string }, client: ClientRecord) => Promise<{ prompts: PromptDef[]; nextCursor?: string }>
+      getPrompt: (args: { name: string; arguments?: Record<string, string> }, client: ClientRecord) => Promise<{ messages: Array<{ role: string; content: Record<string, unknown> }> }>
+      listResources: (args: { cursor?: string }, client: ClientRecord) => Promise<{ resources: Array<Record<string, unknown>>; nextCursor?: string }>
+      listResourceTemplates: (args: { cursor?: string }, client: ClientRecord) => Promise<{ resourceTemplates: Array<Record<string, unknown>>; nextCursor?: string }>
+      readResource: (args: { uri: string }, client: ClientRecord) => Promise<{ contents: Array<Record<string, unknown>> }>
     },
   }
   return state
@@ -88,6 +109,24 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
       // The SDK passes a zod schema whose method is a literal in its shape.
       const shape = (schema as { shape?: { method?: { value?: string } } })?.shape
       hoisted.notify.set(shape?.method?.value ?? 'unknown', handler)
+    }
+    getServerCapabilities(): Record<string, unknown> | undefined {
+      return hoisted.control.getServerCapabilities(this)
+    }
+    listPrompts(args?: { cursor?: string }): Promise<PromptPage> {
+      return hoisted.control.listPrompts(args ?? {}, this)
+    }
+    getPrompt(args: { name: string; arguments?: Record<string, string> }, _options?: unknown): Promise<PromptResult> {
+      return hoisted.control.getPrompt(args, this)
+    }
+    listResources(args?: { cursor?: string }, _options?: unknown): Promise<{ resources: Array<Record<string, unknown>>; nextCursor?: string }> {
+      return hoisted.control.listResources(args ?? {}, this)
+    }
+    listResourceTemplates(args?: { cursor?: string }, _options?: unknown): Promise<{ resourceTemplates: Array<Record<string, unknown>>; nextCursor?: string }> {
+      return hoisted.control.listResourceTemplates(args ?? {}, this)
+    }
+    readResource(args: { uri: string }, _options?: unknown): Promise<{ contents: Array<Record<string, unknown>> }> {
+      return hoisted.control.readResource(args, this)
     }
   },
 }))
@@ -144,7 +183,7 @@ interface RegisteredTool {
   label: string
   description: string
   parameters: unknown
-  execute: (id: string, params: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text?: string }>; details: { error?: string } }>
+  execute: (id: string, params: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; details: { error?: string } }>
 }
 
 type Notification = { message: string; level: string }
@@ -154,12 +193,15 @@ interface Harness {
   notifications: Notification[]
   warnings: string[]
   emitted: Array<{ channel: string; data: unknown }>
+  sent: string[]
   home: string
   cwd: string
   sessionStart: (trusted?: boolean | undefined, approve?: boolean) => Promise<void>
   shutdown: () => Promise<void>
   mcpCommand: () => Promise<void>
   toolNames: () => string[]
+  commandNames: () => string[]
+  runSlash: (name: string, args: string) => Promise<void>
 }
 
 const writeServers = (file: string, servers: Record<string, unknown>): void => {
@@ -180,6 +222,7 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
   const notifications: Notification[] = []
   const warnings: string[] = []
   const emitted: Array<{ channel: string; data: unknown }> = []
+  const sent: string[] = []
   const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<void>>()
   const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>()
 
@@ -203,6 +246,7 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
     on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<void>) => handlers.set(name, fn),
     registerCommand: (name: string, opts2: { handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, opts2),
     registerTool: (tool: RegisteredTool) => tools.push(tool),
+    sendUserMessage: (text: string) => sent.push(text),
     events: { emit: (channel: string, data: unknown) => emitted.push({ channel, data }), on: () => () => {} },
   } as never)
 
@@ -211,6 +255,7 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
     notifications,
     warnings,
     emitted,
+    sent,
     home,
     cwd,
     sessionStart: async (trusted?: boolean, approve = true) => {
@@ -223,6 +268,10 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
       await commands.get('mcp')?.handler('', makeCtx(true))
     },
     toolNames: () => tools.map((t) => t.name),
+    commandNames: () => [...commands.keys()],
+    runSlash: async (name: string, args: string) => {
+      await commands.get(name)?.handler(args, makeCtx(true))
+    },
   }
 }
 
@@ -250,6 +299,12 @@ const defaultControl = (): typeof hoisted.control => ({
   listTools: async () => ({ tools: [] }),
   callTool: async () => ({ content: [{ type: 'text', text: 'ok' }] }),
   close: async () => {},
+  getServerCapabilities: () => undefined,
+  listPrompts: async () => ({ prompts: [] }),
+  getPrompt: async () => ({ messages: [] }),
+  listResources: async () => ({ resources: [] }),
+  listResourceTemplates: async () => ({ resourceTemplates: [] }),
+  readResource: async () => ({ contents: [] }),
 })
 
 const savedEnv: Record<string, string | undefined> = {}
@@ -1357,5 +1412,267 @@ describe('mcp client lifecycle', () => {
     client?.onclose?.()
 
     expect(await statusLinesOf(harness)).toEqual(['live: disconnected (0 tools)'])
+  })
+})
+
+describe('mcp prompts as slash commands', () => {
+  const withPrompts = (prompts: PromptDef[]): void => {
+    hoisted.control.getServerCapabilities = () => ({ prompts: {} })
+    hoisted.control.listPrompts = async () => ({ prompts })
+  }
+
+  it('registers a normalized /mcp__server__prompt command for each advertised prompt', async () => {
+    withPrompts([{ name: 'code-review', description: 'Review code' }])
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+
+    expect(harness.commandNames()).toContain('mcp__demo__code_review')
+  })
+
+  it('does not list prompts from a server that lacks the prompts capability', async () => {
+    let listed = false
+    hoisted.control.listPrompts = async () => {
+      listed = true
+      return { prompts: [] }
+    }
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+
+    expect(listed).toBe(false)
+    expect(harness.commandNames()).toEqual(['mcp'])
+  })
+
+  it('registers every page of a paginated prompt list', async () => {
+    hoisted.control.getServerCapabilities = () => ({ prompts: {} })
+    hoisted.control.listPrompts = async ({ cursor }) => {
+      if (!cursor) return { prompts: [{ name: 'one' }], nextCursor: 'page-2' }
+      return { prompts: [{ name: 'two' }] }
+    }
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+
+    expect(harness.commandNames()).toEqual(expect.arrayContaining(['mcp__demo__one', 'mcp__demo__two']))
+  })
+
+  it('maps args onto the declared arguments and sends the prompt content as a user message', async () => {
+    const calls: unknown[] = []
+    withPrompts([{ name: 'greet', arguments: [{ name: 'who', required: true }] }])
+    hoisted.control.getPrompt = async (args) => {
+      calls.push(args)
+      return {
+        messages: [
+          { role: 'user', content: { type: 'text', text: 'Hello Alex' } },
+          { role: 'user', content: { type: 'text', text: 'Be nice' } },
+        ],
+      }
+    }
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+
+    await harness.runSlash('mcp__demo__greet', 'Alex')
+
+    expect(calls).toEqual([{ name: 'greet', arguments: { who: 'Alex' } }])
+    expect(harness.sent).toEqual([
+      [
+        { type: 'text', text: 'Hello Alex' },
+        { type: 'text', text: 'Be nice' },
+      ],
+    ])
+  })
+
+  it('carries a prompt image block through to the user message', async () => {
+    withPrompts([{ name: 'shot' }])
+    hoisted.control.getPrompt = async () => ({
+      messages: [
+        { role: 'user', content: { type: 'text', text: 'see the screenshot' } },
+        { role: 'user', content: { type: 'image', data: 'ZZZZ', mimeType: 'image/png' } },
+      ],
+    })
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+
+    await harness.runSlash('mcp__demo__shot', '')
+
+    expect(harness.sent).toEqual([
+      [
+        { type: 'text', text: 'see the screenshot' },
+        { type: 'image', data: 'ZZZZ', mimeType: 'image/png' },
+      ],
+    ])
+  })
+
+  it('reports instead of driving a turn when a prompt returns no content', async () => {
+    withPrompts([{ name: 'empty' }])
+    hoisted.control.getPrompt = async () => ({ messages: [] })
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+
+    await harness.runSlash('mcp__demo__empty', '')
+
+    expect(harness.sent).toEqual([])
+    expect(harness.notifications.some((n) => n.message.includes('no content'))).toBe(true)
+  })
+
+  it('skips a second same-server prompt whose name normalizes onto one already taken', async () => {
+    withPrompts([{ name: 'deploy-prod' }, { name: 'deploy_prod' }])
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+
+    expect(harness.commandNames().filter((n) => n === 'mcp__demo__deploy_prod')).toEqual(['mcp__demo__deploy_prod'])
+    expect(harness.warnings.some((w) => w.includes('skipping colliding prompt command mcp__demo__deploy_prod'))).toBe(true)
+  })
+
+  it('omits the arguments field when the prompt declares none', async () => {
+    const calls: unknown[] = []
+    withPrompts([{ name: 'plain' }])
+    hoisted.control.getPrompt = async (args) => {
+      calls.push(args)
+      return { messages: [{ role: 'user', content: { type: 'text', text: 'ok' } }] }
+    }
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+
+    await harness.runSlash('mcp__demo__plain', '')
+
+    expect(calls).toEqual([{ name: 'plain' }])
+  })
+
+  it('registers prompts announced later via prompts list_changed without duplicating existing ones', async () => {
+    withPrompts([{ name: 'first' }])
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+    expect(harness.commandNames()).toEqual(['mcp', 'mcp__demo__first'])
+
+    hoisted.control.listPrompts = async () => ({ prompts: [{ name: 'first' }, { name: 'second' }] })
+    await hoisted.notify.get('notifications/prompts/list_changed')?.()
+
+    expect(harness.commandNames()).toEqual(['mcp', 'mcp__demo__first', 'mcp__demo__second'])
+  })
+
+  it('notifies at error level instead of sending when getPrompt fails', async () => {
+    withPrompts([{ name: 'boom' }])
+    hoisted.control.getPrompt = async () => {
+      throw new Error('prompt exploded')
+    }
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+
+    await harness.runSlash('mcp__demo__boom', '')
+
+    expect(harness.sent).toEqual([])
+    expect(harness.notifications.some((n) => n.level === 'error' && n.message.includes('prompt exploded'))).toBe(true)
+  })
+})
+
+describe('mcp resource tools', () => {
+  const withResourceCapability = (): void => {
+    hoisted.control.getServerCapabilities = () => ({ resources: {} })
+  }
+  const resourceTool = (harness: Harness, name: string): RegisteredTool => {
+    const tool = harness.tools.find((t) => t.name === name)
+    if (!tool) throw new Error(`${name} was not registered`)
+    return tool
+  }
+
+  it('registers no resource tools when no connected server advertises resources', async () => {
+    const harness = await setupStarted({ user: { plain: { command: 'x' } } })
+
+    expect(harness.toolNames()).not.toContain('list_mcp_resources')
+    expect(harness.toolNames()).not.toContain('read_mcp_resource')
+  })
+
+  it('registers the list and read tools exactly once across resource-capable servers', async () => {
+    withResourceCapability()
+    const harness = await setupStarted({ user: { one: { command: 'x' }, two: { command: 'y' } } })
+
+    expect(harness.toolNames().filter((n) => n === 'list_mcp_resources')).toHaveLength(1)
+    expect(harness.toolNames().filter((n) => n === 'read_mcp_resource')).toHaveLength(1)
+  })
+
+  it('lists resources and templates across servers, naming the server on each entry', async () => {
+    withResourceCapability()
+    hoisted.control.listResources = async (_args, client) => (client.transport?.options.command === 'x' ? { resources: [{ uri: 'db://a', name: 'A' }] } : { resources: [{ uri: 'db://b', name: 'B' }] })
+    hoisted.control.listResourceTemplates = async (_args, client) => (client.transport?.options.command === 'x' ? { resourceTemplates: [{ uriTemplate: 'db://{id}', name: 'ById' }] } : { resourceTemplates: [] })
+    const harness = await setupStarted({ user: { one: { command: 'x' }, two: { command: 'y' } } })
+
+    const out = await resourceTool(harness, 'list_mcp_resources').execute('c1', {})
+
+    const entries = JSON.parse(out.content[0].text ?? '') as Array<Record<string, unknown>>
+    expect(entries).toContainEqual(expect.objectContaining({ server: 'one', uri: 'db://a' }))
+    expect(entries).toContainEqual(expect.objectContaining({ server: 'two', uri: 'db://b' }))
+    expect(entries).toContainEqual(expect.objectContaining({ server: 'one', uriTemplate: 'db://{id}' }))
+  })
+
+  it('filters the listing to the requested server and rejects an unknown one', async () => {
+    withResourceCapability()
+    hoisted.control.listResources = async (_args, client) => (client.transport?.options.command === 'x' ? { resources: [{ uri: 'db://a', name: 'A' }] } : { resources: [{ uri: 'db://b', name: 'B' }] })
+    const harness = await setupStarted({ user: { one: { command: 'x' }, two: { command: 'y' } } })
+    const tool = resourceTool(harness, 'list_mcp_resources')
+
+    const out = await tool.execute('c1', { server: 'two' })
+    const entries = JSON.parse(out.content[0].text ?? '') as Array<Record<string, unknown>>
+    expect(entries).toEqual([expect.objectContaining({ server: 'two', uri: 'db://b' })])
+
+    await expect(tool.execute('c2', { server: 'ghost' })).rejects.toThrow('not connected')
+  })
+
+  it('keeps the resource listing when a server does not support templates', async () => {
+    withResourceCapability()
+    hoisted.control.listResources = async () => ({ resources: [{ uri: 'db://a', name: 'A' }] })
+    hoisted.control.listResourceTemplates = async () => {
+      throw new Error('Method not found')
+    }
+    const harness = await setupStarted({ user: { one: { command: 'x' } } })
+
+    const out = await resourceTool(harness, 'list_mcp_resources').execute('c1', {})
+
+    const entries = JSON.parse(out.content[0].text ?? '') as Array<Record<string, unknown>>
+    expect(entries).toEqual([expect.objectContaining({ server: 'one', uri: 'db://a' })])
+    expect(entries.every((entry) => !('error' in entry))).toBe(true)
+  })
+
+  it('reads a resource and routes its text through the output budget', async () => {
+    withResourceCapability()
+    hoisted.control.readResource = async (args) => ({ contents: [{ uri: args.uri, text: 'y'.repeat(60_000), mimeType: 'text/plain' }] })
+    const harness = await setupStarted({ user: { one: { command: 'x' } } })
+
+    const out = await resourceTool(harness, 'read_mcp_resource').execute('c1', { server: 'one', uri: 'db://big' })
+
+    expect(out.content[0].text).toContain('[Resource: db://big]')
+    expect(out.content[0].text).toContain('[truncated')
+  })
+
+  it('maps an image blob to an image block and other blobs to a placeholder', async () => {
+    withResourceCapability()
+    hoisted.control.readResource = async () => ({
+      contents: [
+        { uri: 'img://shot', blob: 'AAAA', mimeType: 'image/png' },
+        { uri: 'bin://blob', blob: 'BBBB', mimeType: 'application/octet-stream' },
+      ],
+    })
+    const harness = await setupStarted({ user: { one: { command: 'x' } } })
+
+    const out = await resourceTool(harness, 'read_mcp_resource').execute('c1', { server: 'one', uri: 'img://shot' })
+
+    expect(out.content[0]).toEqual({ type: 'image', data: 'AAAA', mimeType: 'image/png' })
+    expect(out.content[1].text).toContain('bin://blob')
+    expect(out.content[1].text).not.toContain('BBBB')
+  })
+
+  it('rejects a read against a server that is not connected', async () => {
+    withResourceCapability()
+    const harness = await setupStarted({ user: { one: { command: 'x' } } })
+
+    await expect(resourceTool(harness, 'read_mcp_resource').execute('c1', { server: 'ghost', uri: 'db://a' })).rejects.toThrow('not connected')
+  })
+
+  it('registers the tools from resources list_changed when the capability settled late', async () => {
+    let capabilities: Record<string, unknown> | undefined
+    hoisted.control.getServerCapabilities = () => capabilities
+    const harness = await setupStarted({ user: { one: { command: 'x' } } })
+    expect(harness.toolNames()).not.toContain('list_mcp_resources')
+
+    capabilities = { resources: {} }
+    await hoisted.notify.get('notifications/resources/list_changed')?.()
+
+    expect(harness.toolNames()).toEqual(expect.arrayContaining(['list_mcp_resources', 'read_mcp_resource']))
+  })
+
+  it('reserves the resource tool names against a shadowing server tool', async () => {
+    withTools([{ name: 'mcp-resource' }])
+    const harness = await setupStarted({ user: { read: { command: 'x' } } })
+
+    expect(harness.toolNames()).not.toContain('read_mcp_resource')
+    expect(harness.warnings.join('\n')).toContain('read_mcp_resource')
   })
 })

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { applyServerPolicy, formatToolName, interpolateEnv, loadConfigFrom, loadUserScope, managedSettingsPath, mapContent, mcpAllowDeny, normalizeSchema, parseHelperHeaders, projectConfigPaths, userConfigPaths } from '../extensions/mcp.ts'
+import { applyServerPolicy, formatPromptCommandName, formatToolName, interpolateEnv, loadConfigFrom, loadUserScope, managedSettingsPath, mapContent, mapPromptArguments, mcpAllowDeny, normalizeSchema, parseHelperHeaders, projectConfigPaths, promptMessageContent, userConfigPaths } from '../extensions/mcp.ts'
 
 describe('parseHelperHeaders', () => {
   it('keeps string-valued header entries and drops the rest', () => {
@@ -203,5 +203,69 @@ describe('mcp adapter helpers', () => {
   it('caps a huge resource block, not just text blocks', () => {
     const mapped = mapContent([{ type: 'resource', resource: { uri: 'file:///big', text: 'y'.repeat(60_000) } }])
     expect((mapped[0] as { text: string }).text).toContain('[truncated')
+  })
+})
+
+describe('mcp prompt command naming', () => {
+  it('builds mcp__server__prompt with dashes and spaces normalized to underscores', () => {
+    expect(formatPromptCommandName('demo', 'greet')).toBe('mcp__demo__greet')
+    expect(formatPromptCommandName('my-server', 'code review')).toBe('mcp__my_server__code_review')
+  })
+})
+
+describe('mcp prompt argument mapping', () => {
+  it('maps space-separated tokens positionally onto the declared arguments', () => {
+    expect(mapPromptArguments([{ name: 'a' }, { name: 'b' }], 'one two')).toEqual({ a: 'one', b: 'two' })
+  })
+
+  it('keeps a quoted run together as one value, like slash-command args', () => {
+    expect(mapPromptArguments([{ name: 'a' }, { name: 'b' }], '"one two" three')).toEqual({ a: 'one two', b: 'three' })
+  })
+
+  it('folds extra trailing tokens into the last declared argument so no input is dropped', () => {
+    expect(mapPromptArguments([{ name: 'a' }, { name: 'b' }], 'one two three four')).toEqual({ a: 'one', b: 'two three four' })
+  })
+
+  it('omits declared arguments with no token, and maps nothing when none are declared', () => {
+    expect(mapPromptArguments([{ name: 'a' }, { name: 'b' }], 'one')).toEqual({ a: 'one' })
+    expect(mapPromptArguments([], 'stray')).toEqual({})
+    expect(mapPromptArguments(undefined, 'stray')).toEqual({})
+  })
+})
+
+describe('mcp prompt message content', () => {
+  it('maps text and resource message content to injected text blocks', () => {
+    const blocks = promptMessageContent([{ content: { type: 'text', text: 'first line' } }, { content: { type: 'resource', resource: { uri: 'file:///ctx', text: 'body' } } }])
+    expect(blocks).toEqual([
+      { type: 'text', text: 'first line' },
+      { type: 'text', text: '[Resource: file:///ctx]\nbody' },
+    ])
+  })
+
+  it('carries an image block through instead of dropping it', () => {
+    const blocks = promptMessageContent([{ content: { type: 'text', text: 'look at this' } }, { content: { type: 'image', data: 'AAAA', mimeType: 'image/png' } }])
+    expect(blocks).toEqual([
+      { type: 'text', text: 'look at this' },
+      { type: 'image', data: 'AAAA', mimeType: 'image/png' },
+    ])
+  })
+
+  it('keeps an image-only prompt as a real turn', () => {
+    const blocks = promptMessageContent([{ content: { type: 'image', data: 'BBBB', mimeType: 'image/jpeg' } }])
+    expect(blocks).toEqual([{ type: 'image', data: 'BBBB', mimeType: 'image/jpeg' }])
+  })
+
+  it('yields no blocks for an empty message list, so no turn is driven on a sentinel', () => {
+    expect(promptMessageContent([])).toEqual([])
+  })
+
+  it('yields no blocks when every message carries only empty text', () => {
+    expect(promptMessageContent([{ content: { type: 'text', text: '   ' } }, { content: { type: 'text', text: '' } }])).toEqual([])
+  })
+
+  it('caps a prompt whose messages exceed the output budget', () => {
+    const blocks = promptMessageContent([{ content: { type: 'text', text: 'x'.repeat(60_000) } }])
+    expect(blocks[0]).toMatchObject({ type: 'text' })
+    expect(blocks[0].type === 'text' && blocks[0].text).toContain('[truncated')
   })
 })

--- a/tests/status-line-command.test.ts
+++ b/tests/status-line-command.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setManagedSettingsPath } from '../extensions/internal/managed-settings.ts'
 import statusLine, { readStatusLineConfig } from '../extensions/status-line.ts'
 
 const hoisted = vi.hoisted(() => ({ home: '', runs: [] as Array<{ command: string; payload: unknown }>, result: { code: 0, stdout: '', stderr: '', timedOut: false }, gate: undefined as Promise<void> | undefined }))
@@ -47,9 +48,13 @@ beforeEach(() => {
   hoisted.runs.length = 0
   hoisted.result = { code: 0, stdout: '', stderr: '', timedOut: false }
   hoisted.gate = undefined
+  // Hermetic managed settings: the disableAllHooks read must never resolve to this
+  // machine's real policy file.
+  setManagedSettingsPath(join(hoisted.home, 'managed-settings.json'))
 })
 
 afterEach(() => {
+  setManagedSettingsPath(undefined)
   vi.useRealTimers()
   vi.restoreAllMocks()
   for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
@@ -279,6 +284,46 @@ describe('statusLine concurrency and compaction', () => {
     const afterShutdown = hoisted.runs.length
     await vi.advanceTimersByTimeAsync(5000)
     expect(hoisted.runs.length).toBe(afterShutdown)
+  })
+})
+
+describe('statusLine disableAllHooks', () => {
+  it('does not run the configured command and keeps the built-in segment', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { disableAllHooks: true, statusLine: { type: 'command', command: 'seg.sh' } })
+    const { handlers, status, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(hoisted.runs).toHaveLength(0)
+    expect(status.some((s) => s?.includes('ready'))).toBe(true)
+  })
+
+  it('ignores a disableAllHooks in an unapproved project settings file', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    writeSettings(cwd, 'settings.json', { disableAllHooks: true })
+    hoisted.result = { code: 0, stdout: 'seg', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    const untrusted = { ...ctx, isProjectTrusted: () => false }
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, untrusted)
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(hoisted.runs).toHaveLength(1)
+  })
+
+  it('honors a managed-settings disableAllHooks', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    writeFileSync(join(hoisted.home, 'managed-settings.json'), JSON.stringify({ disableAllHooks: true }))
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(hoisted.runs).toHaveLength(0)
   })
 })
 

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -6,7 +6,7 @@ import type { AgentToolResult } from '@earendil-works/pi-agent-core'
 import { DEFAULT_MAX_LINES } from '@earendil-works/pi-coding-agent'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { hasAgentRunner, runAgent, setAgentRunner } from '../extensions/internal/agent-run.ts'
-import subagentExtension, { AGENT_HOOK_SYSTEM, agentMemoryDir, agentMemorySection, buildHookAgent, withMemoryTools } from '../extensions/subagent/index.ts'
+import subagentExtension, { AGENT_HOOK_SYSTEM, agentMemoryDir, agentMemorySection, agentsListText, buildHookAgent, tasksStatusText, withMemoryTools } from '../extensions/subagent/index.ts'
 
 // The agent-memory tests read settings and stores under the home directory; point
 // homedir at a throwaway dir so the developer's real ~/.claude cannot influence them.
@@ -142,12 +142,27 @@ const emittedEvents: Array<{ channel: string; data: unknown }> = []
 
 const eventHandlers = new Map<string, (event: Record<string, unknown>, ctx: unknown) => Promise<unknown>>()
 
+interface CapturedCommand {
+  description?: string
+  handler: (args: string, ctx: unknown) => Promise<void>
+}
+
+const registeredCommands = new Map<string, CapturedCommand>()
+
+/** The captured /name command; throws so a missing registration fails a test loudly. */
+const command = (name: string): CapturedCommand => {
+  const captured = registeredCommands.get(name)
+  if (!captured) throw new Error(`command /${name} was not registered`)
+  return captured
+}
+
 const getExecute = (): Execute => {
   let execute: Execute | undefined
   subagentExtension({
     registerTool: (t: { name: string; execute: Execute }) => {
       if (t.name === 'subagent') execute = t.execute
     },
+    registerCommand: (name: string, options: CapturedCommand) => registeredCommands.set(name, options),
     sendMessage: sendMessageMock,
     events: { emit: (channel: string, data: unknown) => emittedEvents.push({ channel, data }), on: () => () => {} },
     on: (name: string, fn: (event: Record<string, unknown>, ctx: unknown) => Promise<unknown>) => eventHandlers.set(name, fn),
@@ -166,6 +181,11 @@ const agentConfig = (over: Partial<{ name: string; systemPrompt: string; source:
 })
 
 const trustedCtx = { cwd: '/repo', hasUI: false, isProjectTrusted: () => true, ui: { confirm: vi.fn(async () => true) } }
+
+const notifyMock = vi.fn()
+
+/** The context a slash-command handler runs with: trustedCtx plus the notify sink. */
+const commandCtx = (over: Record<string, unknown> = {}) => ({ ...trustedCtx, ui: { ...trustedCtx.ui, notify: notifyMock }, ...over })
 
 const text = (result: ToolResult): string => {
   const first = result.content[0]
@@ -206,9 +226,12 @@ beforeEach(() => {
   cancelBackgroundRunMock.mockReset()
   resumeBackgroundRunMock.mockReset()
   activeBackgroundRunsMock.mockReturnValue(0)
+  backgroundRunMock.mockReset()
   sendMessageMock.mockClear()
+  notifyMock.mockClear()
   emittedEvents.length = 0
   eventHandlers.clear()
+  registeredCommands.clear()
   trustedCtx.ui.confirm.mockClear()
   discoverAgentsMock.mockReturnValue({ agents: [agentConfig()], projectAgentsDir: null })
   execute = getExecute()
@@ -865,6 +888,145 @@ describe('backgroundCompletionText diagnostics', () => {
 
     const done = backgroundCompletionText({ id: 'bg-2', agent: 'scout', state: 'done', turns: 3, output: 'all good', stderr: 'noise' })
     expect(done).not.toContain('stderr tail:')
+  })
+})
+
+describe('tasksStatusText', () => {
+  it('notes when there are no background runs', () => {
+    expect(tasksStatusText([])).toBe('No background subagent runs in this session.')
+  })
+
+  it('lists each run with id, agent, state, turns and a short output tail', () => {
+    const out = tasksStatusText([
+      { id: 'bg-1', agent: 'scout', task: 'audit the API surface', state: 'running', turns: 0 },
+      { id: 'bg-2', agent: 'reviewer', task: 'review the diff', state: 'done', turns: 3, output: 'Looked at 4 files.\nAll clear.' },
+      { id: 'bg-3', agent: 'scout', task: 'boot check', state: 'failed', turns: 0, stderr: 'unknown model id x' },
+    ])
+
+    expect(out).toContain('bg-1 scout: running - audit the API surface')
+    expect(out).toContain('bg-2 reviewer: done (3 turns) - review the diff')
+    // The tail is the last line of the run output, not the whole transcript.
+    expect(out).toContain('All clear.')
+    expect(out).not.toContain('Looked at 4 files.')
+    expect(out).toContain('bg-3 scout: failed (0 turns) - boot check')
+    // A child that dies at boot leaves only stderr; the tail says so.
+    expect(out).toContain('stderr: unknown model id x')
+  })
+
+  it('uses singular wording for a one-turn run', () => {
+    expect(tasksStatusText([{ id: 'bg-1', agent: 'scout', task: 't', state: 'done', turns: 1 }])).toContain('done (1 turn) - t')
+  })
+
+  it('truncates long task previews and long output tails', () => {
+    const out = tasksStatusText([{ id: 'bg-1', agent: 'scout', task: 'x'.repeat(100), state: 'done', turns: 2, output: 'y'.repeat(400) }])
+
+    expect(out).toContain('x'.repeat(60))
+    expect(out).not.toContain('x'.repeat(61))
+    expect(out).toContain(`${'y'.repeat(200)}...`)
+    expect(out).not.toContain('y'.repeat(201))
+  })
+
+  it('does not split a surrogate pair when the truncation boundary lands mid-character', () => {
+    const loneSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
+    const tail = tasksStatusText([{ id: 'bg-1', agent: 'scout', task: 't', state: 'done', turns: 1, output: `${'y'.repeat(199)}😀😀` }])
+    expect(loneSurrogate.test(tail)).toBe(false)
+    const task = tasksStatusText([{ id: 'bg-2', agent: 'scout', task: `${'z'.repeat(59)}😀😀`, state: 'done', turns: 1 }])
+    expect(loneSurrogate.test(task)).toBe(false)
+  })
+})
+
+describe('agentsListText', () => {
+  it('points at the agent directories when nothing was discovered', () => {
+    const out = agentsListText([])
+
+    expect(out).toContain('No agents discovered')
+    expect(out).toContain('~/.claude/agents')
+    expect(out).toContain('.claude/agents')
+  })
+
+  it('groups agents by source, lists file paths, and appends the add-more hint', () => {
+    const out = agentsListText([
+      { name: 'repo-reviewer', source: 'project', filePath: '/repo/.claude/agents/repo-reviewer.md' },
+      { name: 'scout', source: 'user', filePath: '/home/u/.claude/agents/scout.md' },
+      { name: 'Explore', source: 'builtin', filePath: '/ext/agents/explore.md' },
+      { name: 'linter', source: 'plugin', filePath: '/plugins/lint/agents/linter.md' },
+    ])
+
+    // Grouped lowest to highest precedence, matching discovery's override order.
+    const positions = ['builtin:', 'plugin:', 'user:', 'project:'].map((header) => out.indexOf(header))
+    expect(positions.every((p) => p >= 0)).toBe(true)
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions)
+
+    expect(out).toContain('  Explore - /ext/agents/explore.md')
+    expect(out).toContain('  linter - /plugins/lint/agents/linter.md')
+    expect(out).toContain('  scout - /home/u/.claude/agents/scout.md')
+    expect(out).toContain('  repo-reviewer - /repo/.claude/agents/repo-reviewer.md')
+    expect(out).toContain('~/.claude/agents')
+  })
+
+  it('omits the header of a source with no agents', () => {
+    const out = agentsListText([{ name: 'scout', source: 'user', filePath: '/home/u/.claude/agents/scout.md' }])
+
+    expect(out).toContain('user:')
+    expect(out).not.toContain('builtin:')
+    expect(out).not.toContain('project:')
+  })
+})
+
+describe('viewer commands', () => {
+  it('registers /tasks and /agents with descriptions', () => {
+    expect(command('tasks').description).toBeTruthy()
+    expect(command('agents').description).toBeTruthy()
+  })
+
+  it('/tasks notes the empty registry without running anything', async () => {
+    await command('tasks').handler('', commandCtx())
+
+    expect(notifyMock).toHaveBeenCalledWith('No background subagent runs in this session.', 'info')
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('/tasks lists runs started in this session, resolved against the live registry', async () => {
+    startBackgroundRunMock.mockReturnValue('bg-11111111')
+    await execute('c1', { background: true, agent: 'scout', task: 'audit the API surface' }, undefined, undefined, trustedCtx)
+    backgroundRunMock.mockImplementation((id: string) => (id === 'bg-11111111' ? { id, agent: 'scout', task: 'audit the API surface', state: 'done', turns: 3, output: 'All clear.' } : undefined))
+
+    await command('tasks').handler('', commandCtx())
+
+    const out = notifyMock.mock.calls[0][0] as string
+    expect(out).toContain('bg-11111111 scout: done (3 turns) - audit the API surface')
+    expect(out).toContain('All clear.')
+  })
+
+  it('/tasks drops runs the registry has evicted', async () => {
+    await execute('c1', { background: true, agent: 'scout', task: 'audit' }, undefined, undefined, trustedCtx)
+    backgroundRunMock.mockReturnValue(undefined)
+
+    await command('tasks').handler('', commandCtx())
+
+    expect(notifyMock).toHaveBeenCalledWith('No background subagent runs in this session.', 'info')
+  })
+
+  it('/agents lists the discovered agents for an approved project', async () => {
+    discoverAgentsMock.mockClear()
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig(), agentConfig({ name: 'repo', source: 'project', filePath: '/repo/.pi/agents/repo.md' })], projectAgentsDir: '/repo/.pi/agents' })
+
+    await command('agents').handler('', commandCtx())
+
+    expect(discoverAgentsMock).toHaveBeenCalledWith('/repo', 'both')
+    const out = notifyMock.mock.calls[0][0] as string
+    expect(out).toContain('user:')
+    expect(out).toContain('  scout - /agents/scout.md')
+    expect(out).toContain('project:')
+    expect(out).toContain('  repo - /repo/.pi/agents/repo.md')
+  })
+
+  it('/agents narrows discovery to user scope when the project is not approved', async () => {
+    discoverAgentsMock.mockClear()
+
+    await command('agents').handler('', commandCtx({ isProjectTrusted: () => false }))
+
+    expect(discoverAgentsMock).toHaveBeenCalledWith('/repo', 'user')
   })
 })
 

--- a/tests/subagent-render.test.ts
+++ b/tests/subagent-render.test.ts
@@ -46,6 +46,7 @@ const getTool = (): ToolShape => {
     registerTool: (t: ToolShape) => {
       if (t.name === 'subagent') tool = t
     },
+    registerCommand: () => {},
     on: () => {},
   } as never)
   if (!tool) throw new Error('subagent tool was not registered')


### PR DESCRIPTION
## Summary

Adds the next wave of Claude Code parity to the extension pack, verified against the live docs at code.claude.com. Test-driven with unit and integration coverage; `npm run check` is green at 1473 tests, 96% statements and 91% branches.

MCP servers that advertise the `prompts` capability now expose each prompt as a `/mcp__<server>__<prompt>` slash command, and servers advertising `resources` gain global `list_mcp_resources` and `read_mcp_resource` tools; both track the server's list-changed notifications. A prompt's image blocks are carried through to the turn rather than flattened away, a second prompt whose name normalizes onto one already taken is skipped with a warning instead of shadowing it, and a prompt that returns no content is reported rather than driving an empty turn.

The model can now invoke user slash commands through a `SlashCommand` tool, which lists only the commands not marked `disable-model-invocation` and refuses the rest. A command's tool and model scoping is restored once the run has fully settled (`agent_settled`), so it survives an automatic retry, an auto-compaction, or a Stop-hook continuation. `disable-model-invocation` honors YAML's `yes`, `on`, and `1` spellings rather than only literal `true`, so a command the user marked off-limits is never silently offered to the model, and the model's resolution set is rebuilt on each session start so a resumed or forked session cannot run a previous project's command. `disableSkillShellExecution` replaces a command's `!`-shell spans with a policy placeholder, and the model path always uses the placeholder regardless of the setting.

`disableAllHooks` is honored as an escape hatch, where any settings scope can disable hooks and none can re-enable them, with the status line falling back to the built-in; a new `/hooks` command prints the resolved hooks with their source files, and names a malformed entry rather than failing.

`/tasks` lists this session's background subagent runs and `/agents` lists the discovered roster with sources; both are read-only and return without interrupting the agent.
