### PR TITLE
Fix correctness and security bugs found in the parity audit

### DIFF
--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -13,12 +13,15 @@
  * the checkpoint (files created after the checkpoint are left in place).
  */
 
+import { createHash } from 'node:crypto'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from '@earendil-works/pi-coding-agent'
 
 const CUSTOM_TYPE = 'git-checkpoint'
+/** Sidecar inside the bare shadow repo recording the work tree it snapshots. */
+const WORK_TREE_FILE = 'pi-work-tree'
 const PROMPT_SNIPPET_LENGTH = 60
 const RESTORE_MODES = ['Code and conversation', 'Conversation only', 'Code only']
 
@@ -70,6 +73,31 @@ export function pruneCheckpointRepos(root: string, retentionDays: number, keepDi
 export function sessionSlug(sessionFile: string | undefined): string {
   if (!sessionFile) return `ephemeral-${process.pid}`
   return path.basename(sessionFile).replace(/[^\w.-]+/g, '_')
+}
+
+/** A stable per-directory key, so a session resumed elsewhere gets its own shadow. */
+function cwdSlug(cwd: string): string {
+  const resolved = path.resolve(cwd)
+  const hash = createHash('sha256').update(resolved).digest('hex').slice(0, 8)
+  return `${path.basename(resolved).replace(/[^\w.-]+/g, '_')}-${hash}`
+}
+
+/** The work tree a shadow repo was created against, or undefined for a repo that
+ * predates the sidecar or does not exist yet. */
+function recordedWorkTree(shadowDir: string): string | undefined {
+  try {
+    return fs.readFileSync(path.join(shadowDir, WORK_TREE_FILE), 'utf8').trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
+function rememberWorkTree(shadowDir: string, cwd: string): void {
+  try {
+    fs.writeFileSync(path.join(shadowDir, WORK_TREE_FILE), `${cwd}\n`)
+  } catch {
+    // best effort: without the marker the next resume simply cannot detect a move
+  }
 }
 
 function extractText(content: unknown): string {
@@ -134,6 +162,16 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
     const sessionFile = (ctx.sessionManager as { getSessionFile?: () => string | undefined }).getSessionFile?.()
     const checkpointsRoot = path.join(os.homedir(), '.pi', 'agent', 'checkpoints')
     shadowDir = path.join(checkpointsRoot, sessionSlug(sessionFile))
+    // A resumed session can arrive from a different directory than the one the shadow
+    // snapshotted; restoring those commits here would silently overwrite unrelated
+    // same-named files. Key a fresh shadow to this directory instead of ever checking
+    // one tree out into another. Resuming back in the recorded directory takes the
+    // original shadow again, so its checkpoints stay restorable there.
+    const recorded = recordedWorkTree(shadowDir)
+    if (recorded && path.resolve(recorded) !== path.resolve(ctx.cwd)) {
+      shadowDir = path.join(checkpointsRoot, `${sessionSlug(sessionFile)}-${cwdSlug(ctx.cwd)}`)
+      ctx.ui.notify(`Checkpoints for this session were recorded in ${recorded}; starting fresh checkpoints for ${ctx.cwd} (earlier ones are not restorable here)`, 'warning')
+    }
     pruneCheckpointRepos(checkpointsRoot, CHECKPOINT_RETENTION_DAYS, shadowDir)
     const check = await pi.exec('git', ['--git-dir', shadowDir, 'rev-parse', '--git-dir'], { cwd: ctx.cwd })
     if (check.code !== 0) {
@@ -147,6 +185,8 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
       await pi.exec('git', ['--git-dir', shadowDir, 'config', 'user.email', 'checkpoint@pi-code'], { cwd: ctx.cwd })
       await pi.exec('git', ['--git-dir', shadowDir, 'config', 'user.name', 'pi-code-checkpoint'], { cwd: ctx.cwd })
     }
+    // Written on every start, so repos that predate the sidecar pick it up too.
+    rememberWorkTree(shadowDir, ctx.cwd)
   }
 
   /** `checkout -f <ref> -- .` errors when the ref's tree holds no files, so an empty

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -156,6 +156,42 @@ export function readDisableAllHooks(files: string[], managed: Record<string, unk
   return false
 }
 
+/** Claude's `allowedHttpHookUrls` setting: URL patterns http hooks may target, with
+ * `*` as a wildcard. Per Claude's documentation: undefined (no source sets the key)
+ * means no restrictions, an empty array blocks every http hook, and arrays merge
+ * across settings sources. Merging is a union of managed settings plus every file in
+ * the chain; the chain already gates project files on trust (see hookFiles), and a
+ * trusted project can run arbitrary shell hooks anyway, so letting it extend the
+ * allowlist is no escalation. */
+export function readAllowedHttpHookUrls(files: string[], managed: Record<string, unknown> = readManagedSettings()): string[] | undefined {
+  let found: string[] | undefined
+  const collect = (value: unknown): void => {
+    if (!Array.isArray(value)) return
+    found = [...(found ?? []), ...value.filter((entry): entry is string => typeof entry === 'string')]
+  }
+  collect(managed.allowedHttpHookUrls)
+  for (const file of files) {
+    try {
+      const parsed: unknown = JSON.parse(fs.readFileSync(file, 'utf-8'))
+      if (isRecord(parsed)) collect(parsed.allowedHttpHookUrls)
+    } catch {
+      // missing or invalid file: skip
+    }
+  }
+  return found
+}
+
+/** Whether an http hook may target `url`. `*` in an allowlist entry matches any run
+ * of characters; everything else is literal and the whole URL must match. An
+ * undefined allowlist means the setting is absent, so there are no restrictions. */
+export function httpUrlAllowed(url: string, allowlist: string[] | undefined): boolean {
+  if (allowlist === undefined) return true
+  return allowlist.some((pattern) => {
+    const literal = pattern.split('*').map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`))
+    return new RegExp(`^${literal.join('.*')}$`).test(url)
+  })
+}
+
 export function loadHooks(files: string[], sources?: Map<HookMatcher, string>): HooksConfig {
   const config: HooksConfig = {}
   for (const file of files) {
@@ -459,12 +495,15 @@ function interpolateHeaders(headers: Record<string, string> | undefined, allowed
  * with a valid JSON body renders a decision, read exactly like command stdout.
  * Everything else, including non-2xx statuses, connection failures and timeouts,
  * is a non-blocking error by contract, so none of these outcomes ever reports
- * `timedOut`, which PreToolUse fails closed on. The user wrote the URL into their
- * own settings, so it carries the same trust as a command hook's shell string and
- * gets no SSRF screening.
+ * `timedOut`, which PreToolUse fails closed on. Claude's `allowedHttpHookUrls`
+ * allowlist gates the fetch itself: a URL matching no entry is never contacted,
+ * so a settings file cannot point a hook at an arbitrary endpoint and exfiltrate
+ * the payload; when the setting is absent there are no restrictions, as Claude
+ * documents. A blocked hook renders no decision, like every other http failure.
  */
-export async function runHttpHook(hook: { type?: string; command: string; url?: string; headers?: Record<string, string>; allowedEnvVars?: string[] }, payload: unknown, timeoutMs: number): Promise<HookRunResult> {
+export async function runHttpHook(hook: { type?: string; command: string; url?: string; headers?: Record<string, string>; allowedEnvVars?: string[] }, payload: unknown, timeoutMs: number, allowedUrls?: string[]): Promise<HookRunResult> {
   const url = hook.url ?? hook.command
+  if (!httpUrlAllowed(url, allowedUrls)) return { code: 1, stdout: '', stderr: `${url} does not match allowedHttpHookUrls; the hook was not called`, timedOut: false }
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -615,8 +654,9 @@ function replaceRecord(target: Record<string, unknown>, next: Record<string, unk
   Object.assign(target, next)
 }
 
-/** Claude surfaces a hook error notice and the action proceeds; silence would read a
- * guard that never ran as a clean allow. */
+/** Claude surfaces a hook error notice; on ungated events the action proceeds, while
+ * PreToolUse and UserPromptSubmit additionally fail closed on the same results (see
+ * their spawnFailed checks). Silence would hide that a guard never ran. */
 function surfaceHookFailures(commands: HookCommand[], results: HookRunResult[], notify?: SystemMessageSink): void {
   if (!notify) return
   for (const [i, result] of results.entries()) {
@@ -648,6 +688,10 @@ export async function runPreToolUse(config: HooksConfig, toolName: string, toolI
     // A killed hook never reached its verdict, and SIGKILL leaves a null exit code that
     // would otherwise read as a clean allow. Fail closed instead.
     if (result.timedOut) return { block: true, reason: `Hook timed out after ${timeoutMs(commands[i])}ms: ${commands[i].command}` }
+    // A hook that never spawned (EMFILE, missing /bin/sh) reached no verdict either;
+    // its code 0 must fail closed like a timeout, not read as an allow exactly when
+    // the machine is degraded.
+    if (result.spawnFailed) return { block: true, reason: `Hook failed to run: ${commands[i].command}: ${result.stderr.trim() || 'unknown error'}` }
   }
   if (onSystemMessage) surfaceSystemMessages(results, onSystemMessage)
   // A hard deny wins over an ask, matching Claude's deny > ask > allow precedence:
@@ -698,6 +742,8 @@ export async function runUserPromptSubmit(config: HooksConfig, prompt: string, r
   surfaceHookFailures(commands, results, onSystemMessage)
   for (const [i, result] of results.entries()) {
     if (result.timedOut) return { block: true, reason: `Hook timed out after ${timeoutMs(commands[i])}ms: ${commands[i].command}`, context: '' }
+    // No verdict was delivered, so fail closed like a timeout (see runPreToolUse).
+    if (result.spawnFailed) return { block: true, reason: `Hook failed to run: ${commands[i].command}: ${result.stderr.trim() || 'unknown error'}`, context: '' }
   }
   if (onSystemMessage) surfaceSystemMessages(results, onSystemMessage)
   const contexts: string[] = []
@@ -742,6 +788,8 @@ function postToolFeedback(result: HookRunResult, eventName: string, isError: boo
 export default function hooksExtension(pi: ExtensionAPI) {
   let config: HooksConfig = {}
   let projectDir = ''
+  /** Claude's allowedHttpHookUrls allowlist, resolved from the settings chain. */
+  let allowedHttpHookUrls: string[] | undefined
   let pendingSessionContext: string[] = []
   let stopHookActive = false
   let sessionCtx: ExtensionContext | undefined
@@ -763,7 +811,7 @@ export default function hooksExtension(pi: ExtensionAPI) {
     (ctx: ExtensionContext, extra?: Record<string, unknown>): HookRunner =>
     (hook, payload, ms) => {
       const merged = { ...commonPayload(ctx), ...extra, ...(payload as Record<string, unknown>) }
-      if (hook.type === 'http') return runHttpHook(hook, merged, ms)
+      if (hook.type === 'http') return runHttpHook(hook, merged, ms, allowedHttpHookUrls)
       if (hook.type === 'prompt') return runPromptHook(hook, merged, ctx.model, ms)
       if (hook.type === 'agent') return runAgentHook(hook, merged, ms, (ctx.model as { id?: string } | undefined)?.id)
       if (hook.type === 'mcp_tool') return runMcpToolHook(hook, merged, ms)
@@ -814,8 +862,14 @@ export default function hooksExtension(pi: ExtensionAPI) {
     const ctx = sessionCtx
     const eventName = data.phase === 'start' ? 'SubagentStart' : 'SubagentStop'
     const payload = { hook_event_name: eventName, agent_type: data.agentType, agent_id: data.agentId }
-    const results = await runNotifyHooks(matchingCommands(config[eventName], data.agentType), payload, boundRunner(ctx))
-    surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
+    try {
+      const results = await runNotifyHooks(matchingCommands(config[eventName], data.agentType), payload, boundRunner(ctx))
+      surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
+    } catch {
+      // The bus outlives the session: an event landing between /new disposing this
+      // ctx and the next session_start hits disposed getters, and nothing awaits a
+      // bus listener, so a throw here would escape as an unhandled rejection.
+    }
   })
 
   pi.on('session_start', async (event, ctx) => {
@@ -827,6 +881,7 @@ export default function hooksExtension(pi: ExtensionAPI) {
     projectDir = repoRoot(ctx.cwd) ?? ctx.cwd
     const files = hookFiles(ctx.cwd, os.homedir(), trusted)
     hookSources.clear()
+    allowedHttpHookUrls = readAllowedHttpHookUrls(files)
     // The disableAllHooks escape hatch, checked before any config loads: with no
     // config resolved, no event, plugin hooks included, can fire a hook.
     hooksDisabled = readDisableAllHooks(files)

--- a/extensions/internal/mcp-oauth.ts
+++ b/extensions/internal/mcp-oauth.ts
@@ -49,6 +49,11 @@ export class FileOAuthProvider implements OAuthClientProvider {
   private readonly data: StoredAuth
   private port = 0
   private readonly onRedirect: (authorizationUrl: URL) => void
+  // A fresh random CSRF token per login attempt. The SDK puts it in the authorization
+  // URL's `state` param, the server echoes it back on the redirect, and waitForAuthCode
+  // rejects any callback that does not carry it, so another local process or an open web
+  // page cannot inject an authorization code into this login (RFC 8252 8.9).
+  private readonly loginState = crypto.randomBytes(16).toString('hex')
 
   constructor(serverName: string, onRedirect: (authorizationUrl: URL) => void) {
     this.storePath = storeFileFor(serverName)
@@ -117,6 +122,12 @@ export class FileOAuthProvider implements OAuthClientProvider {
     return this.data.tokens !== undefined
   }
 
+  /** The CSRF token the SDK adds to the authorization URL as `state`; waitForAuthCode
+   * verifies the redirect echoes exactly this value. */
+  state(): string {
+    return this.loginState
+  }
+
   redirectToAuthorization(authorizationUrl: URL): void {
     this.onRedirect(authorizationUrl)
   }
@@ -147,11 +158,30 @@ export async function startCallbackServer(preferredPort?: number): Promise<{ ser
   return { server, port: (server.address() as { port: number }).port }
 }
 
-export function waitForAuthCode(server: http.Server, timeoutMs: number): Promise<string> {
+export function waitForAuthCode(server: http.Server, timeoutMs: number, expectedState?: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(`authorization timed out after ${timeoutMs}ms`)), timeoutMs)
+    // Do not let the pending timer keep the process alive on its own: if the login is
+    // abandoned or resolved out of band, the event loop can still drain.
+    timer.unref?.()
     server.on('request', (request, response) => {
       const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+      // Only the redirect path settles the login. A stray request (a favicon fetch, a
+      // local port scan, or a forged redirect from another process or an open web page)
+      // is answered but ignored, so it can neither inject a code nor abort the login by
+      // rejecting the promise (a repeatable DoS on a stable, guessable loopback port).
+      if (url.pathname !== '/callback') {
+        response.writeHead(404, { 'content-type': 'text/plain' })
+        response.end('not found')
+        return
+      }
+      // The CSRF check: a callback that does not echo this login's state is rejected
+      // without settling, so an attacker who cannot read the state cannot complete it.
+      if (expectedState !== undefined && url.searchParams.get('state') !== expectedState) {
+        response.writeHead(400, { 'content-type': 'text/plain' })
+        response.end('state mismatch')
+        return
+      }
       const code = url.searchParams.get('code')
       const error = url.searchParams.get('error')
       response.writeHead(200, { 'content-type': 'text/html' })

--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -21,8 +21,66 @@ export interface PathAnchors {
 
 const escapeRegExp = (text: string): string => text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 
-/** One gitignore-style pattern as an anchored regular expression source. */
-export function globToRegExpSource(pattern: string): string {
+/** Cap on brace-expanded alternatives per pattern, mirroring Claude's ~1000
+ * budget; an over-budget pattern is used unexpanded. */
+const BRACE_EXPANSION_LIMIT = 1000
+
+interface BraceGroup {
+  start: number
+  end: number
+  options: string[]
+}
+
+/** The `{...}` group opening at `open`, or null when it is unmatched or carries no
+ * top-level comma (literal braces). Options are split on commas at the group's own
+ * depth so a nested group stays inside one option. */
+function parseBraceGroup(pattern: string, open: number): BraceGroup | null {
+  let depth = 1
+  let optionStart = open + 1
+  const options: string[] = []
+  for (let i = open + 1; i < pattern.length; i += 1) {
+    const ch = pattern[i]
+    if (ch === '{') depth += 1
+    else if (ch === ',' && depth === 1) {
+      options.push(pattern.slice(optionStart, i))
+      optionStart = i + 1
+    } else if (ch === '}' && --depth === 0) {
+      if (options.length === 0) return null // no top-level comma: literal braces
+      options.push(pattern.slice(optionStart, i))
+      return { start: open, end: i, options }
+    }
+  }
+  return null
+}
+
+/** The first expandable `{...}` group. A comma-less or unmatched `{` is skipped as
+ * literal, so the scan can still find an expandable group nested inside it. */
+function findBraceGroup(pattern: string): BraceGroup | null {
+  for (let open = pattern.indexOf('{'); open !== -1; open = pattern.indexOf('{', open + 1)) {
+    const group = parseBraceGroup(pattern, open)
+    if (group) return group
+  }
+  return null
+}
+
+/** Bash-style brace expansion of one pattern into its alternatives: each group
+ * multiplies out (Cartesian across groups, nested groups recurse). Returns null
+ * when the expansion would exceed the budget. */
+function expandBraces(pattern: string): string[] | null {
+  const group = findBraceGroup(pattern)
+  if (group === null) return [pattern]
+  const expanded: string[] = []
+  for (const option of group.options) {
+    const branch = expandBraces(pattern.slice(0, group.start) + option + pattern.slice(group.end + 1))
+    if (branch === null) return null
+    expanded.push(...branch)
+    if (expanded.length > BRACE_EXPANSION_LIMIT) return null
+  }
+  return expanded
+}
+
+/** One glob pattern, braces already expanded, as a regular expression source. */
+function translateGlob(pattern: string): string {
   let out = ''
   let i = 0
   while (i < pattern.length) {
@@ -52,6 +110,15 @@ export function globToRegExpSource(pattern: string): string {
     i += 1
   }
   return out
+}
+
+/** One gitignore-style pattern as an anchored regular expression source. Brace
+ * groups (`{ts,tsx}`, nested, Cartesian across groups) expand into ORed
+ * alternatives; an over-budget expansion falls back to the literal pattern. */
+export function globToRegExpSource(pattern: string): string {
+  const alternatives = expandBraces(pattern) ?? [pattern]
+  if (alternatives.length === 1) return translateGlob(alternatives[0])
+  return `(?:${alternatives.map(translateGlob).join('|')})`
 }
 
 /** A rule resolved to an absolute glob per its anchor form. */

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -11,8 +11,10 @@
  * per-project `projects[cwd].mcpServers` local scope, and ~/.pi/agent/mcp.json) is the
  * user's own and loads on the first session. Project config (.mcp.json, .pi/mcp.json)
  * can run arbitrary commands on connect, so it loads only once the project is approved
- * (see project-approval). The two scopes are loaded separately, not merged; user config
- * connects first, so a project server cannot take the name of a user server that connected.
+ * (see project-approval). The two scopes are loaded separately, not merged. Claude's
+ * precedence is project over user for a duplicate name, so a project server the user has
+ * consented to (or an approved project's) wins; a merely-present untrusted project entry
+ * cannot shadow a user server, and a gated project server does not preempt it.
  * Values support ${VAR} / ${VAR:-default} interpolation, connect and per-call timeouts
  * honor MCP_TIMEOUT / MCP_TOOL_TIMEOUT, and a stdio server receives only the SDK's default
  * environment plus its own `env` block, not the whole process environment.
@@ -108,11 +110,18 @@ export type ServerConfig = StdioServerConfig | HttpServerConfig
 
 /** Claude's .mcp.json expansion: ${VAR}, and ${VAR:-default}. The syntax borrows
  * shell's `:-`, which substitutes when the variable is unset OR empty. */
-export function interpolateEnv(value: string, env: NodeJS.ProcessEnv = process.env): string {
-  return value.replace(/\$\{(\w+)(:-([^}]*))?\}/g, (_, name, hasDefault, fallback) => {
+export function interpolateEnv(value: string, env: NodeJS.ProcessEnv = process.env, onMissing?: (name: string) => void): string {
+  return value.replace(/\$\{(\w+)(:-([^}]*))?\}/g, (fullMatch, name, hasDefault, fallback) => {
     const current = env[name]
     if (hasDefault !== undefined) return current || fallback
-    return current ?? ''
+    if (current === undefined) {
+      // A referenced variable with no value and no default: keep the literal ${VAR} and
+      // report it, matching Claude, rather than silently substituting an empty string that
+      // turns `Bearer ${TOKEN}` into a confusing `Bearer ` and a mystery 401.
+      onMissing?.(name)
+      return fullMatch
+    }
+    return current
   })
 }
 
@@ -387,11 +396,40 @@ export function promptMessageContent(messages: ReadonlyArray<{ content: unknown 
   return mapContent(messages.map((message) => message.content as McpContentBlock)).filter((block) => block.type !== 'text' || block.text.trim() !== '')
 }
 
+/** Merge the `properties` (and, for allOf, the `required`) of a root-level combinator's
+ * branches into one flat object schema. Without this a tool whose input schema is a bare
+ * anyOf/oneOf/allOf (no top-level `type`) would present no properties at all, so the model
+ * would be forced to call it with no arguments. */
+function mergeCombinatorBranches(branches: unknown[]): { properties: Record<string, unknown>; required: string[] } {
+  const properties: Record<string, unknown> = {}
+  const required = new Set<string>()
+  for (const branch of branches) {
+    if (!branch || typeof branch !== 'object') continue
+    const b = branch as Record<string, unknown>
+    if (b.properties && typeof b.properties === 'object') Object.assign(properties, b.properties as Record<string, unknown>)
+    if (Array.isArray(b.required)) for (const name of b.required) if (typeof name === 'string') required.add(name)
+  }
+  return { properties, required: [...required] }
+}
+
 export function normalizeSchema(schema: unknown): object {
   const base = (schema as Record<string, unknown>) ?? {}
   const { $schema: _dropSchema, additionalProperties: _dropAdditional, ...rest } = base
-  if (!rest.type) return { type: 'object', properties: {} }
-  return rest
+  if (rest.type) return rest
+  // A root-level combinator carries the real parameters in its branches; flatten them
+  // into one object schema rather than emptying it. allOf means every branch applies, so
+  // its required union is kept; anyOf/oneOf branches are alternatives, so required is left
+  // open (the server still enforces its own).
+  const allOf = Array.isArray(rest.allOf) ? rest.allOf : undefined
+  let branches = allOf
+  if (!branches && Array.isArray(rest.anyOf)) branches = rest.anyOf
+  if (!branches && Array.isArray(rest.oneOf)) branches = rest.oneOf
+  if (!branches) return { type: 'object', properties: {} }
+  const { properties, required } = mergeCombinatorBranches(branches)
+  const merged: Record<string, unknown> = { type: 'object', properties }
+  if (typeof rest.description === 'string') merged.description = rest.description
+  if (allOf && required.length > 0) merged.required = required
+  return merged
 }
 
 interface McpContentBlock {
@@ -494,23 +532,32 @@ async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): P
 
 async function connect(name: string, config: ServerConfig, authUi?: AuthUi): Promise<Client> {
   const client = new Client({ name: 'pi-code-mcp', version: '0.1.0' })
+  // Names referenced by ${VAR} with no value and no default, gathered across this
+  // server's interpolated fields so the connect can warn once rather than fail with a
+  // mystery 401 or a command that lost an argument.
+  const missing = new Set<string>()
+  const fill = (value: string): string => interpolateEnv(value, process.env, (varName) => missing.add(varName))
+  const warnMissing = (): void => {
+    if (missing.size > 0) console.warn(`pi-code-mcp: server ${name} references undefined variable(s) ${[...missing].join(', ')}; leaving them unexpanded`)
+  }
   if (isStdio(config)) {
     // Start from the SDK's allowlist (PATH, HOME, SHELL, ...) rather than the whole
     // process env: a server should not receive ANTHROPIC_API_KEY or GITHUB_TOKEN just
     // for being launched. A server that needs a variable names it in its own env block.
     const env: Record<string, string> = { ...getDefaultEnvironment() }
-    for (const [key, value] of Object.entries(config.env ?? {})) env[key] = interpolateEnv(value)
+    for (const [key, value] of Object.entries(config.env ?? {})) env[key] = fill(value)
     const transport = new StdioClientTransport({
-      command: interpolateEnv(config.command),
-      args: (config.args ?? []).map((arg) => interpolateEnv(arg)),
+      command: fill(config.command),
+      args: (config.args ?? []).map((arg) => fill(arg)),
       env,
       cwd: expandCwd(config.cwd),
       stderr: 'ignore',
     })
+    warnMissing()
     await connectWithTimeout(client, transport, `connect ${name}`)
     return client
   }
-  const url = new URL(interpolateEnv(config.url))
+  const url = new URL(fill(config.url))
   if (config.type === 'ws' || config.type === 'websocket') {
     // The SDK's WebSocket transport takes only a url: it carries no headers, bearer
     // token, or headersHelper output. Warn rather than silently dropping configured
@@ -520,16 +567,18 @@ async function connect(name: string, config: ServerConfig, authUi?: AuthUi): Pro
       console.warn(`pi-code-mcp: server ${name} is a WebSocket server; the SDK ws transport is url-only, so its headers/bearerToken/headersHelper are ignored`)
     }
     const transport = new WebSocketClientTransport(url)
+    warnMissing()
     await connectWithTimeout(client, transport, `connect ${name} (ws)`)
     return client
   }
   const headers: Record<string, string> = {}
-  for (const [key, value] of Object.entries(config.headers ?? {})) headers[key] = interpolateEnv(value)
+  for (const [key, value] of Object.entries(config.headers ?? {})) headers[key] = fill(value)
   const token = resolveBearerToken(config)
   if (token) headers.Authorization = `Bearer ${token}`
   // A headersHelper generates connect-time headers for non-OAuth auth schemes; its
   // JSON stdout merges over the static headers.
-  if (config.headersHelper) Object.assign(headers, await runHeadersHelper(interpolateEnv(config.headersHelper)))
+  if (config.headersHelper) Object.assign(headers, await runHeadersHelper(fill(config.headersHelper)))
+  warnMissing()
   const sseTransport = (authProvider?: OAuthClientProvider) => new SSEClientTransport(url, { requestInit: { headers }, authProvider }) // NOSONAR: explicitly declared or deliberate legacy transport
   if (config.type === 'sse') {
     return await connectHttpFamily(name, config, sseTransport, `connect ${name} (sse)`, token, authUi)
@@ -645,7 +694,9 @@ async function runInteractiveOAuth(name: string, config: { url: string }, makeTr
   provider.bindRedirectPort(port)
   try {
     const transport = makeTransport(provider)
-    const pendingCode = waitForAuthCode(server, OAUTH_FLOW_TIMEOUT_MS)
+    // Verify the redirect echoes this login's state, so a stray or forged callback to the
+    // loopback port cannot inject a code or abort the login (see waitForAuthCode).
+    const pendingCode = waitForAuthCode(server, OAUTH_FLOW_TIMEOUT_MS, provider.state())
     pendingCode.catch(() => {}) // consumed below; an abandoned login must not surface as unhandled
     const client = newClient()
     try {
@@ -790,7 +841,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   const aliases: McpToolAlias[] = []
 
   /** Register every not-yet-registered tool of a server; returns how many were added. */
-  function registerTools(name: string, config: ServerConfig, client: Client, tools: McpToolInfo[]): number {
+  function registerTools(name: string, config: ServerConfig, tools: McpToolInfo[]): number {
     let count = 0
     for (const tool of tools) {
       const toolName = formatToolName(name, tool.name)
@@ -809,12 +860,18 @@ export default async function mcpExtension(pi: ExtensionAPI) {
         description: tool.description ?? `MCP tool ${tool.name} from ${name}`,
         parameters: Type.Unsafe(normalizeSchema(tool.inputSchema)),
         async execute(_id, params) {
+          // Resolve the live client by name at call time rather than capturing the one
+          // present at registration: pi has no tool unregister, so after a server drops
+          // and a later session_start reconnects it, registerTools skips re-registration
+          // and this closure would otherwise keep calling the old, closed client.
+          const current = clients.get(name)
+          if (!current) throw new Error(`MCP server "${name}" is not connected`)
           // Pass the timeout to the SDK too: its own default request timeout is 60s and
           // would otherwise reject first, so the outer race at CALL_TIMEOUT_MS was dead.
           // Claude's per-server timeout wins over MCP_TOOL_TIMEOUT, with a 1s floor.
           const declared = typeof config.timeout === 'number' && config.timeout >= 1000 ? config.timeout : undefined
           const budget = declared ?? callTimeoutMs()
-          const result = await withTimeout(client.callTool({ name: tool.name, arguments: params as Record<string, unknown> }, undefined, { timeout: budget }), budget, toolName)
+          const result = await withTimeout(current.callTool({ name: tool.name, arguments: params as Record<string, unknown> }, undefined, { timeout: budget }), budget, toolName)
           const content = mapContent(result.content as McpContentBlock[], result.structuredContent)
           const details: { error?: string } = {}
           if (result.isError) {
@@ -839,7 +896,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
    * no command unregister, so, like tools, a withdrawn prompt keeps its registration
    * and surfaces the server's own error when invoked; an edit to a prompt's declared
    * arguments only lands on new names, since an existing command keeps its binding. */
-  function registerPrompts(name: string, client: Client, prompts: McpPromptInfo[]): void {
+  function registerPrompts(name: string, prompts: McpPromptInfo[]): void {
     for (const prompt of prompts) {
       const commandName = formatPromptCommandName(name, prompt.name)
       const owner = registeredPrompts.get(commandName)
@@ -855,11 +912,19 @@ export default async function mcpExtension(pi: ExtensionAPI) {
         description: hint ? `${base} ${hint}` : base,
         handler: async (args, ctx) => {
           try {
+            // Resolve the live client at call time, not the one captured at registration:
+            // pi has no command unregister, so after a reconnect this closure must not keep
+            // calling the old, closed client (see registerTools for the same reason).
+            const current = clients.get(name)
+            if (!current) {
+              ctx.ui.notify(`${commandName}: MCP server "${name}" is not connected`, 'error')
+              return
+            }
             const promptArgs = mapPromptArguments(prompt.arguments, args)
             const params: { name: string; arguments?: Record<string, string> } = { name: prompt.name }
             if (Object.keys(promptArgs).length > 0) params.arguments = promptArgs
             const budget = callTimeoutMs()
-            const result = await withTimeout(client.getPrompt(params, { timeout: budget }), budget, commandName)
+            const result = await withTimeout(current.getPrompt(params, { timeout: budget }), budget, commandName)
             // The prompt drives a turn exactly the way a custom slash command does
             // (see commands.ts), carrying its image blocks through. A prompt that
             // yields no content is reported rather than sent as an empty turn.
@@ -882,7 +947,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   async function connectPrompts(name: string, client: Client): Promise<void> {
     if (!client.getServerCapabilities()?.prompts) return
     try {
-      registerPrompts(name, client, await withTimeout(listAllPrompts(client), connectTimeoutMs(), `list prompts ${name}`))
+      registerPrompts(name, await withTimeout(listAllPrompts(client), connectTimeoutMs(), `list prompts ${name}`))
     } catch (error) {
       console.warn(`pi-code-mcp: prompt listing failed for ${name}: ${error instanceof Error ? error.message : String(error)}`)
     }
@@ -894,7 +959,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     try {
       client.setNotificationHandler(PromptListChangedNotificationSchema, async () => {
         try {
-          registerPrompts(name, client, await withTimeout(listAllPrompts(client), connectTimeoutMs(), `list prompts ${name}`))
+          registerPrompts(name, await withTimeout(listAllPrompts(client), connectTimeoutMs(), `list prompts ${name}`))
         } catch (error) {
           console.warn(`pi-code-mcp: prompt refresh failed for ${name}: ${error instanceof Error ? error.message : String(error)}`)
         }
@@ -978,7 +1043,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
       client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
         try {
           const refreshed = await withTimeout(listAllTools(client), connectTimeoutMs(), `list tools ${name}`)
-          const added = registerTools(name, config, client, refreshed)
+          const added = registerTools(name, config, refreshed)
           if (added === 0) return
           const current = status.get(name)
           status.set(name, { state: current?.state ?? 'connected', tools: (current?.tools ?? 0) + added })
@@ -1014,7 +1079,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           const client = await connect(name, config, authUi)
           clients.set(name, client)
           const tools = await withTimeout(listAllTools(client), connectTimeoutMs(), `list tools ${name}`)
-          const count = registerTools(name, config, client, tools)
+          const count = registerTools(name, config, tools)
           subscribeToToolChanges(name, config, client)
           // Prompts and resources are additive surfaces: their failures warn (inside
           // connectPrompts) rather than flipping a tool-serving server to failed.
@@ -1075,7 +1140,15 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     const pluginServers = loadPluginServers(installedPlugins(os.homedir()))
     const { allowed, denied } = mcpAllowDeny()
     const scoped = applyServerPolicy({ ...pluginServers, ...loadUserScope(os.homedir(), ctx.cwd) }, allowed, denied)
-    const userServers = Object.fromEntries(Object.entries(scoped).filter(([name]) => !clients.has(name)))
+    // Claude's precedence is project over user for a duplicate name. A project .mcp.json
+    // server only outranks the user's own when it will actually connect (the user already
+    // consented to it, or an approved project's), so a merely-present untrusted project
+    // entry cannot shadow a trusted user server by reusing its name. A gated project
+    // server still awaiting the approval prompt does not preempt the user server: that is
+    // a deliberate narrowing of Claude's rule to keep the safe default.
+    const projectPolicy = projectServerPolicy(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
+    const projectWinners = new Set(Object.keys(splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), allowed, denied), projectPolicy).consented))
+    const userServers = Object.fromEntries(Object.entries(scoped).filter(([name]) => !clients.has(name) && !projectWinners.has(name)))
     if (Object.keys(userServers).length > 0) await connectServers(userServers, authUiFor(ctx))
     // A project .mcp.json can run arbitrary commands on connect, so only honor it once
     // the project is trusted. Per-server settings refine that: disabled servers never

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -26,6 +26,10 @@ export interface BackgroundRun {
   /** True until the child process actually closes: a cancelled child that ignores
    * SIGTERM is still alive and must keep holding its concurrency slot. */
   live?: boolean
+  /** Monotonic finish order, stamped when the run completes. Eviction drops the
+   * earliest-finished runs by this, not Map insertion (start) order: a long run
+   * started first but finished last must not vanish the instant it completes. */
+  finishedAt?: number
   /** pi session the child ran under, so a follow-up can continue its context. */
   sessionId: string
   /** How the child was spawned, so a follow-up can repeat it with a new task. */
@@ -63,8 +67,13 @@ export function activeBackgroundRuns(): number {
   return [...runs.values()].filter((run) => run.live || run.state === 'running').length
 }
 
+/** Stamps BackgroundRun.finishedAt; a counter rather than a clock so two runs
+ * completing in the same millisecond still evict in their true finish order. */
+let finishSequence = 0
+
 function evictFinishedRuns(): void {
   const finished = [...runs.values()].filter((run) => !run.live && run.state !== 'running')
+  finished.sort((a, b) => (a.finishedAt ?? 0) - (b.finishedAt ?? 0))
   for (const stale of finished.slice(0, Math.max(0, finished.length - MAX_FINISHED_RUNS))) runs.delete(stale.id)
 }
 
@@ -160,6 +169,7 @@ export function resumeBackgroundRun(id: string, task: string, onComplete: (run: 
   run.output = undefined
   run.exitCode = undefined
   run.stderr = undefined
+  run.finishedAt = undefined
   driveRun(run, { ...run.spawn, args }, onComplete)
   return 'resumed'
 }
@@ -256,6 +266,7 @@ function driveRun(run: BackgroundRun, invocation: BackgroundSpawn, onComplete: (
   const complete = (): void => {
     if (completed) return
     completed = true
+    run.finishedAt = ++finishSequence
     evictFinishedRuns()
     // A run outlives the session that started it, and pi's loader wires assertActive()
     // into every runtime call, so notifying a disposed session throws. This fires from

--- a/tests/git-checkpoint-more.test.ts
+++ b/tests/git-checkpoint-more.test.ts
@@ -651,6 +651,65 @@ describe('empty snapshots', () => {
   })
 })
 
+describe('resume from a different working directory', () => {
+  /** Checkpoint in the original repo, then resume the same session from another
+   * directory holding an unrelated file of the same name. */
+  async function resumeElsewhere(t: Harness): Promise<{ other: string; entry: any }> {
+    writeFileSync(join(t.repo, 'only-in-original.txt'), 'from the original tree\n')
+    await checkpointOneTurn(t)
+    const entry = checkpointEntry({ entryId: 'user0001', ref: t.appended[0].data.ref, prompt: 'earlier prompt' })
+    const other = mkdtempSync(join(tmpdir(), 'gcm-moved-'))
+    tempDirs.push(other)
+    writeFileSync(join(other, 'tracked.txt'), 'unrelated file, same name\n')
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ cwd: other, entries: [entry] }))
+    return { other, entry }
+  }
+
+  it('never restores the original directory snapshot over the resumed directory', async () => {
+    const t = setup()
+    const { other, entry } = await resumeElsewhere(t)
+
+    await rewind(t, { cwd: other, entries: [entry], branch: [userEntry], answers: [0, 'Code only'] })
+
+    // The snapshot holds the original tree; checking it out here would silently
+    // overwrite this unrelated same-named file and materialize the original's files.
+    expect(readFileSync(join(other, 'tracked.txt'), 'utf8')).toBe('unrelated file, same name\n')
+    expect(existsSync(join(other, 'only-in-original.txt'))).toBe(false)
+  })
+
+  it('notifies that earlier checkpoints belong to another directory', async () => {
+    const t = setup()
+    await resumeElsewhere(t)
+
+    expect(t.notifications.some((n) => n.startsWith('[warning]') && n.includes(t.repo))).toBe(true)
+  })
+
+  it('checkpoints the resumed directory in a fresh shadow and restores it normally', async () => {
+    const t = setup()
+    const { other } = await resumeElsewhere(t)
+
+    await t.handlers.get('turn_start')?.({ turnIndex: 1 }, t.makeCtx({ cwd: other }))
+    await t.handlers.get('turn_end')?.({ turnIndex: 1 }, t.makeCtx({ cwd: other, branch: [messageEntry('user0002', 'work here')] }))
+    expect(t.appended).toHaveLength(2)
+    writeFileSync(join(other, 'tracked.txt'), 'edited after the move\n')
+
+    await rewind(t, { cwd: other, answers: [0, 'Code only'] })
+
+    expect(readFileSync(join(other, 'tracked.txt'), 'utf8')).toBe('unrelated file, same name\n')
+  })
+
+  it('keeps the original checkpoints restorable when resumed back in the original directory', async () => {
+    const t = setup()
+    const { entry } = await resumeElsewhere(t)
+    writeFileSync(join(t.repo, 'tracked.txt'), 'edited meanwhile\n')
+
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx({ entries: [entry] }))
+    await rewind(t, { entries: [entry], branch: [userEntry], answers: [0, 'Code only'] })
+
+    expect(readFileSync(join(t.repo, 'tracked.txt'), 'utf8')).toBe('v1\n')
+  })
+})
+
 describe('shadow repo init failure', () => {
   it('notifies that checkpoints are disabled when the shadow repo cannot be created', async () => {
     const t = setup()

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -1126,6 +1126,24 @@ describe('hooks subagent lifecycle', () => {
     await ext.emitSubagent({ phase: 'start', agentType: 'scout', agentId: 'fg-abc' })
     expect(commandsRun()).toEqual([])
   })
+
+  it('does not reject when the captured session ctx is disposed and its getters throw', async () => {
+    // The bus outlives the session: an event landing between /new disposing the ctx
+    // and the next session_start hits disposed getters, and nothing awaits a bus
+    // listener, so a throw here used to escape as an unhandled rejection.
+    writeSettings(hoisted.home, 'settings.json', { SubagentStart: [{ hooks: [{ command: 'sub-start' }] }] })
+    const ext = setupExtension()
+    const disposed = () => {
+      throw new Error('session disposed')
+    }
+    await ext.sessionStart('startup', {
+      cwd: tempDir('hooks-proj-'),
+      sessionManager: { getSessionId: disposed, getSessionFile: disposed },
+      ui: { notify: disposed },
+    })
+    const pending = ext.emitSubagent({ phase: 'start', agentType: 'scout', agentId: 'fg-1' }) as unknown as Promise<void>
+    await expect(pending).resolves.toBeUndefined()
+  })
 })
 
 describe('hooks InstructionsLoaded', () => {
@@ -1439,6 +1457,38 @@ describe('disableAllHooks', () => {
   })
 })
 
+describe('allowedHttpHookUrls wiring', () => {
+  const withHttpHook = async (settings: Record<string, unknown>) => {
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify(settings))
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('never fetches an http hook whose url misses the settings allowlist', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 200 }))
+    const ext = await withHttpHook({
+      allowedHttpHookUrls: ['https://hooks.example.com/*'],
+      hooks: { PreToolUse: [{ hooks: [{ type: 'http', url: 'https://evil.example.com/exfil' }] }] },
+    })
+    // The blocked hook renders no decision, like every other http failure.
+    expect(await ext.toolCall('bash', { command: 'ls' })).toBeUndefined()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('fetches an http hook whose url matches the allowlist and honors its decision', async () => {
+    const deny = JSON.stringify({ hookSpecificOutput: { permissionDecision: 'deny', permissionDecisionReason: 'nope' } })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(deny, { status: 200 }))
+    const ext = await withHttpHook({
+      allowedHttpHookUrls: ['https://hooks.example.com/*'],
+      hooks: { PreToolUse: [{ hooks: [{ type: 'http', url: 'https://hooks.example.com/pre' }] }] },
+    })
+    expect(await ext.toolCall('bash', { command: 'ls' })).toEqual({ block: true, reason: 'nope' })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('/hooks command', () => {
   it('registers the hooks viewer command', () => {
     expect(setupExtension().commands).toContain('hooks')
@@ -1485,14 +1535,37 @@ describe('/hooks command', () => {
 })
 
 describe('hook spawn failures', () => {
-  it('surfaces a spawn failure through the system message sink and proceeds', async () => {
-    // Claude shows a hook error notice and the action proceeds; a silent code-0
-    // meant a deny-list guard that never ran read as a clean allow.
+  it('fails closed on PreToolUse and still surfaces the spawn failure notice', async () => {
+    // The guard never spawned, so its code 0 carries no verdict; reading it as an
+    // allow would fail open exactly when the machine is degraded (EMFILE, missing
+    // /bin/sh), the same no-verdict window a timed-out hook already fails closed on.
     const runner: HookRunner = async () => ({ code: 0, stdout: '', stderr: 'spawn /bin/sh ENOENT', timedOut: false, spawnFailed: true })
     const messages: string[] = []
     const config = { PreToolUse: [{ hooks: [{ command: 'guard.sh' }] }] }
     const decision = await runPreToolUse(config, 'bash', { a: 1 }, runner, undefined, (m) => messages.push(m))
-    expect(decision).toEqual({ block: false })
+    expect(decision.block).toBe(true)
+    expect(decision.reason).toContain('guard.sh')
+    expect(decision.reason).toContain('ENOENT')
     expect(messages.some((m) => m.includes('guard.sh') && m.includes('ENOENT'))).toBe(true)
+  })
+
+  it('fails closed on UserPromptSubmit rather than letting the prompt through', async () => {
+    const runner: HookRunner = async () => ({ code: 0, stdout: '', stderr: 'spawn /bin/sh EMFILE', timedOut: false, spawnFailed: true })
+    const config = { UserPromptSubmit: [{ hooks: [{ command: 'audit.sh' }] }] }
+    const decision = await runUserPromptSubmit(config, 'hello', runner)
+    expect(decision.block).toBe(true)
+    expect(decision.reason).toContain('audit.sh')
+    expect(decision.context).toBe('')
+  })
+
+  it('blocks the tool end to end when the hook process errors before spawning', async () => {
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'guard' }] }] })
+    script('guard', { error: new Error('spawn /bin/sh ENOENT') })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    const decision = (await ext.toolCall('bash', { command: 'ls' })) as { block: boolean; reason?: string }
+    expect(decision?.block).toBe(true)
+    expect(decision?.reason).toContain('ENOENT')
+    expect(ext.notes.some((note) => note.msg.includes('guard') && note.msg.includes('ENOENT'))).toBe(true)
   })
 })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { formatHooksSummary, type HookRunner, hookFiles, interpretHookResult, lastAssistantText, loadHooks, matchingCommands, readDisableAllHooks, runAgentHook, runHookCommand, runHttpHook, runMcpToolHook, runPreToolUse, runPromptHook } from '../extensions/hooks.ts'
+import { formatHooksSummary, type HookRunner, hookFiles, httpUrlAllowed, interpretHookResult, lastAssistantText, loadHooks, matchingCommands, readAllowedHttpHookUrls, readDisableAllHooks, runAgentHook, runHookCommand, runHttpHook, runMcpToolHook, runPreToolUse, runPromptHook } from '../extensions/hooks.ts'
 import { setAgentRunner } from '../extensions/internal/agent-run.ts'
 import { setMcpToolCaller } from '../extensions/internal/mcp-call.ts'
 import { setCompleteBackend } from '../extensions/internal/model-complete.ts'
@@ -597,6 +597,88 @@ describe('http hooks', () => {
     const config = { PreToolUse: [{ hooks: [{ type: 'http', command: srvError.url, url: srvError.url }] }] }
     const decision = await runPreToolUse(config, 'bash', {}, async () => failing)
     expect(decision.block).toBe(false)
+  })
+
+  it('fetches a URL matching the allowlist and never fetches one that misses it', async () => {
+    let hits = 0
+    const srv = await serve((_req, res) => {
+      hits++
+      res.writeHead(200)
+      res.end()
+    })
+    const hook = { type: 'http', command: srv.url, url: srv.url }
+
+    const allowed = await runHttpHook(hook, {}, 5000, ['http://127.0.0.1:*/hook'])
+    const denied = await runHttpHook(hook, {}, 5000, ['https://hooks.example.com/*'])
+    const blockedAll = await runHttpHook(hook, {}, 5000, [])
+    await srv.close()
+
+    expect(allowed).toMatchObject({ code: 0, timedOut: false })
+    expect(hits).toBe(1)
+    // A denied hook renders no decision, like every other http failure: non-blocking.
+    for (const result of [denied, blockedAll]) {
+      expect(result.timedOut).toBe(false)
+      expect(result.code).not.toBe(0)
+      expect(result.code).not.toBe(2)
+      expect(result.stderr).toContain('allowedHttpHookUrls')
+    }
+  })
+})
+
+describe('httpUrlAllowed', () => {
+  it('matches allowlist entries with * as a wildcard, whole-URL otherwise', () => {
+    expect(httpUrlAllowed('https://hooks.example.com/pre', ['https://hooks.example.com/*'])).toBe(true)
+    expect(httpUrlAllowed('https://hooks.example.com/pre', ['*'])).toBe(true)
+    expect(httpUrlAllowed('https://evil.example.com/pre', ['https://hooks.example.com/*'])).toBe(false)
+    // Without a wildcard the whole URL must match; a prefix is not enough.
+    expect(httpUrlAllowed('https://hooks.example.com/pre', ['https://hooks.example.com'])).toBe(false)
+    expect(httpUrlAllowed('https://hooks.example.com', ['https://hooks.example.com'])).toBe(true)
+  })
+
+  it('treats regex characters in a pattern as literals', () => {
+    expect(httpUrlAllowed('https://hooksXexample.com/', ['https://hooks.example.com/'])).toBe(false)
+    expect(httpUrlAllowed('https://h.example.com/a+b', ['https://h.example.com/a+b'])).toBe(true)
+  })
+
+  it('is unrestricted when undefined and blocks everything on an empty list', () => {
+    // Claude: undefined = no restrictions, empty array = block all http hooks.
+    expect(httpUrlAllowed('https://anywhere.example/', undefined)).toBe(true)
+    expect(httpUrlAllowed('https://anywhere.example/', [])).toBe(false)
+  })
+})
+
+describe('readAllowedHttpHookUrls', () => {
+  it('is undefined when no settings source sets the key', () => {
+    const dir = tempDir()
+    const file = join(dir, 'settings.json')
+    writeFileSync(file, JSON.stringify({ hooks: {} }))
+    expect(readAllowedHttpHookUrls([file, join(dir, 'absent.json')], {})).toBeUndefined()
+  })
+
+  it('merges entries across managed settings and the chain, skipping non-strings', () => {
+    // Claude documents allowedHttpHookUrls arrays as merging across settings sources.
+    const dir = tempDir()
+    const user = join(dir, 'user.json')
+    const local = join(dir, 'local.json')
+    writeFileSync(user, JSON.stringify({ allowedHttpHookUrls: ['https://a.example/*'] }))
+    writeFileSync(local, JSON.stringify({ allowedHttpHookUrls: ['https://b.example/*', 42] }))
+    expect(readAllowedHttpHookUrls([user, local], { allowedHttpHookUrls: ['https://m.example/*'] })).toEqual(['https://m.example/*', 'https://a.example/*', 'https://b.example/*'])
+  })
+
+  it('keeps an empty array as enforce-and-block-all rather than reading it as absent', () => {
+    const dir = tempDir()
+    const file = join(dir, 'settings.json')
+    writeFileSync(file, JSON.stringify({ allowedHttpHookUrls: [] }))
+    expect(readAllowedHttpHookUrls([file], {})).toEqual([])
+  })
+
+  it('ignores a non-array value and malformed files', () => {
+    const dir = tempDir()
+    const junk = join(dir, 'junk.json')
+    const broken = join(dir, 'broken.json')
+    writeFileSync(junk, JSON.stringify({ allowedHttpHookUrls: 'https://a.example/*' }))
+    writeFileSync(broken, '{not json')
+    expect(readAllowedHttpHookUrls([junk, broken], {})).toBeUndefined()
   })
 })
 

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -432,6 +432,20 @@ describe('mcp startup config scoping', () => {
     expect(closed).toHaveLength(1)
   })
 
+  it('lets a consented project server outrank a user server of the same name', async () => {
+    // Claude's precedence is project over user for a duplicate name. Here the user has
+    // consented to the project server in their own settings, so the project definition
+    // connects and the user server of the same name is not connected.
+    withTools([{ name: 'query' }])
+    const harness = await setup({ user: { shared: { command: 'user-server' } }, project: { shared: { command: 'proj-server' } } })
+    mkdirSync(join(harness.home, '.claude'), { recursive: true })
+    writeFileSync(join(harness.home, '.claude', 'settings.json'), JSON.stringify({ enabledMcpjsonServers: ['shared'] }))
+    await harness.sessionStart(true)
+
+    expect(hoisted.transports).toHaveLength(1)
+    expect(hoisted.transports[0].options.command).toBe('proj-server')
+  })
+
   it('connects project config only once across repeated sessions', async () => {
     withTools([{ name: 'query' }])
     const harness = await setup({ project: { proj: { command: 'proj-server' } } })
@@ -1412,6 +1426,29 @@ describe('mcp client lifecycle', () => {
     client?.onclose?.()
 
     expect(await statusLinesOf(harness)).toEqual(['live: disconnected (0 tools)'])
+  })
+
+  it('routes a tool call to the reconnected client, not the closed one', async () => {
+    // pi has no tool unregister, so after a drop-and-reconnect the tool stays registered
+    // from the first connect; its execute must call the live client, not the closed one
+    // captured at registration, or every call fails with "Not connected".
+    withTools([{ name: 'go' }])
+    const harness = await setupStarted({ user: { live: { command: 'ok' } } })
+    const first = hoisted.clients.at(-1)
+    ;(first as unknown as { onclose?: () => void }).onclose?.()
+
+    withTools([{ name: 'go' }])
+    await harness.sessionStart()
+    const second = hoisted.clients.at(-1)
+    expect(second).not.toBe(first)
+
+    const calledOn: unknown[] = []
+    hoisted.control.callTool = async (_args, client) => {
+      calledOn.push(client)
+      return { content: [{ type: 'text', text: 'ok' }] }
+    }
+    await harness.tools[0].execute('call-1', {})
+    expect(calledOn).toEqual([second])
   })
 })
 

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -64,6 +64,14 @@ describe('FileOAuthProvider', () => {
     await provider.saveTokens({ access_token: 'x', token_type: 'bearer' })
     expect(new FileOAuthProvider('github', () => {}).hasTokens()).toBe(true)
   })
+
+  it('generates a distinct, stable CSRF state per login attempt', () => {
+    const a = new FileOAuthProvider('srv-a', () => {})
+    const b = new FileOAuthProvider('srv-b', () => {})
+    expect(a.state()).toMatch(/^[0-9a-f]{32}$/)
+    expect(a.state()).toBe(a.state()) // stable within a single login
+    expect(a.state()).not.toBe(b.state()) // a fresh token per attempt
+  })
 })
 
 describe('callback server', () => {
@@ -101,5 +109,27 @@ describe('callback server', () => {
     expect(second.port).not.toBe(first.port)
     first.server.close()
     second.server.close()
+  })
+
+  it('ignores a request to a non-callback path so a stray hit cannot settle the login', async () => {
+    const { server, port } = await startCallbackServer()
+    const pending = waitForAuthCode(server, 5000, 'st8')
+    const stray = await fetch(`http://127.0.0.1:${port}/favicon.ico`)
+    expect(stray.status).toBe(404)
+    // The stray did not settle the promise: the genuine redirect still resolves it.
+    await fetch(`http://127.0.0.1:${port}/callback?code=real&state=st8`)
+    expect(await pending).toBe('real')
+    server.close()
+  })
+
+  it('ignores a callback whose state does not match, then accepts the genuine one', async () => {
+    const { server, port } = await startCallbackServer()
+    const pending = waitForAuthCode(server, 5000, 'expected-state')
+    // A forged redirect from another local process cannot inject its code or abort the login.
+    const forged = await fetch(`http://127.0.0.1:${port}/callback?code=attacker&state=wrong`)
+    expect(forged.status).toBe(400)
+    await fetch(`http://127.0.0.1:${port}/callback?code=genuine&state=expected-state`)
+    expect(await pending).toBe('genuine')
+    server.close()
   })
 })

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -111,8 +111,19 @@ describe('mcp adapter helpers', () => {
   it('interpolates ${VAR} from the environment', () => {
     // biome-ignore lint/suspicious/noTemplateCurlyInString: the literal ${} syntax is exactly what interpolateEnv parses
     expect(interpolateEnv('Bearer ${TOKEN}', { TOKEN: 'abc' } as NodeJS.ProcessEnv)).toBe('Bearer abc')
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: same
-    expect(interpolateEnv('${MISSING}', {} as NodeJS.ProcessEnv)).toBe('')
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: a set-but-empty variable still expands to empty
+    expect(interpolateEnv('${EMPTY}', { EMPTY: '' } as NodeJS.ProcessEnv)).toBe('')
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: a default is used when the variable is unset
+    expect(interpolateEnv('${MISSING:-fallback}', {} as NodeJS.ProcessEnv)).toBe('fallback')
+  })
+
+  it('keeps a missing ${VAR} literal and reports it rather than silently emptying', () => {
+    const missing: string[] = []
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: exercising the unset-no-default path
+    const out = interpolateEnv('Bearer ${TOKEN}', {} as NodeJS.ProcessEnv, (name) => missing.push(name))
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: the literal is preserved so the failure is visible, not a blank Bearer
+    expect(out).toBe('Bearer ${TOKEN}')
+    expect(missing).toEqual(['TOKEN'])
   })
 
   // biome-ignore lint/suspicious/noTemplateCurlyInString: the title documents the ${VAR:-default} syntax Claude's .mcp.json supports
@@ -181,6 +192,24 @@ describe('mcp adapter helpers', () => {
     const schema = normalizeSchema({ $schema: 'x', additionalProperties: false, type: 'object', properties: { a: { type: 'string' } } })
     expect(schema).toEqual({ type: 'object', properties: { a: { type: 'string' } } })
     expect(normalizeSchema(undefined)).toEqual({ type: 'object', properties: {} })
+  })
+
+  it('flattens a root-level combinator schema so its parameters survive', () => {
+    // A bare anyOf/oneOf/allOf has no top-level `type`; emptying it would force the model
+    // to call the tool with no arguments. anyOf/oneOf are alternatives, so required stays open.
+    const anyOf = normalizeSchema({ anyOf: [{ properties: { a: { type: 'string' } }, required: ['a'] }, { properties: { b: { type: 'number' } } }] })
+    expect(anyOf).toEqual({ type: 'object', properties: { a: { type: 'string' }, b: { type: 'number' } } })
+    // allOf means every branch applies, so its required union is kept.
+    const allOf = normalizeSchema({
+      allOf: [
+        { properties: { a: { type: 'string' } }, required: ['a'] },
+        { properties: { b: { type: 'number' } }, required: ['b'] },
+      ],
+    })
+    expect(allOf).toEqual({ type: 'object', properties: { a: { type: 'string' }, b: { type: 'number' } }, required: ['a', 'b'] })
+    // A schema with neither a type nor a combinator is still the empty object schema,
+    // as before (a typeless schema carries no parameters to preserve).
+    expect(normalizeSchema({ foo: 'x' })).toEqual({ type: 'object', properties: {} })
   })
 
   it('maps text, image, and resource content blocks', () => {

--- a/tests/path-rules.test.ts
+++ b/tests/path-rules.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { matchesPathRules } from '../extensions/internal/path-rules.ts'
+import { globToRegExpSource, matchesPathRules } from '../extensions/internal/path-rules.ts'
 
 const anchors = { cwd: '/repo/app', projectRoot: '/repo', home: '/home/alex' }
 
@@ -38,5 +38,53 @@ describe('matchesPathRules', () => {
     expect(matchesPathRules('../secrets.txt', ['**'], anchors)).toBe(false)
     expect(matchesPathRules('../secrets.txt', ['//repo/**'], anchors)).toBe(true)
     expect(matchesPathRules('a.ts', [], anchors)).toBe(false)
+  })
+})
+
+describe('brace expansion', () => {
+  it('expands {ts,tsx} so one rule covers both extensions', () => {
+    const rules = ['src/**/*.{ts,tsx}']
+    expect(matchesPathRules('src/a.ts', rules, anchors)).toBe(true)
+    expect(matchesPathRules('src/b.tsx', rules, anchors)).toBe(true)
+    expect(matchesPathRules('src/nested/deep/b.tsx', rules, anchors)).toBe(true)
+    expect(matchesPathRules('src/c.js', rules, anchors)).toBe(false)
+  })
+
+  it('takes the Cartesian product across groups and expands nested groups', () => {
+    const cartesian = ['{a,b}/{c,d}.ts']
+    expect(matchesPathRules('a/c.ts', cartesian, anchors)).toBe(true)
+    expect(matchesPathRules('a/d.ts', cartesian, anchors)).toBe(true)
+    expect(matchesPathRules('b/c.ts', cartesian, anchors)).toBe(true)
+    expect(matchesPathRules('b/d.ts', cartesian, anchors)).toBe(true)
+    expect(matchesPathRules('a/e.ts', cartesian, anchors)).toBe(false)
+    const nested = ['src/{a,{b,c}}.ts']
+    expect(matchesPathRules('src/a.ts', nested, anchors)).toBe(true)
+    expect(matchesPathRules('src/b.ts', nested, anchors)).toBe(true)
+    expect(matchesPathRules('src/c.ts', nested, anchors)).toBe(true)
+    expect(matchesPathRules('src/d.ts', nested, anchors)).toBe(false)
+  })
+
+  it('allows an empty alternative', () => {
+    const rules = ['file.{ts,}']
+    expect(matchesPathRules('file.ts', rules, anchors)).toBe(true)
+    expect(matchesPathRules('file.', rules, anchors)).toBe(true)
+    expect(matchesPathRules('file.tsx', rules, anchors)).toBe(false)
+  })
+
+  it('keeps a comma-less group, an unmatched brace, and a bare comma literal', () => {
+    expect(matchesPathRules('a{b}c.ts', ['a{b}c.ts'], anchors)).toBe(true)
+    expect(matchesPathRules('abc.ts', ['a{b}c.ts'], anchors)).toBe(false)
+    expect(matchesPathRules('weird{name.ts', ['weird{name.ts'], anchors)).toBe(true)
+    expect(matchesPathRules('a,b.ts', ['a,b.ts'], anchors)).toBe(true)
+  })
+
+  it('falls back to the unexpanded pattern past the expansion budget', () => {
+    const group = '{a,b,c,d,e,f,g,h,i,j}'
+    const over = `${group.repeat(4)}.ts` // 10^4 alternatives, over the 1000 budget
+    const overRegExp = new RegExp(`^${globToRegExpSource(over)}$`)
+    expect(overRegExp.test(`${group.repeat(4)}.ts`)).toBe(true)
+    expect(overRegExp.test('abcd.ts')).toBe(false)
+    const atLimit = `${group.repeat(3)}.ts` // exactly 1000, still expands
+    expect(new RegExp(`^${globToRegExpSource(atLimit)}$`).test('adg.ts')).toBe(true)
   })
 })

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -687,6 +687,32 @@ describe('startBackgroundRun', () => {
   })
 })
 
+describe('finished-run eviction', () => {
+  const invocation = { command: 'pi', args: ['--mode', 'json'], cwd: '/work/dir' }
+
+  it('evicts the earliest-finished run past the cap, not the earliest-started', async () => {
+    const { startBackgroundRun, backgroundRun, MAX_FINISHED_RUNS } = await loadBackground()
+    // The long run starts first but outlives every short run.
+    const longId = startBackgroundRun('scout', 'long survey', invocation, () => {}) as string
+    const shortIds: string[] = []
+    for (let i = 0; i <= MAX_FINISHED_RUNS; i++) {
+      shortIds.push(startBackgroundRun('scout', `short ${i}`, invocation, () => {}) as string)
+      spawned.children[i + 1].emit('close', 0)
+    }
+    // One more short finished than the cap keeps: the earliest-finished one is gone.
+    expect(backgroundRun(shortIds[0])).toBeUndefined()
+    expect(backgroundRun(longId)?.state).toBe('running')
+
+    // The long run finishes last of all. Eviction in start order would delete it the
+    // instant it completes; it must survive as the newest finisher, with the
+    // next-earliest-finished short run going instead.
+    spawned.children[0].emit('close', 0)
+    expect(backgroundRun(longId)?.state).toBe('done')
+    expect(backgroundRun(shortIds[1])).toBeUndefined()
+    expect(backgroundRun(shortIds.at(-1) as string)).toBeDefined()
+  })
+})
+
 describe('agent skills preload', () => {
   it('parses a skills list and appends the named skill bodies to the prompt', () => {
     const skillsRoot = join(fakeHome.path, '.claude', 'skills')


### PR DESCRIPTION
## Summary

Fixes the correctness and security bugs a multi-agent audit of the extension pack surfaced, each with a regression test written to fail first. `npm run check` is green at 1503 tests, 96% statements and 91% branches.

MCP is the largest area. Registered tools and prompt commands now resolve the live client at call time, so after a server drops and a later session start reconnects it they keep working rather than calling the closed client while `/mcp` still reports the server connected. A tool whose input schema is a bare root-level `anyOf`/`oneOf`/`allOf` is flattened into one object schema instead of emptied, so the model can still pass its arguments. A project server the user has consented to now outranks a user server of the same name, matching Claude's precedence, without letting a merely-present untrusted project entry shadow a user server. A referenced `${VAR}` with no value and no default is kept literal and reported rather than silently substituted with an empty string.

The MCP OAuth loopback callback now verifies the redirect echoes this login's `state` and only settles on the `/callback` path, so a stray or forged request to the loopback port from another local process or an open web page can neither inject an authorization code nor abort the login.

For hooks, a hook whose process fails to spawn now fails closed on `PreToolUse` and `UserPromptSubmit` the way a timeout does, rather than reading as an allow exactly when the machine is degraded; `type: http` hooks honor an `allowedHttpHookUrls` allowlist; and a `SubagentStop` hook running against a disposed session no longer becomes an unhandled rejection that can terminate the process.

Rounding out: rules `paths:` globs expand brace groups such as `src/**/*.{ts,tsx}` instead of silently matching nothing; checkpoints key a fresh shadow repository when a session is resumed from a different directory, so a `/rewind` restore can no longer overwrite an unrelated tree's files; and background subagent runs evict the earliest-finished rather than the earliest-started, so a long run is not dropped from `/tasks` the instant it completes.