### PR TITLE
Clear SonarCloud findings across the extension pack

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -80,6 +80,16 @@ function substitutePathRule(rule: string, vars: Record<string, string | undefine
   return rule.trimStart().startsWith('${CLAUDE_') && path.isAbsolute(substituted) ? `/${substituted}` : substituted
 }
 
+/** The path rules that survive an allowed-tools intersection: only the tools the
+ * grant kept get their scopes, each rule ${CLAUDE_*}-substituted like the body. */
+function scopedPathRules(pathRules: Partial<Record<PathRuleTool, string[]>>, granted: string[], vars: Record<string, string | undefined>): Partial<Record<PathRuleTool, string[]>> {
+  const result: Partial<Record<PathRuleTool, string[]>> = {}
+  for (const [tool, rules] of Object.entries(pathRules)) {
+    if (granted.includes(tool)) result[tool as PathRuleTool] = rules.map((rule) => substitutePathRule(rule, vars))
+  }
+  return result
+}
+
 /** Wall-clock budget for one injected span: the Bash tool's documented 2-minute
  * default, which is what Claude runs these commands under. */
 const BASH_TIMEOUT_MS = 120_000
@@ -204,7 +214,7 @@ export async function expandCommand(runner: SpanRunner, parsed: ParsedCommand, a
   // `${user_config.KEY}` is a plugin-command variable only; leave it literal in an
   // ordinary command so a body that happens to contain the syntax is not stripped.
   const substituted = substituteVars(withArgs, vars)
-  const withVars = plugin ? substituted.replace(/\$\{user_config\.([A-Za-z0-9_]+)\}/g, (_, key: string) => plugin.userConfig?.[key] ?? '') : substituted
+  const withVars = plugin ? substituted.replace(/\$\{user_config\.(\w+)\}/g, (_, key: string) => plugin.userConfig?.[key] ?? '') : substituted
 
   const exec: CommandExec =
     (options?.allowShell ?? true)
@@ -259,7 +269,8 @@ export function slashCommandToolDescription(commands: SlashCommandEntry[], budge
   let used = 0
   let omitted = 0
   for (const command of commands) {
-    const entry = `/${command.name} - ${command.description}${command.argumentHint ? ` (${command.argumentHint})` : ''}`.slice(0, ENTRY_CHAR_CAP)
+    const hintSuffix = command.argumentHint ? ` (${command.argumentHint})` : ''
+    const entry = `/${command.name} - ${command.description}${hintSuffix}`.slice(0, ENTRY_CHAR_CAP)
     if (used + entry.length + 1 > budget) {
       omitted++
       continue // a shorter later entry may still fit the remaining budget
@@ -336,6 +347,57 @@ export default function commandsExtension(pi: ExtensionAPI) {
     }
   })
 
+  /** Take the tool set to restore when this run ends, captured once per turn so a
+   * second restricted command narrows against the original unrestricted set. */
+  function captureRestorePoint(): string[] {
+    const original = pendingRestore ?? pi.getActiveTools()
+    pendingRestore = original
+    return original
+  }
+
+  /** Apply a command's allowed-tools to the run it drives: intersect with the tools
+   * pi actually has, keep the bash and path scopes for the tool_call guard, and let
+   * agent_settled restore the previous set. */
+  function applyAllowedTools(parsed: ParsedCommand, vars: Record<string, string | undefined>): void {
+    const allowed = parsed.allowedTools
+    if (!allowed) return
+    // Only the first restriction in a turn sees the unrestricted set; a second
+    // command must grant and restore against that original set, or its own tools
+    // are intersected away by the first command's narrowing.
+    const original = captureRestorePoint()
+    const granted = allowed.filter((tool) => original.includes(tool))
+    // `allowed-tools: []` says no tools, and is honored. A non-empty list that
+    // intersects to nothing named only tools pi has none of: that restriction cannot
+    // be expressed, and applying it as "no tools" is not what the command asked for.
+    if (granted.length > 0 || allowed.length === 0) pi.setActiveTools(granted)
+    // The latest restricted command speaks for the turn: a later unscoped grant
+    // lifts an earlier command's scopes rather than stacking under them. Rules get
+    // the same ${CLAUDE_*} substitution as the body, so a rule can name a bundled
+    // script by its real path, as the skills docs show.
+    pendingBashRules = granted.includes('bash') ? parsed.bashRules?.map((rule) => substituteVars(rule, vars)) : undefined
+    pendingPathRules = parsed.pathRules ? scopedPathRules(parsed.pathRules, granted, vars) : undefined
+  }
+
+  /** Claude removes disallowed-tools from the pool while the command is active; with
+   * both fields present the removal wins, as in subagent tool lists. */
+  function applyDisallowedTools(parsed: ParsedCommand): void {
+    const disallowed = parsed.disallowedTools
+    if (!disallowed || disallowed.length === 0) return
+    captureRestorePoint()
+    pi.setActiveTools(pi.getActiveTools().filter((tool) => !disallowed.includes(tool)))
+  }
+
+  /** Claude's `model:` frontmatter overrides the model for this run only, then the
+   * session model resumes; restore happens on agent_settled like the tool-set restore.
+   * Applied before sendUserMessage so the run it drives happens on the new model. */
+  async function applyModelOverride(parsed: ParsedCommand, varCtx: VarContext): Promise<void> {
+    const target = resolveCommandModel(parsed.model, varCtx.modelRegistry?.getAvailable() ?? [])
+    if (target && varCtx.model && target.id !== varCtx.model.id) {
+      pendingModelRestore = pendingModelRestore ?? varCtx.model
+      await pi.setModel(target as Parameters<typeof pi.setModel>[0])
+    }
+  }
+
   async function runCommand(parsed: ParsedCommand, args: string, ctx: ExtensionCommandContext, filePath: string, plugin?: CommandPlugin): Promise<void> {
     const varCtx = ctx as unknown as VarContext
     const vars = commandVars(ctx, filePath, plugin)
@@ -354,46 +416,9 @@ export default function commandsExtension(pi: ExtensionAPI) {
     // restored when that run ends. Restoring inline does not work: sendUserMessage is
     // fire-and-forget, so the restore would land before the agent ever read the tool
     // list, leaving the command running with everything enabled.
-    if (parsed.allowedTools) {
-      // Only the first restriction in a turn sees the unrestricted set; a second
-      // command must grant and restore against that original set, or its own tools
-      // are intersected away by the first command's narrowing.
-      const original = pendingRestore ?? pi.getActiveTools()
-      pendingRestore = original
-      const granted = parsed.allowedTools.filter((tool) => original.includes(tool))
-      // `allowed-tools: []` says no tools, and is honored. A non-empty list that
-      // intersects to nothing named only tools pi has none of: that restriction cannot
-      // be expressed, and applying it as "no tools" is not what the command asked for.
-      if (granted.length > 0 || parsed.allowedTools.length === 0) pi.setActiveTools(granted)
-      // The latest restricted command speaks for the turn: a later unscoped grant
-      // lifts an earlier command's scopes rather than stacking under them. Rules get
-      // the same ${CLAUDE_*} substitution as the body, so a rule can name a bundled
-      // script by its real path, as the skills docs show.
-      pendingBashRules = granted.includes('bash') ? parsed.bashRules?.map((rule) => substituteVars(rule, vars)) : undefined
-      pendingPathRules = undefined
-      if (parsed.pathRules) {
-        pendingPathRules = {}
-        for (const [tool, rules] of Object.entries(parsed.pathRules)) {
-          if (granted.includes(tool)) pendingPathRules[tool as PathRuleTool] = rules.map((rule) => substitutePathRule(rule, vars))
-        }
-      }
-    }
-    // Claude removes disallowed-tools from the pool while the skill is active;
-    // with both fields present the removal wins, as in subagent tool lists.
-    if (parsed.disallowedTools && parsed.disallowedTools.length > 0) {
-      const original = pendingRestore ?? pi.getActiveTools()
-      pendingRestore = original
-      const disallowed = parsed.disallowedTools
-      pi.setActiveTools(pi.getActiveTools().filter((tool) => !disallowed.includes(tool)))
-    }
-    // Claude's `model:` frontmatter overrides the model for this run only, then the
-    // session model resumes; restore happens on agent_settled like the tool-set restore.
-    // Applied before sendUserMessage so the run it drives happens on the new model.
-    const target = resolveCommandModel(parsed.model, varCtx.modelRegistry?.getAvailable() ?? [])
-    if (target && varCtx.model && target.id !== varCtx.model.id) {
-      pendingModelRestore = pendingModelRestore ?? varCtx.model
-      await pi.setModel(target as Parameters<typeof pi.setModel>[0])
-    }
+    applyAllowedTools(parsed, vars)
+    applyDisallowedTools(parsed)
+    await applyModelOverride(parsed, varCtx)
     pi.sendUserMessage(expanded)
   }
 

--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -159,32 +159,58 @@ function readImport(target: string, fromDir: string, home: string, allowedRoots:
   }
 }
 
+/** Optional controls for a collection run: the byte/file budget shared across the
+ * whole run, the path of the file this content came from (seeds each top-level
+ * import's `parent`), and the exclusion predicate. Recursion depth is internal. */
+export interface CollectImportsOptions {
+  budget?: ImportBudget
+  importer?: string
+  isExcluded?: (realPath: string) => boolean
+}
+
+/** The parts of a collection run that stay fixed across the recursion: resolution
+ * roots, the seen/budget accumulators, and the exclusion predicate. Only content,
+ * fromDir, depth and the parent path change from one level to the next. */
+interface ImportScan {
+  home: string
+  allowedRoots: string[]
+  seen: Set<string>
+  budget: ImportBudget
+  isExcluded?: (realPath: string) => boolean
+}
+
+/** One recursion level: read the imports named in `content`, then recurse into each. */
+function collectFrom(scan: ImportScan, content: string, fromDir: string, depth: number, importer?: string): ImportedFile[] {
+  if (depth >= MAX_IMPORT_DEPTH) return []
+  const out: ImportedFile[] = []
+  for (const target of importTargets(content)) {
+    // Checked before the read so an exhausted budget costs no I/O.
+    if (scan.budget.files === 0 || scan.budget.bytes === 0) {
+      scan.budget.dropped += 1
+      continue
+    }
+    const file = readImport(target, fromDir, scan.home, scan.allowedRoots, scan.seen, scan.isExcluded)
+    if (!file) continue
+    scan.budget.files -= 1
+    const kept = file.body.slice(0, scan.budget.bytes)
+    scan.budget.bytes -= kept.length
+    const body = kept.length < file.body.length ? `${kept.trim()}\n${IMPORT_TRUNCATED_MARKER}` : kept.trim()
+    // Comments are stripped before the scan for further imports, so a
+    // commented-out @import stays dead at every depth, matching the top level
+    // (whose bodies arrive here already stripped by the caller).
+    out.push({ path: file.real, body, parent: importer }, ...collectFrom(scan, stripBlockComments(kept), path.dirname(file.real), depth + 1, file.real))
+  }
+  return out
+}
+
 /**
  * Collect the contents of every file transitively imported via `@path`, in
  * discovery order. Imports are resolved through symlinks and kept within
  * `allowedRoots` (which must already be realpath'd).
  */
-export function collectImports(content: string, fromDir: string, home: string, allowedRoots: string[], seen: Set<string>, budget: ImportBudget = createImportBudget(), depth = 0, importer?: string, isExcluded?: (realPath: string) => boolean): ImportedFile[] {
-  if (depth >= MAX_IMPORT_DEPTH) return []
-  const out: ImportedFile[] = []
-  for (const target of importTargets(content)) {
-    // Checked before the read so an exhausted budget costs no I/O.
-    if (budget.files === 0 || budget.bytes === 0) {
-      budget.dropped += 1
-      continue
-    }
-    const file = readImport(target, fromDir, home, allowedRoots, seen, isExcluded)
-    if (!file) continue
-    budget.files -= 1
-    const kept = file.body.slice(0, budget.bytes)
-    budget.bytes -= kept.length
-    const body = kept.length < file.body.length ? `${kept.trim()}\n${IMPORT_TRUNCATED_MARKER}` : kept.trim()
-    // Comments are stripped before the scan for further imports, so a
-    // commented-out @import stays dead at every depth, matching the top level
-    // (whose bodies arrive here already stripped by the caller).
-    out.push({ path: file.real, body, parent: importer }, ...collectImports(stripBlockComments(kept), path.dirname(file.real), home, allowedRoots, seen, budget, depth + 1, file.real, isExcluded))
-  }
-  return out
+export function collectImports(content: string, fromDir: string, home: string, allowedRoots: string[], seen: Set<string>, options: CollectImportsOptions = {}): ImportedFile[] {
+  const scan: ImportScan = { home, allowedRoots, seen, budget: options.budget ?? createImportBudget(), isExcluded: options.isExcluded }
+  return collectFrom(scan, content, fromDir, 0, options.importer)
 }
 
 /**
@@ -357,6 +383,114 @@ export function isExcludedPath(absPath: string, globs: string[], home: string): 
   })
 }
 
+/** Apply claudeMdExcludes and comment-stripping to pi's native context blocks,
+ * rewriting the assembled prompt by exact substring: an excluded file's block is
+ * removed, a surviving file's block is replaced with its comment-stripped body. A
+ * wrapper not found in the prompt is skipped rather than risk corrupting it.
+ * Returns the rewritten prompt and the files that survived exclusion (stripped). */
+function rewriteNativeBlocks(prompt: string, native: Array<{ path: string; content: string }>, excluded: (absPath: string) => boolean): { prompt: string; changed: boolean; kept: Array<{ path: string; content: string }> } {
+  let changed = false
+  const kept: Array<{ path: string; content: string }> = []
+  for (const file of native) {
+    const wrapper = instructionsBlock(file.path, file.content)
+    if (excluded(file.path)) {
+      const removed = removeBlock(prompt, wrapper)
+      if (removed !== null) {
+        prompt = removed
+        changed = true
+      }
+      continue
+    }
+    const stripped = stripBlockComments(file.content)
+    if (stripped !== file.content) {
+      const replaced = replaceBlock(prompt, wrapper, instructionsBlock(file.path, stripped))
+      if (replaced !== null) {
+        prompt = replaced
+        changed = true
+      }
+    }
+    kept.push({ path: file.path, content: stripped })
+  }
+  return { prompt, changed, kept }
+}
+
+/** Claude's --add-dir memory files, minus any pi already loaded natively (added to
+ * `seenSet` here so an @import cannot pull one in twice) and any the excludes drop
+ * or that strip to nothing. Each survivor is comment-stripped and tagged with its
+ * additional dir, so its relative imports can resolve from there. */
+function additionalDirExtras(addDirs: string[], seenSet: Set<string>, excluded: (absPath: string) => boolean, includeLocal: boolean): Array<{ path: string; content: string; dir: string }> {
+  const extras: Array<{ path: string; content: string; dir: string }> = []
+  for (const dir of addDirs) {
+    for (const file of additionalDirContextFiles(dir, includeLocal)) {
+      const [real] = realRoots([file.path])
+      const key = real ?? file.path
+      if (seenSet.has(key)) continue // pi already loaded it natively
+      seenSet.add(key)
+      if (excluded(file.path)) continue
+      const stripped = stripBlockComments(file.content)
+      if (stripped.trim().length === 0) continue
+      extras.push({ path: file.path, content: stripped, dir })
+    }
+  }
+  return extras
+}
+
+/** Resolve every context and additional-dir file's @imports through the one shared
+ * budget, each with roots scoped to the importing file so a project file never
+ * reaches user config. */
+function expandImports(contextFiles: Array<{ path: string; content: string }>, extras: Array<{ path: string; content: string; dir: string }>, home: string, cwd: string, seenSet: Set<string>, excluded: (absPath: string) => boolean, budget: ImportBudget): ImportedFile[] {
+  const imported: ImportedFile[] = []
+  for (const file of contextFiles) {
+    const allowedRoots = rootsForImporter(file.path, home, cwd)
+    imported.push(...collectImports(file.content, path.dirname(file.path), home, allowedRoots, seenSet, { budget, importer: file.path, isExcluded: excluded }))
+  }
+  for (const extra of extras) {
+    // The additional dir itself is an allowed root, so its files' relative imports
+    // resolve even from .claude/rules two levels down.
+    const allowedRoots = [...realRoots([extra.dir]), ...rootsForImporter(extra.path, home, cwd)]
+    imported.push(...collectImports(extra.content, path.dirname(extra.path), home, allowedRoots, seenSet, { budget, importer: extra.path, isExcluded: excluded }))
+  }
+  return imported
+}
+
+/** The CLAUDE.local.md bodies appended after the native context, announced as they
+ * are added (only the non-empty ones, matching what actually reaches the prompt). */
+function localContextAddition(keptLocals: Array<{ path: string; content: string }>, announce: (event: InstructionLoadEvent) => void): string {
+  let addition = ''
+  for (const local of keptLocals) {
+    if (local.content.trim().length > 0) {
+      addition += `\n\n## CLAUDE.local.md (${local.path})\n\n${local.content.trim()}`
+      announce({ file_path: local.path, memory_type: 'Local', load_reason: 'session_start' })
+    }
+  }
+  return addition
+}
+
+/** The --add-dir memory files appended as extra project_instructions blocks.
+ * Additional dirs are extra working directories, so their files are Project-typed
+ * regardless of where the dir sits (Local for a CLAUDE.local.md). */
+function additionalDirsAddition(extras: Array<{ path: string; content: string; dir: string }>, announce: (event: InstructionLoadEvent) => void): string {
+  let addition = ''
+  for (const extra of extras) {
+    addition += `\n\n${instructionsBlock(extra.path, extra.content)}`
+    announce({ file_path: extra.path, memory_type: path.basename(extra.path) === 'CLAUDE.local.md' ? 'Local' : 'Project', load_reason: 'session_start' })
+  }
+  return addition
+}
+
+/** The `## Imported context (@)` section for every resolved @import, with the
+ * budget-exhaustion notice, announcing each as an `include`. Empty when nothing
+ * was imported. */
+function importedAddition(imported: ImportedFile[], budget: ImportBudget, home: string, projectRoot: string, announce: (event: InstructionLoadEvent) => void): string {
+  if (imported.length === 0) return ''
+  const section = imported.map((entry) => `### ${entry.path}\n\n${stripBlockComments(entry.body)}`).join('\n\n')
+  const notice = budget.dropped === 0 ? '' : `\n\n${budget.dropped} further @imports were skipped: the import budget (${MAX_IMPORT_FILES} files, ${MAX_IMPORT_BYTES} bytes) is spent.`
+  for (const entry of imported) {
+    announce({ file_path: entry.path, memory_type: memoryTypeForPath(entry.path, home, projectRoot), load_reason: 'include', ...(entry.parent === undefined ? {} : { parent_file_path: entry.parent }) })
+  }
+  return `\n\n## Imported context (@)\n\n${section}${notice}`
+}
+
 export default function contextImportsExtension(pi: ExtensionAPI) {
   let localContexts: Array<{ path: string; content: string }> = []
   // Whether project settings may contribute claudeMdExcludes; decided at session
@@ -416,37 +550,16 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     const excluded = (absPath: string): boolean => isExcludedPath(absPath, excludeGlobs, home)
     const projectRoot = repoRoot(cwd) ?? cwd
 
-    let prompt = event.systemPrompt
-    let changed = false
-
     // claudeMdExcludes drops an excluded file's block from the assembled prompt and
     // from import expansion; surviving blocks get block-level comments stripped.
-    // Both rewrite by exact substring: a wrapper that is not found in the prompt is
-    // skipped rather than risk corrupting it.
-    const keptNative: Array<{ path: string; content: string }> = []
-    for (const file of native) {
-      const wrapper = instructionsBlock(file.path, file.content)
-      if (excluded(file.path)) {
-        const removed = removeBlock(prompt, wrapper)
-        if (removed !== null) {
-          prompt = removed
-          changed = true
-        }
-        continue
-      }
-      const stripped = stripBlockComments(file.content)
-      if (stripped !== file.content) {
-        const replaced = replaceBlock(prompt, wrapper, instructionsBlock(file.path, stripped))
-        if (replaced !== null) {
-          prompt = replaced
-          changed = true
-        }
-      }
-      keptNative.push({ path: file.path, content: stripped })
-      // Exclusion is owned here, so the session_start InstructionsLoaded events
-      // for pi's native context files are published here too, only for files
-      // that actually survived it: Claude fires no event for a file it never
-      // loaded. The hooks extension consumes them off the shared bus.
+    const rewrite = rewriteNativeBlocks(event.systemPrompt, native, excluded)
+    let prompt = rewrite.prompt
+    let changed = rewrite.changed
+    // Exclusion is owned here, so the session_start InstructionsLoaded events for
+    // pi's native context files are published here too, only for files that
+    // survived it: Claude fires no event for a file it never loaded. The hooks
+    // extension consumes them off the shared bus.
+    for (const file of rewrite.kept) {
       announce({ file_path: file.path, memory_type: memoryTypeForPath(file.path, home, projectRoot), load_reason: 'session_start' })
     }
 
@@ -460,69 +573,27 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     }
 
     const keptLocals = localContexts.filter((local) => !excluded(local.path)).map((local) => ({ path: local.path, content: stripBlockComments(local.content) }))
-    const contextFiles = [...keptNative, ...keptLocals]
+    const contextFiles = [...rewrite.kept, ...keptLocals]
 
     // Seed with every loaded context file path, excluded ones included, so pi's own
     // files are never re-imported and an excluded file cannot return as an import.
-    const seen = realRoots([...native, ...localContexts].map((file) => file.path))
-    const seenSet = new Set(seen)
+    const seenSet = new Set(realRoots([...native, ...localContexts].map((file) => file.path)))
 
     // Claude's --add-dir memory loading, env-gated. The files join the seen set
     // before import expansion so an @import cannot pull one in twice, and they get
     // the same exclude and comment-strip treatment as native context files.
     const addDirs = additionalDirsClaudeMdEnabled() ? parseAdditionalDirs(pi.getFlag?.('add-dir'), home, cwd) : []
-    const extras: Array<{ path: string; content: string; dir: string }> = []
-    for (const dir of addDirs) {
-      for (const file of additionalDirContextFiles(dir, projectApproved)) {
-        const [real] = realRoots([file.path])
-        const key = real ?? file.path
-        if (seenSet.has(key)) continue // pi already loaded it natively
-        seenSet.add(key)
-        if (excluded(file.path)) continue
-        const stripped = stripBlockComments(file.content)
-        if (stripped.trim().length === 0) continue
-        extras.push({ path: file.path, content: stripped, dir })
-      }
-    }
+    const extras = additionalDirExtras(addDirs, seenSet, excluded, projectApproved)
 
-    const imported: ImportedFile[] = []
     // One budget for the whole run, so N context files cannot each spend a full one.
     // Exclusion applies inside the recursion: an excluded @import is skipped before
     // it is read, so its transitive imports never load and it spends no budget.
     const budget = createImportBudget()
-    for (const file of contextFiles) {
-      // Roots are scoped per importing file: a project file never reaches user config.
-      const allowedRoots = rootsForImporter(file.path, home, cwd)
-      imported.push(...collectImports(file.content, path.dirname(file.path), home, allowedRoots, seenSet, budget, 0, file.path, excluded))
-    }
-    for (const extra of extras) {
-      // The additional dir itself is an allowed root, so its files' relative
-      // imports resolve even from .claude/rules two levels down.
-      const allowedRoots = [...realRoots([extra.dir]), ...rootsForImporter(extra.path, home, cwd)]
-      imported.push(...collectImports(extra.content, path.dirname(extra.path), home, allowedRoots, seenSet, budget, 0, extra.path, excluded))
-    }
+    const imported = expandImports(contextFiles, extras, home, cwd, seenSet, excluded, budget)
 
-    let addition = ''
-    for (const local of keptLocals) {
-      if (local.content.trim().length > 0) {
-        addition += `\n\n## CLAUDE.local.md (${local.path})\n\n${local.content.trim()}`
-        announce({ file_path: local.path, memory_type: 'Local', load_reason: 'session_start' })
-      }
-    }
-    for (const extra of extras) {
-      addition += `\n\n${instructionsBlock(extra.path, extra.content)}`
-      // Additional dirs are extra working directories, so their memory files are
-      // Project-typed regardless of where the dir sits (Local for CLAUDE.local.md).
-      announce({ file_path: extra.path, memory_type: path.basename(extra.path) === 'CLAUDE.local.md' ? 'Local' : 'Project', load_reason: 'session_start' })
-    }
-    if (imported.length > 0) {
-      const section = imported.map((entry) => `### ${entry.path}\n\n${stripBlockComments(entry.body)}`).join('\n\n')
-      const notice = budget.dropped === 0 ? '' : `\n\n${budget.dropped} further @imports were skipped: the import budget (${MAX_IMPORT_FILES} files, ${MAX_IMPORT_BYTES} bytes) is spent.`
-      addition += `\n\n## Imported context (@)\n\n${section}${notice}`
-      for (const entry of imported) {
-        announce({ file_path: entry.path, memory_type: memoryTypeForPath(entry.path, home, projectRoot), load_reason: 'include', ...(entry.parent === undefined ? {} : { parent_file_path: entry.parent }) })
-      }
-    }
+    let addition = localContextAddition(keptLocals, announce)
+    addition += additionalDirsAddition(extras, announce)
+    addition += importedAddition(imported, budget, home, projectRoot, announce)
     if (!changed && addition.length === 0) return
 
     return { systemPrompt: prompt + addition }

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -276,6 +276,23 @@ function isRunnableHook(hook: HookCommand): boolean {
   return typeof hook.command === 'string' && (hook.type === undefined || hook.type === 'command')
 }
 
+/** The synthetic identity of a non-shell hook entry: an http/prompt/agent/mcp_tool
+ * entry has no `command`, so its url / prompt / server:tool stands in. A shell hook
+ * (undefined or `command` type) already has one, so this is undefined. */
+function syntheticCommand(hook: HookCommand): string | undefined {
+  if (hook.type === 'http') return hook.url
+  if (hook.type === 'prompt' || hook.type === 'agent') return hook.prompt
+  if (hook.type === 'mcp_tool') return `${hook.server}:${hook.tool}`
+  return undefined
+}
+
+/** A matched entry with its `command` filled in: mirroring the synthetic identity into
+ * `command` keeps dedup, timeout messages and display working for non-shell hooks. */
+function withCommand(raw: HookCommand): HookCommand {
+  const identity = syntheticCommand(raw)
+  return identity !== undefined && typeof raw.command !== 'string' ? { ...raw, command: identity } : raw
+}
+
 /** Command specs whose matcher applies to any of the given tool/source names.
  * Multiple candidates let one event offer both the pi name and its Claude alias. */
 export function matchingCommands(matchers: HookMatcher[] | undefined, names: string | readonly string[]): HookCommand[] {
@@ -285,11 +302,7 @@ export function matchingCommands(matchers: HookMatcher[] | undefined, names: str
   for (const entry of matchers ?? []) {
     if (!matcherApplies(entry.matcher, candidates)) continue
     for (const raw of (entry.hooks ?? []).filter(isRunnableHook)) {
-      // An http/prompt/agent/mcp_tool entry has no `command`; its identity is the
-      // url / prompt / server:tool. Mirroring it into `command` keeps dedup, timeout
-      // messages and display working.
-      const identity = raw.type === 'http' ? raw.url : raw.type === 'prompt' || raw.type === 'agent' ? raw.prompt : raw.type === 'mcp_tool' ? `${raw.server}:${raw.tool}` : undefined
-      const hook = identity !== undefined && typeof raw.command !== 'string' ? { ...raw, command: identity } : raw
+      const hook = withCommand(raw)
       // Claude runs a handler defined in more than one settings file once.
       if (seen.has(hook.command)) continue
       seen.add(hook.command)
@@ -325,8 +338,9 @@ export function formatHooksSummary(config: HooksConfig, sources?: Map<HookMatche
     for (const entry of matchers) {
       const matcher = entry.matcher || '*'
       const source = sources?.get(entry)
+      const suffix = source ? ` (${source})` : ''
       for (const hook of entry.hooks ?? []) {
-        entryLines.push(`  [${matcher}] ${hookIdentity(hook)}${source ? ` (${source})` : ''}`)
+        entryLines.push(`  [${matcher}] ${hookIdentity(hook)}${suffix}`)
       }
     }
     if (entryLines.length > 0) lines.push(`${event}:`, ...entryLines)
@@ -432,7 +446,7 @@ function interpolateHeaders(headers: Record<string, string> | undefined, allowed
   const allowedSet = new Set(allowed ?? [])
   const out: Record<string, string> = {}
   for (const [key, value] of Object.entries(headers ?? {})) {
-    out[key] = value.replace(/\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g, (_token, braced?: string, bare?: string) => {
+    out[key] = value.replace(/\$(?:\{([A-Za-z_]\w*)\}|([A-Za-z_]\w*))/g, (_token, braced?: string, bare?: string) => {
       const name = braced ?? bare ?? ''
       return allowedSet.has(name) ? (process.env[name] ?? '') : ''
     })
@@ -709,6 +723,22 @@ function claudeSpelling(map: Record<string, string>, raw: string): { names: stri
   return { names: value === raw ? [raw] : [raw, value], value }
 }
 
+/** The feedback lines one PostToolUse/PostToolUseFailure result appends next to the
+ * tool result: a block notice (exit-2 stderr, or decision:block on success) followed
+ * by any additionalContext. A failed tool cannot be blocked, so its stderr is shown
+ * but never a decision:block verdict. */
+function postToolFeedback(result: HookRunResult, eventName: string, isError: boolean): string[] {
+  const lines: string[] = []
+  const parsed = tryParseJson(result.stdout)
+  // A failed tool cannot be blocked, but the hook's stderr is still shown; on
+  // success, exit-2 / decision:block feed back as a block notice.
+  if (!result.timedOut && result.code === 2) lines.push(`${eventName} hook: ${result.stderr.trim() || (isError ? 'hook reported an error' : 'Blocked by hook')}`)
+  else if (!isError && parsed?.decision === 'block') lines.push(`PostToolUse hook: ${parsed.reason ?? 'Blocked by hook'}`)
+  const context = parsed?.hookSpecificOutput?.additionalContext
+  if (context) lines.push(context)
+  return lines
+}
+
 export default function hooksExtension(pi: ExtensionAPI) {
   let config: HooksConfig = {}
   let projectDir = ''
@@ -861,16 +891,7 @@ export default function hooksExtension(pi: ExtensionAPI) {
     const run = boundRunner(ctx, { tool_use_id: event.toolCallId })
     const results = await Promise.all(commands.map((command) => run(command, payload, timeoutMs(command))))
     surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
-    const feedback: string[] = []
-    for (const result of results) {
-      const parsed = tryParseJson(result.stdout)
-      // A failed tool cannot be blocked, but the hook's stderr is still shown; on
-      // success, exit-2 / decision:block feed back as a block notice.
-      if (!result.timedOut && result.code === 2) feedback.push(`${eventName} hook: ${result.stderr.trim() || (event.isError ? 'hook reported an error' : 'Blocked by hook')}`)
-      else if (!event.isError && parsed?.decision === 'block') feedback.push(`PostToolUse hook: ${parsed.reason ?? 'Blocked by hook'}`)
-      const context = parsed?.hookSpecificOutput?.additionalContext
-      if (context) feedback.push(context)
-    }
+    const feedback = results.flatMap((result) => postToolFeedback(result, eventName, event.isError))
     if (feedback.length === 0) return
     return { content: [...event.content, ...feedback.map((text) => ({ type: 'text' as const, text }))] }
   })

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -16,6 +16,9 @@ import { parseFrontmatter } from '@earendil-works/pi-coding-agent'
 
 import { splitSegments } from './shell-split.js'
 
+/** The pi file tools a Claude path rule can govern. */
+export type PathRuleTool = 'read' | 'edit' | 'write'
+
 export interface ParsedCommand {
   description: string
   argumentHint?: string
@@ -23,7 +26,7 @@ export interface ParsedCommand {
   /** Claude `Bash(...)` specifiers, present only when every bash grant is scoped. */
   bashRules?: string[]
   /** Claude path rules per pi file tool, from Read(...)/Edit(...)/Write(...) grants. */
-  pathRules?: Partial<Record<'read' | 'edit' | 'write', string[]>>
+  pathRules?: Partial<Record<PathRuleTool, string[]>>
   /** Names from the `arguments:` frontmatter list, mapped to positions in order. */
   argumentNames?: string[]
   /** Tools removed from the pool while the command's turn runs. */
@@ -122,16 +125,76 @@ export interface ToolGrants {
   /** Claude path rules per pi file tool, absent for a tool with an unscoped grant.
    * Edit scopes govern writes too, as Claude documents; Write scopes are honored
    * rather than Claude's accept-and-warn-then-ignore, which would fail open here. */
-  pathRules?: Partial<Record<'read' | 'edit' | 'write', string[]>>
+  pathRules?: Partial<Record<PathRuleTool, string[]>>
   /** Entries that carried an argument scope, in their original spelling. */
   scopedEntries: string[]
 }
 
 /** The pi file tools one Claude path-ruled entry governs. */
-const PATH_RULE_TOOLS: Record<string, Array<'read' | 'edit' | 'write'>> = {
+const PATH_RULE_TOOLS: Record<string, Array<PathRuleTool>> = {
   read: ['read'],
   edit: ['edit', 'write'],
   write: ['write'],
+}
+
+/** The tools, scopes, and path rules accumulated while scanning one grant list. */
+interface GrantAccumulator {
+  tools: string[]
+  scopedEntries: string[]
+  bashRules: string[]
+  bashUnscoped: boolean
+  pathScopes: Record<PathRuleTool, string[]>
+  pathUnscoped: Set<PathRuleTool>
+}
+
+function createGrantAccumulator(): GrantAccumulator {
+  return { tools: [], scopedEntries: [], bashRules: [], bashUnscoped: false, pathScopes: { read: [], edit: [], write: [] }, pathUnscoped: new Set() }
+}
+
+/** Coerce a raw grant value to its string entries: a YAML list stays a list, a
+ * comma-separated string is split, and anything else (or a list with a non-string
+ * member) is rejected as undefined, the same "not a grant" signal as an absent field. */
+function coerceGrantItems(raw: unknown): string[] | undefined {
+  let items: unknown[]
+  if (Array.isArray(raw)) items = raw
+  else if (typeof raw === 'string') items = toolEntries(raw)
+  else return undefined
+  if (items.some((item) => typeof item !== 'string')) return undefined
+  return items as string[]
+}
+
+/** Fold one grant entry into the accumulator: the base tool is granted, an unscoped
+ * entry marks its tools wide, and a scoped entry records the scope for bash and the
+ * file tools it governs. */
+function addGrantEntry(acc: GrantAccumulator, item: string): void {
+  const entry = item.trim()
+  const name = normalizeToolName(entry)
+  if (!name) return
+  if (!acc.tools.includes(name)) acc.tools.push(name)
+  const open = entry.indexOf('(')
+  if (open === -1) {
+    if (name === 'bash') acc.bashUnscoped = true
+    for (const tool of PATH_RULE_TOOLS[name] ?? []) acc.pathUnscoped.add(tool)
+    return
+  }
+  acc.scopedEntries.push(entry)
+  const scope = entry.slice(open + 1, entry.endsWith(')') ? -1 : undefined).trim()
+  // An empty specifier (`Bash()`, `Read()`) matches nothing and must not read as
+  // the unscoped grant it explicitly is not: it is recorded so the tool stays
+  // restricted, and the matchers treat an empty rule as matching no input.
+  if (name === 'bash') acc.bashRules.push(scope)
+  for (const tool of PATH_RULE_TOOLS[name] ?? []) acc.pathScopes[tool].push(scope)
+}
+
+/** The per-tool path rules from a scan: a tool with any unscoped grant is omitted
+ * (it is wide), one with only scoped grants keeps them, and the whole map is absent
+ * when no tool carries a rule. */
+function buildPathRules(acc: GrantAccumulator): ToolGrants['pathRules'] {
+  const pathRules: NonNullable<ToolGrants['pathRules']> = {}
+  for (const tool of ['read', 'edit', 'write'] as const) {
+    if (!acc.pathUnscoped.has(tool) && acc.pathScopes[tool].length > 0) pathRules[tool] = acc.pathScopes[tool]
+  }
+  return Object.keys(pathRules).length > 0 ? pathRules : undefined
 }
 
 /**
@@ -147,47 +210,15 @@ const PATH_RULE_TOOLS: Record<string, Array<'read' | 'edit' | 'write'>> = {
  * whose widening reaches everything, so it is the one enforced.
  */
 export function parseToolGrants(raw: unknown): ToolGrants | undefined {
-  if (raw === undefined || raw === null) return undefined
-  let items: unknown[]
-  if (Array.isArray(raw)) items = raw
-  else if (typeof raw === 'string') items = toolEntries(raw)
-  else return undefined
-  if (items.some((item) => typeof item !== 'string')) return undefined
-
-  const tools: string[] = []
-  const scopedEntries: string[] = []
-  const bashRules: string[] = []
-  let bashUnscoped = false
-  const pathScopes: Record<'read' | 'edit' | 'write', string[]> = { read: [], edit: [], write: [] }
-  const pathUnscoped = new Set<'read' | 'edit' | 'write'>()
-  for (const item of items as string[]) {
-    const entry = item.trim()
-    const name = normalizeToolName(entry)
-    if (!name) continue
-    if (!tools.includes(name)) tools.push(name)
-    const open = entry.indexOf('(')
-    if (open === -1) {
-      if (name === 'bash') bashUnscoped = true
-      for (const tool of PATH_RULE_TOOLS[name] ?? []) pathUnscoped.add(tool)
-      continue
-    }
-    scopedEntries.push(entry)
-    const scope = entry.slice(open + 1, entry.endsWith(')') ? -1 : undefined).trim()
-    // An empty specifier (`Bash()`, `Read()`) matches nothing and must not read as
-    // the unscoped grant it explicitly is not: it is recorded so the tool stays
-    // restricted, and the matchers treat an empty rule as matching no input.
-    if (name === 'bash') bashRules.push(scope)
-    for (const tool of PATH_RULE_TOOLS[name] ?? []) pathScopes[tool].push(scope)
-  }
-  const pathRules: ToolGrants['pathRules'] = {}
-  for (const tool of ['read', 'edit', 'write'] as const) {
-    if (!pathUnscoped.has(tool) && pathScopes[tool].length > 0) pathRules[tool] = pathScopes[tool]
-  }
+  const items = coerceGrantItems(raw)
+  if (items === undefined) return undefined
+  const acc = createGrantAccumulator()
+  for (const item of items) addGrantEntry(acc, item)
   return {
-    tools,
-    scopedEntries,
-    bashRules: !bashUnscoped && bashRules.length > 0 ? bashRules : undefined,
-    pathRules: Object.keys(pathRules).length > 0 ? pathRules : undefined,
+    tools: acc.tools,
+    scopedEntries: acc.scopedEntries,
+    bashRules: !acc.bashUnscoped && acc.bashRules.length > 0 ? acc.bashRules : undefined,
+    pathRules: buildPathRules(acc),
   }
 }
 
@@ -208,14 +239,14 @@ const isFlagEnabled = (value: unknown): boolean => value === true || YAML_TRUE.h
 /** Claude writes `argument-hint: [pr]`, which YAML reads as a list; render it back. */
 const hint = (value: unknown): string => (Array.isArray(value) ? `[${value.join(', ')}]` : text(value))
 
-const ARGUMENT_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
+const ARGUMENT_NAME = /^[A-Za-z_]\w*$/
 
 /** The `arguments:` frontmatter: a YAML list or a space- or comma-separated string
  * of names mapping to positions in order. Invalid names are dropped, and ARGUMENTS
  * itself is reserved by the built-in placeholder. */
 function parseArgumentNames(raw: unknown): string[] | undefined {
   let items: string[]
-  if (Array.isArray(raw)) items = raw.map((entry) => String(entry))
+  if (Array.isArray(raw)) items = raw.map(String)
   else if (typeof raw === 'string') items = raw.split(/[\s,]+/)
   else return undefined
   const names = items.map((name) => name.trim()).filter((name) => ARGUMENT_NAME.test(name) && name !== 'ARGUMENTS')
@@ -312,8 +343,8 @@ export function substituteArgsDetailed(body: string, args: string, names: string
     return value
   }
   const text = body.replaceAll(argPattern(names), (token, bracketIdx?: string, defIdx?: string, defVal?: string, argsDefault?: string, shorthandIdx?: string, name?: string) => {
-    if (token === '\\\\') return token
-    if (token === '\\$') return '$'
+    if (token === String.raw`\\`) return token
+    if (token === String.raw`\$`) return '$'
     if (bracketIdx !== undefined) return fill(parts[Number(bracketIdx)], token)
     if (defIdx !== undefined) return fill(parts[Number(defIdx)], defVal ?? '')
     if (argsDefault !== undefined) {

--- a/extensions/internal/html-markdown.ts
+++ b/extensions/internal/html-markdown.ts
@@ -20,6 +20,16 @@ function decodeAllEntities(text: string): string {
 
 const stripInnerTags = (html: string): string => html.replace(/<[^<>]*>/g, '')
 
+// Strip leading and trailing newline runs in linear time. The equivalent
+// /^\n+|\n+$/g backtracks super-linearly on a long run of newlines (S8786).
+const trimNewlines = (value: string): string => {
+  let start = 0
+  let end = value.length
+  while (start < end && value[start] === '\n') start++
+  while (end > start && value[end - 1] === '\n') end--
+  return value.slice(start, end)
+}
+
 export function htmlToMarkdown(html: string): string {
   // Pre blocks are lifted out first so no later transform touches their content.
   const preBodies: string[] = []
@@ -27,7 +37,7 @@ export function htmlToMarkdown(html: string): string {
     .replace(/<!--[\s\S]*?-->/g, ' ')
     .replace(/<(script|style|noscript|head|svg)\b[^<>]*>[\s\S]*?<\/\1[^<>]*>/gi, ' ')
     .replace(/<pre\b[^<>]*>([\s\S]*?)<\/pre>/gi, (_whole, inner: string) => {
-      preBodies.push(decodeAllEntities(stripInnerTags(inner)).replace(/^\n+|\n+$/g, ''))
+      preBodies.push(trimNewlines(decodeAllEntities(stripInnerTags(inner))))
       return `\n\n\uE000PRE${preBodies.length - 1}\uE000\n\n`
     })
 

--- a/extensions/internal/instruction-events.ts
+++ b/extensions/internal/instruction-events.ts
@@ -15,7 +15,7 @@ export const INSTRUCTIONS_CHANNEL = 'pi-code:instructions'
 /** Claude's memory_type vocabulary for InstructionsLoaded payloads. */
 export type InstructionMemoryType = 'User' | 'Project' | 'Local' | 'Managed'
 
-const MEMORY_TYPES: readonly string[] = ['User', 'Project', 'Local', 'Managed']
+const MEMORY_TYPES: ReadonlySet<string> = new Set(['User', 'Project', 'Local', 'Managed'])
 
 export interface InstructionLoadEvent {
   /** Absolute path of the instruction file that entered context. */
@@ -35,7 +35,7 @@ export function isInstructionLoadEvent(data: unknown): data is InstructionLoadEv
   const event = data as InstructionLoadEvent | null
   if (event === null || typeof event !== 'object') return false
   if (typeof event.file_path !== 'string' || typeof event.load_reason !== 'string') return false
-  if (!MEMORY_TYPES.includes(event.memory_type)) return false
+  if (!MEMORY_TYPES.has(event.memory_type)) return false
   if (event.globs !== undefined && !(Array.isArray(event.globs) && event.globs.every((glob) => typeof glob === 'string'))) return false
   if (event.trigger_file_path !== undefined && typeof event.trigger_file_path !== 'string') return false
   if (event.parent_file_path !== undefined && typeof event.parent_file_path !== 'string') return false

--- a/extensions/internal/managed-settings.ts
+++ b/extensions/internal/managed-settings.ts
@@ -15,7 +15,7 @@ import * as fs from 'node:fs'
 export function managedSettingsPath(platform: NodeJS.Platform = process.platform): string {
   if (platform === 'darwin') return '/Library/Application Support/ClaudeCode/managed-settings.json'
   // The legacy C:\ProgramData\ClaudeCode path was dropped in Claude Code v2.1.75.
-  if (platform === 'win32') return 'C:\\Program Files\\ClaudeCode\\managed-settings.json'
+  if (platform === 'win32') return String.raw`C:\Program Files\ClaudeCode\managed-settings.json`
   return '/etc/claude-code/managed-settings.json'
 }
 

--- a/extensions/internal/mcp-oauth.ts
+++ b/extensions/internal/mcp-oauth.ts
@@ -32,17 +32,21 @@ interface StoredAuth {
  * the store directory and distinct names from colliding after sanitization. */
 function storeFileFor(serverName: string): string {
   const digest = crypto.createHash('sha256').update(serverName).digest('hex').slice(0, 8)
-  const safe =
-    serverName
-      .replace(/[^A-Za-z0-9_-]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 40) || 'server'
+  // Collapse disallowed runs to a single hyphen, then strip leading and trailing
+  // hyphens by index. The old /^-+|-+$/g trim rescanned on every hyphen of a long run
+  // (its trailing-anchored branch backtracks per start position), which is quadratic.
+  const collapsed = serverName.replace(/[^A-Za-z0-9_-]+/g, '-')
+  let start = 0
+  let end = collapsed.length
+  while (start < end && collapsed[start] === '-') start++
+  while (end > start && collapsed[end - 1] === '-') end--
+  const safe = collapsed.slice(start, end).slice(0, 40) || 'server'
   return path.join(getAgentDir(), 'mcp-oauth', `${safe}-${digest}.json`)
 }
 
 export class FileOAuthProvider implements OAuthClientProvider {
   private readonly storePath: string
-  private data: StoredAuth
+  private readonly data: StoredAuth
   private port = 0
   private readonly onRedirect: (authorizationUrl: URL) => void
 
@@ -161,7 +165,9 @@ export function waitForAuthCode(server: http.Server, timeoutMs: number): Promise
 
 /** Best-effort browser launch; the caller also surfaces the URL as text. */
 export function openBrowser(url: string): void {
-  const command = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open'
+  let command = 'xdg-open'
+  if (process.platform === 'darwin') command = 'open'
+  else if (process.platform === 'win32') command = 'cmd'
   const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url]
   try {
     spawn(command, args, { stdio: 'ignore', detached: true }).unref()

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -64,6 +64,15 @@ function enabledMap(settingsFiles: string[]): Record<string, boolean> {
   return merged
 }
 
+/** Copy one plugin config's `options` into `target`, coercing scalars to strings and
+ * ignoring the rest, later keys winning. */
+function mergeOptionValues(target: Record<string, string>, options: object): void {
+  for (const [key, value] of Object.entries(options)) {
+    if (typeof value === 'string') target[key] = value
+    else if (typeof value === 'number' || typeof value === 'boolean') target[key] = String(value)
+  }
+}
+
 /** `pluginConfigs[id].options` per plugin id, later files winning per key. */
 function pluginConfigsMap(settingsFiles: string[]): Record<string, Record<string, string>> {
   const merged: Record<string, Record<string, string>> = {}
@@ -74,10 +83,7 @@ function pluginConfigsMap(settingsFiles: string[]): Record<string, Record<string
       const options = (config as Record<string, unknown>)?.options
       if (options === null || typeof options !== 'object') continue
       const values = merged[id] ?? {}
-      for (const [key, value] of Object.entries(options)) {
-        if (typeof value === 'string') values[key] = value
-        else if (typeof value === 'number' || typeof value === 'boolean') values[key] = String(value)
-      }
+      mergeOptionValues(values, options)
       merged[id] = values
     }
   }
@@ -99,20 +105,27 @@ export function installedPlugins(home: string, extraSettingsFiles: string[] = []
   const plugins: InstalledPlugin[] = []
   for (const marketplace of listDirs(cacheDir)) {
     for (const pluginDir of listDirs(path.join(cacheDir, marketplace))) {
-      const qualified = `${pluginDir}@${marketplace}`
-      const state = enabled[qualified] ?? enabled[pluginDir]
-      if (state !== true) continue
-      const version = newestVersion(listDirs(path.join(cacheDir, marketplace, pluginDir)))
-      if (!version) continue
-      const root = path.join(cacheDir, marketplace, pluginDir, version)
-      const manifest = readJson(path.join(root, '.claude-plugin', 'plugin.json'))
-      const name = typeof manifest.name === 'string' && manifest.name.length > 0 ? manifest.name : pluginDir
-      const id = qualified.replace(/[^A-Za-z0-9]+/g, '-')
-      const userConfig = configs[qualified] ?? configs[pluginDir] ?? configs[name]
-      plugins.push({ name, root, dataDir: path.join(home, '.claude', 'plugins', 'data', id), manifest, ...(userConfig ? { userConfig } : {}) })
+      const plugin = resolvePlugin(home, cacheDir, marketplace, pluginDir, enabled, configs)
+      if (plugin) plugins.push(plugin)
     }
   }
   return plugins
+}
+
+/** Resolve one cached plugin directory into an enabled InstalledPlugin, or null to skip
+ * it: not turned on in settings, or no version directory on disk yet. */
+function resolvePlugin(home: string, cacheDir: string, marketplace: string, pluginDir: string, enabled: Record<string, boolean>, configs: Record<string, Record<string, string>>): InstalledPlugin | null {
+  const qualified = `${pluginDir}@${marketplace}`
+  const state = enabled[qualified] ?? enabled[pluginDir]
+  if (state !== true) return null
+  const version = newestVersion(listDirs(path.join(cacheDir, marketplace, pluginDir)))
+  if (!version) return null
+  const root = path.join(cacheDir, marketplace, pluginDir, version)
+  const manifest = readJson(path.join(root, '.claude-plugin', 'plugin.json'))
+  const name = typeof manifest.name === 'string' && manifest.name.length > 0 ? manifest.name : pluginDir
+  const id = qualified.replace(/[^A-Za-z0-9]+/g, '-')
+  const userConfig = configs[qualified] ?? configs[pluginDir] ?? configs[name]
+  return { name, root, dataDir: path.join(home, '.claude', 'plugins', 'data', id), manifest, ...(userConfig ? { userConfig } : {}) }
 }
 
 /** The two plugin path variables, textually substituted into plugin-shipped
@@ -121,5 +134,5 @@ export function substitutePluginVars(value: string, plugin: InstalledPlugin): st
   return value
     .replaceAll('${CLAUDE_PLUGIN_ROOT}', plugin.root)
     .replaceAll('${CLAUDE_PLUGIN_DATA}', plugin.dataDir)
-    .replace(/\$\{user_config\.([A-Za-z0-9_]+)\}/g, (_, key: string) => plugin.userConfig?.[key] ?? '')
+    .replace(/\$\{user_config\.(\w+)\}/g, (_, key: string) => plugin.userConfig?.[key] ?? '')
 }

--- a/extensions/internal/strip-comments.ts
+++ b/extensions/internal/strip-comments.ts
@@ -25,51 +25,74 @@ function fenceLength(lineStart: string, marker: string): number {
   return length
 }
 
+// CommonMark closes a fenced block only with a fence of the same character that
+// is at least as long as the opener, so both are tracked: a shorter same-char
+// fence line (the classic 3-backtick block quoted inside a 4-backtick one) is
+// content, not a closer.
+interface Fence {
+  marker: string
+  length: number
+}
+
+/** The fence state after a line, plus whether the line is fenced code (opener,
+ * body, or closer) and so emitted verbatim rather than scanned for comments. */
+function stepFence(fence: Fence | null, trimmed: string, marker: string | null): { fence: Fence | null; fenced: boolean } {
+  if (marker !== null && fence === null) {
+    return { fence: { marker, length: fenceLength(trimmed, marker) }, fenced: true }
+  }
+  if (fence !== null) {
+    const closes = marker === fence.marker && fenceLength(trimmed, marker) >= fence.length
+    return { fence: closes ? null : fence, fenced: true } // closer included: comments are content, not maintainer notes
+  }
+  return { fence, fenced: false }
+}
+
+/** Advance a line while inside an open multi-line comment. Emits any content that
+ * trails the closer onto its own line; returns whether the comment stays open. */
+function continueOpenComment(out: string[], line: string): boolean {
+  const close = line.indexOf('-->')
+  if (close === -1) return true // still inside the comment: the line goes with it
+  const rest = line.slice(close + 3)
+  // Content trailing the closer keeps its line; a bare closer line is dropped.
+  if (rest.trim().length > 0) out.push(rest.trimStart())
+  return false
+}
+
+/** Fold line-starting HTML comments off `trimmed`; several may share one line.
+ * `allComment` means the line held nothing but comments and whitespace, so it is
+ * dropped; `opensBlock` means the last comment opened a multi-line block. */
+function consumeLineComments(trimmed: string): { allComment: boolean; opensBlock: boolean } {
+  let rest = trimmed
+  let sawComment = false
+  while (rest.startsWith('<!--')) {
+    sawComment = true
+    const close = rest.indexOf('-->')
+    if (close === -1) return { allComment: true, opensBlock: true } // opens a multi-line comment
+    rest = rest.slice(close + 3).trimStart()
+  }
+  return { allComment: sawComment && rest.length === 0, opensBlock: false }
+}
+
 /** Remove whole-line HTML comments, keeping fenced code and inline comments. */
 export function stripBlockComments(text: string): string {
   const out: string[] = []
-  // CommonMark closes a fenced block only with a fence of the same character
-  // that is at least as long as the opener, so both are tracked: a shorter
-  // same-char fence line (the classic 3-backtick block quoted inside a
-  // 4-backtick one) is content, not a closer.
-  let fence: { marker: string; length: number } | null = null
+  let fence: Fence | null = null
   let inComment = false
   for (const line of text.split('\n')) {
     if (inComment) {
-      const close = line.indexOf('-->')
-      if (close === -1) continue // still inside the comment: the line goes with it
-      inComment = false
-      const rest = line.slice(close + 3)
-      // Content trailing the closer keeps its line; a bare closer line is dropped.
-      if (rest.trim().length > 0) out.push(rest.trimStart())
+      inComment = continueOpenComment(out, line)
       continue
     }
     const trimmed = line.trimStart()
-    const marker = fenceMarker(trimmed)
-    if (marker !== null && fence === null) {
-      fence = { marker, length: fenceLength(trimmed, marker) }
+    const step = stepFence(fence, trimmed, fenceMarker(trimmed))
+    fence = step.fence
+    if (step.fenced) {
       out.push(line)
       continue
     }
-    if (fence !== null) {
-      if (marker === fence.marker && fenceLength(trimmed, marker) >= fence.length) fence = null
-      out.push(line) // fenced code, closer included: comments are content, not maintainer notes
-      continue
-    }
-    // Consume comments anchored at the line start; several may share one line.
-    let rest = trimmed
-    let sawComment = false
-    while (rest.startsWith('<!--')) {
-      sawComment = true
-      const close = rest.indexOf('-->')
-      if (close === -1) {
-        inComment = true // opens a multi-line comment
-        rest = ''
-        break
-      }
-      rest = rest.slice(close + 3).trimStart()
-    }
-    if (sawComment && rest.length === 0) continue // the whole line was comment
+    const { allComment, opensBlock } = consumeLineComments(trimmed)
+    if (opensBlock) inComment = true
+    if (allComment) continue // the whole line was comment
     // No comment, or a line-starting comment followed by content: inline, verbatim.
     out.push(line)
   }

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -207,6 +207,29 @@ export function loadUserScope(home: string, cwd: string): Record<string, ServerC
   return servers
 }
 
+/** The mcpServers one plugin declares: an inline map on the manifest, or the file it
+ * points to (default .mcp.json at the plugin root), with ${CLAUDE_PLUGIN_*} substituted
+ * before parsing. Malformed or missing JSON yields no entries. */
+function pluginServerEntries(plugin: InstalledPlugin): Record<string, ServerConfig> {
+  const declared = plugin.manifest.mcpServers
+  // An inline map of name -> config; an array is not a valid mcpServers map (it
+  // would register a server named '0'), so it falls through to the path branch.
+  if (declared !== null && typeof declared === 'object' && !Array.isArray(declared)) {
+    try {
+      return JSON.parse(substitutePluginVars(JSON.stringify(declared), plugin))
+    } catch {
+      return {}
+    }
+  }
+  const file = path.resolve(plugin.root, typeof declared === 'string' ? declared : '.mcp.json')
+  try {
+    const parsed = JSON.parse(substitutePluginVars(fs.readFileSync(file, 'utf-8'), plugin))
+    return parsed.mcpServers ?? {}
+  } catch {
+    return {}
+  }
+}
+
 /** Servers shipped by enabled plugins (.mcp.json or the manifest's `mcpServers`,
  * inline or by path), with ${CLAUDE_PLUGIN_*} substituted before parsing. Their
  * tools alias as mcp__plugin_<plugin>_<server>__<tool> for hook matchers, as
@@ -215,26 +238,7 @@ export function loadPluginServers(plugins: InstalledPlugin[]): Record<string, Se
   const fold = (name: string): string => name.replaceAll('-', '_')
   const servers: Record<string, ServerConfig> = {}
   for (const plugin of plugins) {
-    const declared = plugin.manifest.mcpServers
-    let entries: Record<string, ServerConfig> = {}
-    // An inline map of name -> config; an array is not a valid mcpServers map (it
-    // would register a server named '0'), so it falls through to the path branch.
-    if (declared !== null && typeof declared === 'object' && !Array.isArray(declared)) {
-      try {
-        entries = JSON.parse(substitutePluginVars(JSON.stringify(declared), plugin))
-      } catch {
-        continue
-      }
-    } else {
-      const file = path.resolve(plugin.root, typeof declared === 'string' ? declared : '.mcp.json')
-      try {
-        const parsed = JSON.parse(substitutePluginVars(fs.readFileSync(file, 'utf-8'), plugin))
-        entries = parsed.mcpServers ?? {}
-      } catch {
-        continue
-      }
-    }
-    for (const [name, config] of Object.entries(entries)) {
+    for (const [name, config] of Object.entries(pluginServerEntries(plugin))) {
       servers[name] = { ...config, aliasPrefix: `mcp__plugin_${fold(plugin.name)}_${fold(name)}__` }
     }
   }
@@ -273,7 +277,7 @@ export function parseHelperHeaders(stdout: string): Record<string, string> {
 export function managedSettingsPath(platform: NodeJS.Platform = process.platform): string {
   if (platform === 'darwin') return '/Library/Application Support/ClaudeCode/managed-settings.json'
   // The legacy C:\ProgramData\ClaudeCode path was dropped in Claude Code v2.1.75.
-  if (platform === 'win32') return 'C:\\Program Files\\ClaudeCode\\managed-settings.json'
+  if (platform === 'win32') return String.raw`C:\Program Files\ClaudeCode\managed-settings.json`
   return '/etc/claude-code/managed-settings.json'
 }
 
@@ -296,8 +300,12 @@ export function mcpAllowDeny(managedFile: string = managedSettingsFileOverride ?
   } catch {
     // No managed policy on this machine: no restriction.
   }
-  const names = (value: unknown): string[] =>
-    Array.isArray(value) ? value.map((entry) => (typeof entry === 'string' ? entry : typeof (entry as { serverName?: unknown })?.serverName === 'string' ? (entry as { serverName: string }).serverName : undefined)).filter((name): name is string => typeof name === 'string' && name.length > 0) : []
+  const entryName = (entry: unknown): string | undefined => {
+    if (typeof entry === 'string') return entry
+    const serverName = (entry as { serverName?: unknown })?.serverName
+    return typeof serverName === 'string' ? serverName : undefined
+  }
+  const names = (value: unknown): string[] => (Array.isArray(value) ? value.map(entryName).filter((name): name is string => typeof name === 'string' && name.length > 0) : [])
   return {
     allowed: Array.isArray(settings.allowedMcpServers) ? new Set(names(settings.allowedMcpServers)) : null,
     denied: new Set(names(settings.deniedMcpServers)),
@@ -551,6 +559,15 @@ export interface AuthUi {
   notify: (message: string, level: 'info' | 'warning' | 'error') => void
 }
 
+/** The OAuth flow's UI seams, absent in headless runs. */
+function authUiFor(ctx: ExtensionContext): AuthUi | undefined {
+  if (!ctx.hasUI) return undefined
+  return {
+    confirm: (title, body) => ctx.ui.confirm(title, body),
+    notify: (message, level) => ctx.ui.notify(message, level),
+  }
+}
+
 /** Browser logins are human-paced; a connect-sized timeout would cut them off. */
 const OAUTH_FLOW_TIMEOUT_MS = 180_000
 
@@ -558,6 +575,14 @@ const OAUTH_FLOW_TIMEOUT_MS = 180_000
  * failed). A typed marker so the SSE-fallback caller can tell an auth failure
  * from a transport mismatch without matching on message text. */
 class OAuthRequiredError extends Error {}
+
+/** Wrap a login-flow failure as OAuthRequiredError, passing an existing one through
+ * unchanged so its message is not doubled. */
+function asOAuthRequiredError(name: string, error: unknown): OAuthRequiredError {
+  if (error instanceof OAuthRequiredError) return error
+  const detail = error instanceof Error ? error.message : String(error)
+  return new OAuthRequiredError(`login for ${name} failed: ${detail}`)
+}
 
 /** Whether a connect failure is an authentication problem: the SDK's own
  * UnauthorizedError, a transport error carrying HTTP 401 (which is what a 401
@@ -568,6 +593,13 @@ function isUnauthorized(error: unknown): boolean {
   return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 401
 }
 
+// SSEClientTransport is deprecated in favour of Streamable HTTP, but both concrete
+// transports expose finishAuth (the base Transport interface does not), so the union
+// stays as the http-family fallback type through the migration period.
+type HttpFamilyTransport = SSEClientTransport | StreamableHTTPClientTransport // NOSONAR typescript:S1874 - SSE fallback still required by the MCP SDK
+
+type MakeTransport = (authProvider?: OAuthClientProvider) => HttpFamilyTransport
+
 /**
  * Connect an http-family server, running Claude's OAuth login when the server
  * demands one. Stored tokens ride the first attempt so the SDK refreshes
@@ -576,7 +608,7 @@ function isUnauthorized(error: unknown): boolean {
  * Bearer-token servers never enter the OAuth path: an explicit token is the
  * user saying how auth works.
  */
-async function connectHttpFamily(name: string, config: { url: string }, makeTransport: (authProvider?: OAuthClientProvider) => SSEClientTransport | StreamableHTTPClientTransport, label: string, bearerToken: string | undefined, authUi: AuthUi | undefined): Promise<Client> {
+async function connectHttpFamily(name: string, config: { url: string }, makeTransport: MakeTransport, label: string, bearerToken: string | undefined, authUi: AuthUi | undefined): Promise<Client> {
   const newClient = () => new Client({ name: 'pi-code-mcp', version: '0.1.0' })
   // Stored tokens ride the first attempt so the SDK refreshes them; with none, no
   // provider is attached, so a 401 surfaces as a transport error carrying code 401
@@ -590,39 +622,47 @@ async function connectHttpFamily(name: string, config: { url: string }, makeTran
   } catch (error) {
     if (bearerToken || !isUnauthorized(error)) throw error
     if (!authUi) throw new OAuthRequiredError(`${name} requires a login; run pi interactively to authenticate`)
-    const approved = await authUi.confirm(`MCP server "${name}" requires login`, `Open your browser to authorize ${config.url}?`)
-    if (!approved) throw new OAuthRequiredError(`login declined for ${name}`)
-    const provider = new FileOAuthProvider(name, (authorizationUrl) => {
-      openBrowser(String(authorizationUrl))
-      authUi.notify(`Authorize "${name}" in the browser. If it did not open: ${authorizationUrl}`, 'info')
-    })
-    const { server, port } = await startCallbackServer(provider.savedRedirectPort())
-    provider.bindRedirectPort(port)
+    return await runInteractiveOAuth(name, config, makeTransport, label, authUi, newClient)
+  }
+}
+
+/**
+ * The interactive half of the OAuth login, reached only once a silent connect has
+ * failed with a 401 and a UI is present: confirm, open the browser, catch the loopback
+ * redirect, and exchange the code via the SDK's finishAuth. Past the confirm the server
+ * is known to need OAuth, so any failure here (a denied consent page, the 180s wait, a
+ * token exchange error) is wrapped as an auth failure, not a transport mismatch: that
+ * keeps the typeless-url caller from retrying over SSE and prompting for a second login.
+ */
+async function runInteractiveOAuth(name: string, config: { url: string }, makeTransport: MakeTransport, label: string, authUi: AuthUi, newClient: () => Client): Promise<Client> {
+  const approved = await authUi.confirm(`MCP server "${name}" requires login`, `Open your browser to authorize ${config.url}?`)
+  if (!approved) throw new OAuthRequiredError(`login declined for ${name}`)
+  const provider = new FileOAuthProvider(name, (authorizationUrl) => {
+    openBrowser(String(authorizationUrl))
+    authUi.notify(`Authorize "${name}" in the browser. If it did not open: ${authorizationUrl}`, 'info')
+  })
+  const { server, port } = await startCallbackServer(provider.savedRedirectPort())
+  provider.bindRedirectPort(port)
+  try {
+    const transport = makeTransport(provider)
+    const pendingCode = waitForAuthCode(server, OAUTH_FLOW_TIMEOUT_MS)
+    pendingCode.catch(() => {}) // consumed below; an abandoned login must not surface as unhandled
+    const client = newClient()
     try {
-      const transport = makeTransport(provider)
-      const pendingCode = waitForAuthCode(server, OAUTH_FLOW_TIMEOUT_MS)
-      pendingCode.catch(() => {}) // consumed below; an abandoned login must not surface as unhandled
-      const client = newClient()
-      try {
-        await connectWithTimeout(client, transport, label)
-        return client // authorized between attempts; nothing left to exchange
-      } catch (retryError) {
-        if (!isUnauthorized(retryError)) throw retryError
-        const code = await pendingCode
-        await transport.finishAuth(code)
-        const authed = newClient()
-        await connectWithTimeout(authed, makeTransport(provider), label)
-        return authed
-      }
-    } catch (flowError) {
-      // Past the confirm the server is known to need OAuth, so any failure here (a
-      // denied consent page, the 180s wait, a token exchange error) is an auth
-      // failure, not a transport mismatch. Marking it keeps the typeless-url caller
-      // from retrying over SSE and prompting the user to log in a second time.
-      throw flowError instanceof OAuthRequiredError ? flowError : new OAuthRequiredError(`login for ${name} failed: ${flowError instanceof Error ? flowError.message : String(flowError)}`)
-    } finally {
-      server.close()
+      await connectWithTimeout(client, transport, label)
+      return client // authorized between attempts; nothing left to exchange
+    } catch (retryError) {
+      if (!isUnauthorized(retryError)) throw retryError
+      const code = await pendingCode
+      await transport.finishAuth(code)
+      const authed = newClient()
+      await connectWithTimeout(authed, makeTransport(provider), label)
+      return authed
     }
+  } catch (flowError) {
+    throw asOAuthRequiredError(name, flowError)
+  } finally {
+    server.close()
   }
 }
 
@@ -672,6 +712,62 @@ async function listAllPrompts(client: Client): Promise<McpPromptInfo[]> {
     cursor = page.nextCursor
   } while (cursor)
   return prompts
+}
+
+/** One resource's flat record for the list_mcp_resources output, dropping the optional
+ * description/mimeType when the server omits them. */
+function resourceEntry(server: string, resource: { uri: string; name: string; description?: string; mimeType?: string }): Record<string, unknown> {
+  return { server, uri: resource.uri, name: resource.name, ...(resource.description ? { description: resource.description } : {}), ...(resource.mimeType ? { mimeType: resource.mimeType } : {}) }
+}
+
+/** One resource template's flat record, likewise dropping absent optional fields. */
+function resourceTemplateEntry(server: string, template: { uriTemplate: string; name: string; description?: string; mimeType?: string }): Record<string, unknown> {
+  return { server, uriTemplate: template.uriTemplate, name: template.name, ...(template.description ? { description: template.description } : {}), ...(template.mimeType ? { mimeType: template.mimeType } : {}) }
+}
+
+/** Page a server's resources to exhaustion under the call budget, appending each as a
+ * flat record. Pushed into the caller's array incrementally so a mid-pagination failure
+ * still leaves the earlier pages in place. */
+async function collectResources(entries: Array<Record<string, unknown>>, name: string, client: Client, budget: number): Promise<void> {
+  let cursor: string | undefined
+  do {
+    const page = await withTimeout(client.listResources({ cursor }, { timeout: budget }), budget, `list resources ${name}`)
+    for (const resource of page.resources) entries.push(resourceEntry(name, resource))
+    cursor = page.nextCursor
+  } while (cursor)
+}
+
+/** Page a server's resource templates to exhaustion under the call budget. */
+async function collectResourceTemplates(entries: Array<Record<string, unknown>>, name: string, client: Client, budget: number): Promise<void> {
+  let cursor: string | undefined
+  do {
+    const page = await withTimeout(client.listResourceTemplates({ cursor }, { timeout: budget }), budget, `list resource templates ${name}`)
+    for (const template of page.resourceTemplates) entries.push(resourceTemplateEntry(name, template))
+    cursor = page.nextCursor
+  } while (cursor)
+}
+
+/** Append every resource and template one server exposes. A resource-listing failure
+ * surfaces inline as an error record, so one server cannot empty the whole listing; a
+ * template-listing failure is silent, templates being optional (a server with the
+ * resources capability but no templates answers method-not-found). */
+async function collectServerResourceEntries(entries: Array<Record<string, unknown>>, name: string, client: Client, budget: number): Promise<void> {
+  try {
+    await collectResources(entries, name, client, budget)
+  } catch (error) {
+    entries.push({ server: name, error: error instanceof Error ? error.message : String(error) })
+  }
+  try {
+    await collectResourceTemplates(entries, name, client, budget)
+  } catch {
+    // Templates are optional: a method-not-found here is not worth reporting.
+  }
+}
+
+/** The optional server-name filter for list_mcp_resources: a non-empty string, else undefined. */
+function resourceServerFilter(params: unknown): string | undefined {
+  const server = (params as { server?: unknown }).server
+  return typeof server === 'string' && server.length > 0 ? server : undefined
 }
 
 export default async function mcpExtension(pi: ExtensionAPI) {
@@ -828,34 +924,12 @@ export default async function mcpExtension(pi: ExtensionAPI) {
       description: 'List available resources and resource templates from connected MCP servers. Optionally filter to a single server by name.',
       parameters: Type.Object({ server: Type.Optional(Type.String({ description: 'Only list resources from this server' })) }),
       async execute(_id, params) {
-        const filter = typeof (params as { server?: unknown }).server === 'string' && (params as { server: string }).server.length > 0 ? (params as { server: string }).server : undefined
+        const filter = resourceServerFilter(params)
         if (filter && !clients.has(filter)) throw new Error(`MCP server "${filter}" is not connected`)
         const entries: Array<Record<string, unknown>> = []
         for (const [name, client] of resourceServers()) {
           if (filter && name !== filter) continue
-          const budget = callTimeoutMs()
-          try {
-            let cursor: string | undefined
-            do {
-              const page = await withTimeout(client.listResources({ cursor }, { timeout: budget }), budget, `list resources ${name}`)
-              for (const resource of page.resources) entries.push({ server: name, uri: resource.uri, name: resource.name, ...(resource.description ? { description: resource.description } : {}), ...(resource.mimeType ? { mimeType: resource.mimeType } : {}) })
-              cursor = page.nextCursor
-            } while (cursor)
-          } catch (error) {
-            // One server failing must not empty the whole listing; surface it inline.
-            entries.push({ server: name, error: error instanceof Error ? error.message : String(error) })
-          }
-          try {
-            let cursor: string | undefined
-            do {
-              const page = await withTimeout(client.listResourceTemplates({ cursor }, { timeout: budget }), budget, `list resource templates ${name}`)
-              for (const template of page.resourceTemplates) entries.push({ server: name, uriTemplate: template.uriTemplate, name: template.name, ...(template.description ? { description: template.description } : {}), ...(template.mimeType ? { mimeType: template.mimeType } : {}) })
-              cursor = page.nextCursor
-            } while (cursor)
-          } catch {
-            // Templates are optional: a server with the resources capability but no
-            // templates answers method-not-found, which is not worth reporting.
-          }
+          await collectServerResourceEntries(entries, name, client, callTimeoutMs())
         }
         return { content: mapContent([{ type: 'text', text: JSON.stringify(entries, null, 2) }]), details: {} }
       },
@@ -987,15 +1061,6 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     if (!(await isProjectApproved(ctx))) return false
     await connectServers(gated, authUi)
     return true
-  }
-
-  /** The OAuth flow's UI seams, absent in headless runs. */
-  function authUiFor(ctx: ExtensionContext): AuthUi | undefined {
-    if (!ctx.hasUI) return undefined
-    return {
-      confirm: (title, body) => ctx.ui.confirm(title, body),
-      notify: (message, level) => ctx.ui.notify(message, level),
-    }
   }
 
   let projectConnected = false

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -159,6 +159,33 @@ export function saveMemory(dir: string, indexPath: string, name: string | undefi
   return { content: [{ type: 'text', text: `Saved memory ${name}.` }], details: {} }
 }
 
+/** The read action: a memory's body, capped for context, or a not-found message. */
+function readMemory(dir: string, name: string): { content: Array<{ type: 'text'; text: string }>; details: Record<string, never> } {
+  try {
+    const body = fs.readFileSync(path.join(dir, `${name}.md`), 'utf-8')
+    return { content: [{ type: 'text', text: capForContext(body) }], details: {} }
+  } catch {
+    return { content: [{ type: 'text', text: `No memory named ${name}.` }], details: {} }
+  }
+}
+
+/** The delete action: remove a memory file and its index line. The index is read
+ * before anything is removed: refusing on a failed read must leave both the memory
+ * file and the index as they were. */
+function deleteMemory(dir: string, indexPath: string, name: string): { content: Array<{ type: 'text'; text: string }>; details: Record<string, never> } {
+  let index: string
+  try {
+    index = readIndex(dir)
+  } catch (error) {
+    return { content: [{ type: 'text', text: `Memory delete failed: ${error instanceof Error ? error.message : String(error)}. Nothing was deleted.` }], details: {} }
+  }
+  fs.rmSync(path.join(dir, `${name}.md`), { force: true })
+  const remaining = removeIndexLine(index, name)
+  if (remaining) writeIndex(indexPath, remaining)
+  else fs.rmSync(indexPath, { force: true })
+  return { content: [{ type: 'text', text: `Deleted memory ${name}.` }], details: {} }
+}
+
 /** The index as injected into the prompt, bounded like Claude's startup load. */
 export function capIndexForPrompt(index: string): string {
   const loaded = stripNonLoaded(index)
@@ -327,29 +354,12 @@ export default function memoryExtension(pi: ExtensionAPI) {
 
       if (params.action === 'read') {
         if (!name) return { content: [{ type: 'text' as const, text: 'read requires name.' }], details: {} }
-        try {
-          const body = fs.readFileSync(path.join(dir, `${name}.md`), 'utf-8')
-          return { content: [{ type: 'text' as const, text: capForContext(body) }], details: {} }
-        } catch {
-          return { content: [{ type: 'text' as const, text: `No memory named ${name}.` }], details: {} }
-        }
+        return readMemory(dir, name)
       }
 
       if (params.action === 'delete') {
         if (!name) return { content: [{ type: 'text' as const, text: 'delete requires name.' }], details: {} }
-        // The index is read before anything is removed: refusing on a failed read
-        // must leave both the memory file and the index as they were.
-        let index: string
-        try {
-          index = readIndex(dir)
-        } catch (error) {
-          return { content: [{ type: 'text' as const, text: `Memory delete failed: ${error instanceof Error ? error.message : String(error)}. Nothing was deleted.` }], details: {} }
-        }
-        fs.rmSync(path.join(dir, `${name}.md`), { force: true })
-        const remaining = removeIndexLine(index, name)
-        if (remaining) writeIndex(indexPath, remaining)
-        else fs.rmSync(indexPath, { force: true })
-        return { content: [{ type: 'text' as const, text: `Deleted memory ${name}.` }], details: {} }
+        return deleteMemory(dir, indexPath, name)
       }
 
       const index = readIndexQuietly(dir)

--- a/extensions/notify.ts
+++ b/extensions/notify.ts
@@ -104,10 +104,9 @@ export default function notifyExtension(pi: ExtensionAPI) {
   // Claude's "appear to be away" check. Undefined until the first prompt this session.
   let lastInputAt: number | undefined
 
-  pi.on('session_start', async (_event, ctx) => {
+  pi.on('session_start', async (_event, _ctx) => {
     channel = resolveNotifChannel(readPreferredNotifChannel(os.homedir()))
     lastInputAt = undefined
-    void ctx
   })
 
   pi.on('input', async () => {

--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -252,7 +252,7 @@ export default function statusLine(pi: ExtensionAPI) {
   })
   // The last message's token usage, for the breakdown getContextUsage() omits.
   pi.on('message_end', async (event) => {
-    const usage = (event as { message?: { usage?: typeof lastUsage } }).message?.usage
+    const usage = (event as { message?: { usage?: NonNullable<typeof lastUsage> } }).message?.usage
     if (usage) lastUsage = usage
   })
 

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -589,7 +589,8 @@ export function tasksStatusText(runs: ReadonlyArray<BackgroundRunView>): string 
   if (runs.length === 0) return 'No background subagent runs in this session.'
   return runs
     .map((run) => {
-      const label = run.state === 'running' ? 'running' : `${run.state} (${run.turns} turn${run.turns === 1 ? '' : 's'})`
+      const plural = run.turns === 1 ? '' : 's'
+      const label = run.state === 'running' ? 'running' : `${run.state} (${run.turns} turn${plural})`
       const head = `${run.id} ${run.agent}: ${label} - ${clipCodepoints(run.task, TASK_PREVIEW_CHARS)}`
       const tail = runOutputTail(run)
       return tail ? `${head}\n  ${tail}` : head
@@ -611,7 +612,8 @@ export function agentsListText(agents: ReadonlyArray<Pick<AgentConfig, 'name' | 
   for (const source of AGENT_SOURCE_ORDER) {
     const group = agents.filter((agent) => agent.source === source)
     if (group.length === 0) continue
-    sections.push(`${source}:\n${group.map((agent) => `  ${agent.name} - ${agent.filePath}`).join('\n')}`)
+    const lines = group.map((agent) => `  ${agent.name} - ${agent.filePath}`).join('\n')
+    sections.push(`${source}:\n${lines}`)
   }
   return `${sections.join('\n')}\n\n${AGENTS_DIR_HINT}`
 }
@@ -788,7 +790,20 @@ function removeTmpPrompt(tmpPrompt: { dir: string; filePath: string } | undefine
   }
 }
 
-async function runBackgroundMode(params: SubagentParamsStatic, agents: AgentConfig[], defaultCwd: string, pi: ExtensionAPI, makeDetails: MakeDetails, skillRoots: string[], availableModels: ReadonlyArray<{ id: string }>, projectApproved: boolean, onStarted?: (id: string) => void): Promise<ToolResult> {
+/** Everything runBackgroundMode needs from the surrounding execute() call, grouped so
+ * the parameter list stays in bounds. */
+interface BackgroundContext {
+  agents: AgentConfig[]
+  defaultCwd: string
+  pi: ExtensionAPI
+  makeDetails: MakeDetails
+  skillRoots: string[]
+  availableModels: ReadonlyArray<{ id: string }>
+  projectApproved: boolean
+}
+
+async function runBackgroundMode(params: SubagentParamsStatic, context: BackgroundContext, onStarted?: (id: string) => void): Promise<ToolResult> {
+  const { agents, defaultCwd, pi, makeDetails, skillRoots, availableModels, projectApproved } = context
   const task = params.task
   const agentName = params.agent
   if (!task || !agentName) {
@@ -1464,7 +1479,7 @@ export default function subagentExtension(pi: ExtensionAPI) {
       // unavailable tier still falls back to the session model.
       const availableModels = ctx.modelRegistry?.getAvailable?.() ?? []
 
-      if (params.background) return runBackgroundMode(params, agents, ctx.cwd, pi, makeDetails, skillRoots, availableModels, projectApproved, (id) => rememberBackgroundRun(id))
+      if (params.background) return runBackgroundMode(params, { agents, defaultCwd: ctx.cwd, pi, makeDetails, skillRoots, availableModels, projectApproved }, (id) => rememberBackgroundRun(id))
 
       const mode: ModeContext = { agents, defaultCwd: ctx.cwd, signal, onUpdate, makeDetails, skillRoots, availableModels, projectApproved, onPhase: (phase, agentType, agentId) => pi.events.emit(SUBAGENT_CHANNEL, { phase, agentType, agentId }) }
 

--- a/extensions/web.ts
+++ b/extensions/web.ts
@@ -233,6 +233,40 @@ async function fetchText(rawUrl: string, transport = httpFetch): Promise<{ text:
 const FETCH_CACHE_TTL_MS = 15 * 60 * 1000
 const FETCH_CACHE_MAX_ENTRIES = 50
 
+type FetchCache = Map<string, { expires: number; body: string }>
+
+/** Store a freshly fetched body. Drop expired entries first, then evict the oldest
+ * live one if still full; deleting before set keeps Map insertion order a true
+ * recency order, so a refreshed URL moves to the newest slot instead of keeping its
+ * stale one. Only a delivered body reaches here, so a thrown fetch retries next call. */
+function rememberFetch(cache: FetchCache, url: string, body: string, now: number): void {
+  cache.delete(url)
+  for (const [key, entry] of cache) {
+    if (entry.expires <= now) cache.delete(key)
+  }
+  if (cache.size >= FETCH_CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value
+    if (oldest !== undefined) cache.delete(oldest)
+  }
+  cache.set(url, { expires: now + FETCH_CACHE_TTL_MS, body })
+}
+
+/** Claude's WebFetch runs the prompt over the page with a fast model and returns
+ * that answer, not the raw page. Best-effort: any failure (no model, provider error)
+ * yields null so the caller falls back to the markdown. */
+async function answerFromPage(model: Parameters<typeof completeText>[0], prompt: string, url: string, body: string, signal?: AbortSignal): Promise<string | null> {
+  try {
+    const answer = await completeText(model, `${prompt}\n\nAnswer using only the page content below, fetched from ${url}:\n\n${body}`, {
+      system: 'You extract and answer questions from a web page. Answer only from the provided content, concisely. If the content does not contain the answer, say so.',
+      maxTokens: 1024,
+      signal,
+    })
+    return answer || null
+  } catch {
+    return null
+  }
+}
+
 export default function webExtension(pi: ExtensionAPI) {
   const fetchCache = new Map<string, { expires: number; body: string }>()
   pi.registerTool({
@@ -280,35 +314,14 @@ export default function webExtension(pi: ExtensionAPI) {
       } else {
         const { text, contentType } = await fetchText(params.url)
         body = capFetchChars(contentType.includes('html') ? htmlToMarkdown(text) : text)
-        // Only a delivered body is cached; a thrown fetch must retry next call.
-        // Drop expired entries first, then evict the oldest live one if still full;
-        // deleting before set keeps Map insertion order a true recency order, so a
-        // refreshed URL moves to the newest slot instead of keeping its stale one.
-        fetchCache.delete(params.url)
-        for (const [url, entry] of fetchCache) {
-          if (entry.expires <= now) fetchCache.delete(url)
-        }
-        if (fetchCache.size >= FETCH_CACHE_MAX_ENTRIES) {
-          const oldest = fetchCache.keys().next().value
-          if (oldest !== undefined) fetchCache.delete(oldest)
-        }
-        fetchCache.set(params.url, { expires: now + FETCH_CACHE_TTL_MS, body })
+        rememberFetch(fetchCache, params.url, body, now)
       }
 
-      // Claude's WebFetch runs the prompt over the page with a fast model and returns
-      // that answer, not the raw page. Best-effort: any failure (no model, provider
-      // error) falls back to the markdown, so web_fetch always returns something.
+      // Best-effort prompt-over-page: a failure returns null, so web_fetch always
+      // falls back to the raw markdown and returns something.
       if (params.prompt && ctx?.model) {
-        try {
-          const answer = await completeText(ctx.model, `${params.prompt}\n\nAnswer using only the page content below, fetched from ${params.url}:\n\n${body}`, {
-            system: 'You extract and answer questions from a web page. Answer only from the provided content, concisely. If the content does not contain the answer, say so.',
-            maxTokens: 1024,
-            signal,
-          })
-          if (answer) return { content: [{ type: 'text' as const, text: answer }], details: {} }
-        } catch {
-          // fall through to the raw markdown
-        }
+        const answer = await answerFromPage(ctx.model, params.prompt, params.url, body, signal)
+        if (answer) return { content: [{ type: 'text' as const, text: answer }], details: {} }
       }
       // The char cap alone admits thousands of short lines; pi's tool-output budget
       // bounds lines too, which the shared guard enforces.

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -249,7 +249,7 @@ describe('collectImports', () => {
     writeFileSync(join(dir, 'docs', 'child.md'), 'CHILD')
     const budget = createImportBudget()
 
-    const out = collectImports('@docs/secret.md', dir, dir, [dir], new Set(), budget, 0, undefined, (real) => real.endsWith('secret.md'))
+    const out = collectImports('@docs/secret.md', dir, dir, [dir], new Set(), { budget, isExcluded: (real) => real.endsWith('secret.md') })
 
     expect(out).toEqual([])
     expect(budget.files).toBe(MAX_IMPORT_FILES)
@@ -289,7 +289,7 @@ describe('import budget', () => {
     const { dir, body } = fanOut(MAX_IMPORT_FILES + excess)
     const budget = createImportBudget()
 
-    const out = collectImports(body, dir, dir, [dir], new Set(), budget)
+    const out = collectImports(body, dir, dir, [dir], new Set(), { budget })
 
     expect(out).toHaveLength(MAX_IMPORT_FILES)
     expect(budget.dropped).toBe(excess)
@@ -300,7 +300,7 @@ describe('import budget', () => {
     writeFileSync(join(dir, 'big.md'), 'a'.repeat(MAX_IMPORT_BYTES + 1024))
     const budget = createImportBudget()
 
-    const out = collectImports('@big.md', dir, dir, [dir], new Set(), budget)
+    const out = collectImports('@big.md', dir, dir, [dir], new Set(), { budget })
 
     expect(out).toHaveLength(1)
     expect(out[0].body.endsWith(IMPORT_TRUNCATED_MARKER)).toBe(true)
@@ -313,8 +313,8 @@ describe('import budget', () => {
     writeFileSync(join(dir, 'extra.md'), 'extra')
     const budget = createImportBudget()
 
-    collectImports(body, dir, dir, [dir], new Set(), budget)
-    const second = collectImports('@extra.md', dir, dir, [dir], new Set(), budget)
+    collectImports(body, dir, dir, [dir], new Set(), { budget })
+    const second = collectImports('@extra.md', dir, dir, [dir], new Set(), { budget })
 
     expect(second).toEqual([])
     expect(budget.dropped).toBe(1)


### PR DESCRIPTION
Resolves the open SonarCloud findings across the extension pack. The bulk is behavior-preserving: cognitive-complexity reductions by extracting cohesive helpers, over-long parameter lists grouped into options objects, and two super-linear string trims replaced with linear ones. The rest is mechanical: concise `\w` classes, `String.raw` for backslash paths, extracted nested ternaries and templates, a `Set` membership check, and `readonly` members. No functional change; `npm run check` stays green at 1473 tests.

The one deprecated `SSEClientTransport` reference is kept and suppressed, since both concrete http-family transports expose `finishAuth` that the base `Transport` interface does not, so the union is still needed as the fallback type.
