### PR TITLE
Fix SDK-usage correctness bugs found in the best-practices audit

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -46,6 +46,7 @@ import { Type } from 'typebox'
 import { matchesBashRules } from './internal/bash-rules.js'
 import { type CommandExec, type DiscoveredCommand, discoverCommandFiles, expandDynamicContent, type ParsedCommand, parseCommandFile, resolvePowershellBinary, spanExec, substituteArgsDetailed, substituteVars } from './internal/command-file.js'
 import { readManagedSettings } from './internal/managed-settings.js'
+import { capForContext } from './internal/output-guard.js'
 import { matchesPathRules } from './internal/path-rules.js'
 import { type InstalledPlugin, installedPlugins } from './internal/plugins.js'
 import { isProjectApproved } from './internal/project-approval.js'
@@ -315,12 +316,17 @@ export default function commandsExtension(pi: ExtensionAPI) {
     pendingBashRules = undefined
     pendingPathRules = undefined
     if (pendingModelRestore) {
-      void pi.setModel(pendingModelRestore as Parameters<typeof pi.setModel>[0])
+      const restore = pendingModelRestore as Parameters<typeof pi.setModel>[0]
       pendingModelRestore = undefined
+      // setModel can reject (e.g. auth resolution fails), and a floated rejection would
+      // escape as unhandled; surface it instead of leaving the session silently on the
+      // command's override model.
+      void pi.setModel(restore).catch(() => {})
     }
-    if (!pendingRestore) return
-    pi.setActiveTools(pendingRestore)
-    pendingRestore = undefined
+    if (pendingRestore) {
+      pi.setActiveTools(pendingRestore)
+      pendingRestore = undefined
+    }
   })
 
   // The active-tool set has no argument dimension, so a scoped grant hands the turn
@@ -416,6 +422,16 @@ export default function commandsExtension(pi: ExtensionAPI) {
     // restored when that run ends. Restoring inline does not work: sendUserMessage is
     // fire-and-forget, so the restore would land before the agent ever read the tool
     // list, leaving the command running with everything enabled.
+    // A command invoked while the agent is streaming must not narrow the in-flight run's
+    // tools or switch its model (that would corrupt a run it does not own), and a bare
+    // sendUserMessage throws mid-stream and would be silently dropped. Queue it as a
+    // follow-up through pi's own queue, which is abort-aware and shown to the user; its
+    // frontmatter scoping is not applied in that case, since it cannot land on a run that
+    // has not started yet.
+    if (!ctx.isIdle()) {
+      pi.sendUserMessage(expanded, { deliverAs: 'followUp' })
+      return
+    }
     applyAllowedTools(parsed, vars)
     applyDisallowedTools(parsed)
     await applyModelOverride(parsed, varCtx)
@@ -500,7 +516,10 @@ export default function commandsExtension(pi: ExtensionAPI) {
         // the tool result is the channel, and frontmatter scoping stays user-path
         // territory (see the header).
         const expanded = await expandCommand(pi, current, args, execCtx, command.filePath, command.plugin, { allowShell: false })
-        return { content: [{ type: 'text' as const, text: `Contents of /${name} (expanded):\n\n${expanded}` }], details: {} }
+        // Cap the tool result: a command body can inline an arbitrarily large @file, and
+        // an uncapped tool result overflows the model's context (every other pi-code tool
+        // routes its output through capForContext). The user-invoked path stays uncapped.
+        return { content: [{ type: 'text' as const, text: capForContext(`Contents of /${name} (expanded):\n\n${expanded}`) }], details: {} }
       },
     })
   })

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -565,7 +565,7 @@ export async function runPromptHook(hook: HookCommand, payload: unknown, model: 
   const prompt = substituteArguments(hook.prompt, payload)
   const signal = AbortSignal.timeout(timeoutMs)
   try {
-    const answer = await completeText(model, prompt, { system: PROMPT_HOOK_SYSTEM, maxTokens: 512, signal })
+    const { text: answer } = await completeText(model, prompt, { system: PROMPT_HOOK_SYSTEM, maxTokens: 512, signal })
     return { code: 0, stdout: answer, stderr: '', timedOut: false }
   } catch (error) {
     return abortAwareFailure(signal, error)
@@ -971,6 +971,12 @@ export default function hooksExtension(pi: ExtensionAPI) {
   // turn, and stop_hook_active in the payload tells the next firing it is already
   // continuing from a stop hook, which is the hook script's documented loop guard.
   // Only exit 2 and decision:"block" continue; continue:false means "stay stopped".
+  //
+  // On agent_end rather than agent_settled: agent_settled is only emitted after every
+  // agent_end handler returns, and a peer extension (plan mode) blocks its agent_end
+  // handler on a UI dialog, which would starve the Stop hook and idle notification
+  // until the user answers it. agent_end can fire slightly early before a rare
+  // automatic retry or compaction; that is the better tradeoff.
   pi.on('agent_end', async (event, ctx) => {
     // Claude's Notification event, for the one type pi can honestly source: the
     // agent finished and is waiting for input (idle_prompt). Observational only;

--- a/extensions/init.ts
+++ b/extensions/init.ts
@@ -75,7 +75,9 @@ export default function initExtension(pi: ExtensionAPI) {
       const existing = findExistingContextFile(root)
       const cursorRules = statOf(path.join(root, '.cursor', 'rules'))?.isDirectory() === true || statOf(path.join(root, '.cursorrules'))?.isFile() === true
       const copilotRules = statOf(path.join(root, '.github', 'copilot-instructions.md'))?.isFile() === true
-      pi.sendUserMessage(buildInitPrompt({ ...(existing !== undefined ? { existingContextFile: existing } : {}), cursorRules, copilotRules }))
+      // A bare send throws (and is silently swallowed) while the agent is
+      // streaming, so mid-stream invocations queue as a follow-up turn.
+      pi.sendUserMessage(buildInitPrompt({ ...(existing !== undefined ? { existingContextFile: existing } : {}), cursorRules, copilotRules }), ctx.isIdle() ? {} : { deliverAs: 'followUp' })
     },
   })
 }

--- a/extensions/internal/model-complete.ts
+++ b/extensions/internal/model-complete.ts
@@ -14,7 +14,7 @@
  * throw and the caller falls back to its non-model behavior.
  */
 
-import type { Api, AssistantMessage, Context, Model, ModelsSimpleStreamOptions } from '@earendil-works/pi-ai'
+import type { Api, AssistantMessage, Context, Model, ModelsSimpleStreamOptions, Usage } from '@earendil-works/pi-ai'
 import { ModelRuntime } from '@earendil-works/pi-coding-agent'
 
 /** The completion backend: model + context -> assistant message. Overridable for tests. */
@@ -52,11 +52,13 @@ export interface CompleteOptions {
 }
 
 /**
- * Run `prompt` through `model` as a single user turn and return the reply text.
+ * Run `prompt` through `model` as a single user turn and return the reply text plus
+ * the call's usage. A tool that makes a nested LLM call must return that usage on
+ * its tool result, or the call's tokens and cost vanish from pi's session totals.
  * Throws on any failure so the caller can fall back; never returns a partial or a
  * tool call, only assistant text.
  */
-export async function completeText(model: Model<Api>, prompt: string, options: CompleteOptions = {}): Promise<string> {
+export async function completeText(model: Model<Api>, prompt: string, options: CompleteOptions = {}): Promise<{ text: string; usage: Usage }> {
   backend ??= realBackend()
   const complete = await backend
   const context: Context = {
@@ -64,5 +66,5 @@ export async function completeText(model: Model<Api>, prompt: string, options: C
     messages: [{ role: 'user', content: prompt, timestamp: Date.now() }],
   }
   const message = await complete(model, context, { maxTokens: options.maxTokens ?? 1024, signal: options.signal })
-  return assistantText(message)
+  return { text: assistantText(message), usage: message.usage }
 }

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -933,7 +933,9 @@ export default async function mcpExtension(pi: ExtensionAPI) {
               ctx.ui.notify(`${commandName}: prompt returned no content`, 'info')
               return
             }
-            pi.sendUserMessage(content)
+            // A bare send throws (and is silently swallowed) while the agent is
+            // streaming, so mid-stream invocations queue as a follow-up turn.
+            pi.sendUserMessage(content, ctx.isIdle() ? {} : { deliverAs: 'followUp' })
           } catch (error) {
             ctx.ui.notify(`${commandName}: ${error instanceof Error ? error.message : String(error)}`, 'error')
           }

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -12,7 +12,7 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { StringEnum } from '@earendil-works/pi-ai'
-import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import { type ExtensionAPI, withFileMutationQueue } from '@earendil-works/pi-coding-agent'
 import { Type } from 'typebox'
 import { capForContext } from './internal/output-guard.js'
 import { isProjectApprovedSilently } from './internal/project-approval.js'
@@ -138,29 +138,39 @@ export function indexWouldOverflow(index: string, name: string, description: str
   return next.split('\n').length > INDEX_MAX_LINES || Buffer.byteLength(next, 'utf-8') > INDEX_MAX_BYTES
 }
 
-/** Write a memory and its index line, or say why it cannot be written. */
-export function saveMemory(dir: string, indexPath: string, name: string | undefined, description: string | undefined, content: string | undefined, now: string = new Date().toISOString()): { content: Array<{ type: 'text'; text: string }>; details: Record<string, never> } {
+type MemoryToolResult = { content: Array<{ type: 'text'; text: string }>; details: Record<string, never> }
+
+/** Write a memory and its index line, or say why it cannot be written. The whole
+ * read-modify-write holds the index's mutation queue: tool calls run in parallel, so
+ * two unqueued saves both read the same index and the second silently drops the first's
+ * line. The queue keys ONLY on the index, the shared file every save touches, and never
+ * also on the memory file: a second nested queue self-deadlocks when a memory name
+ * canonicalizes to the same key as the index (e.g. `memory.md` and `MEMORY.md` under a
+ * case-insensitive filesystem, since the queue keys on realpath). */
+export async function saveMemory(dir: string, indexPath: string, name: string | undefined, description: string | undefined, content: string | undefined, now: string = new Date().toISOString()): Promise<MemoryToolResult> {
   if (!name || !description || !content) {
     return { content: [{ type: 'text', text: 'save requires name, description, and content.' }], details: {} }
   }
-  const index = readIndex(dir)
-  // Claude reports an explicit error rather than writing a memory the next session
-  // would never load, and says what to do about it.
-  if (indexWouldOverflow(index, name, description)) {
-    return {
-      content: [{ type: 'text', text: `Memory index is full (${INDEX_MAX_LINES} entries or ${INDEX_MAX_BYTES} bytes). Delete or consolidate memories before saving ${name}.` }],
-      details: {},
+  return withFileMutationQueue(indexPath, async (): Promise<MemoryToolResult> => {
+    const index = readIndex(dir)
+    // Claude reports an explicit error rather than writing a memory the next session
+    // would never load, and says what to do about it.
+    if (indexWouldOverflow(index, name, description)) {
+      return {
+        content: [{ type: 'text', text: `Memory index is full (${INDEX_MAX_LINES} entries or ${INDEX_MAX_BYTES} bytes). Delete or consolidate memories before saving ${name}.` }],
+        details: {},
+      }
     }
-  }
-  fs.mkdirSync(dir, { recursive: true })
-  // A memory with frontmatter records its write time; one without is left as-is.
-  fs.writeFileSync(path.join(dir, `${name}.md`), stampModified(content, now))
-  writeIndex(indexPath, upsertIndexLine(index, name, description))
-  return { content: [{ type: 'text', text: `Saved memory ${name}.` }], details: {} }
+    fs.mkdirSync(dir, { recursive: true })
+    // A memory with frontmatter records its write time; one without is left as-is.
+    fs.writeFileSync(path.join(dir, `${name}.md`), stampModified(content, now))
+    writeIndex(indexPath, upsertIndexLine(index, name, description))
+    return { content: [{ type: 'text', text: `Saved memory ${name}.` }], details: {} }
+  })
 }
 
 /** The read action: a memory's body, capped for context, or a not-found message. */
-function readMemory(dir: string, name: string): { content: Array<{ type: 'text'; text: string }>; details: Record<string, never> } {
+function readMemory(dir: string, name: string): MemoryToolResult {
   try {
     const body = fs.readFileSync(path.join(dir, `${name}.md`), 'utf-8')
     return { content: [{ type: 'text', text: capForContext(body) }], details: {} }
@@ -169,21 +179,23 @@ function readMemory(dir: string, name: string): { content: Array<{ type: 'text';
   }
 }
 
-/** The delete action: remove a memory file and its index line. The index is read
- * before anything is removed: refusing on a failed read must leave both the memory
- * file and the index as they were. */
-function deleteMemory(dir: string, indexPath: string, name: string): { content: Array<{ type: 'text'; text: string }>; details: Record<string, never> } {
-  let index: string
+/** The delete action: remove a memory file and its index line, queued on the index
+ * like save (single key, no deadlock). The index is read before anything is removed,
+ * and any failure (a bad index read, or an unreadable store the queue key cannot
+ * realpath) leaves both the memory file and the index as they were. */
+async function deleteMemory(dir: string, indexPath: string, name: string): Promise<MemoryToolResult> {
   try {
-    index = readIndex(dir)
+    return await withFileMutationQueue(indexPath, async (): Promise<MemoryToolResult> => {
+      const index = readIndex(dir)
+      fs.rmSync(path.join(dir, `${name}.md`), { force: true })
+      const remaining = removeIndexLine(index, name)
+      if (remaining) writeIndex(indexPath, remaining)
+      else fs.rmSync(indexPath, { force: true })
+      return { content: [{ type: 'text', text: `Deleted memory ${name}.` }], details: {} }
+    })
   } catch (error) {
     return { content: [{ type: 'text', text: `Memory delete failed: ${error instanceof Error ? error.message : String(error)}. Nothing was deleted.` }], details: {} }
   }
-  fs.rmSync(path.join(dir, `${name}.md`), { force: true })
-  const remaining = removeIndexLine(index, name)
-  if (remaining) writeIndex(indexPath, remaining)
-  else fs.rmSync(indexPath, { force: true })
-  return { content: [{ type: 'text', text: `Deleted memory ${name}.` }], details: {} }
 }
 
 /** The index as injected into the prompt, bounded like Claude's startup load. */
@@ -346,7 +358,8 @@ export default function memoryExtension(pi: ExtensionAPI) {
 
       if (params.action === 'save') {
         try {
-          return saveMemory(dir, indexPath, name, params.description, params.content)
+          // Awaited here, not returned: the catch must see a queued write's rejection.
+          return await saveMemory(dir, indexPath, name, params.description, params.content)
         } catch (error) {
           return { content: [{ type: 'text' as const, text: `Memory save failed: ${error instanceof Error ? error.message : String(error)}. The index was left untouched.` }], details: {} }
         }

--- a/extensions/notify.ts
+++ b/extensions/notify.ts
@@ -113,6 +113,11 @@ export default function notifyExtension(pi: ExtensionAPI) {
     lastInputAt = Date.now()
   })
 
+  // Fires on agent_end rather than agent_settled deliberately: agent_settled is only
+  // emitted after every agent_end handler returns, and a peer extension (plan mode)
+  // blocks its agent_end handler on a UI dialog, which would starve this notification
+  // exactly when the user has stepped away. agent_end can fire slightly early before a
+  // rare automatic retry or compaction, which is a better failure than never notifying.
   pi.on('agent_end', async () => {
     if (channel === 'off') return
     // Piped or headless stdout (pi -p, CI) must not receive raw escape bytes.

--- a/extensions/plan-mode/index.ts
+++ b/extensions/plan-mode/index.ts
@@ -209,7 +209,9 @@ export default function planModeExtension(pi: ExtensionAPI): void {
       planFromTool = false
       const refinement = await ctx.ui.editor('Refine the plan:', '')
       if (refinement?.trim()) {
-        pi.sendUserMessage(refinement.trim())
+        // A bare send throws (and is silently swallowed) while the agent is
+        // streaming, so mid-stream invocations queue as a follow-up turn.
+        pi.sendUserMessage(refinement.trim(), ctx.isIdle() ? {} : { deliverAs: 'followUp' })
       }
     }
   }

--- a/extensions/question.ts
+++ b/extensions/question.ts
@@ -238,7 +238,39 @@ async function askOne(params: QuestionSpec, ctx: ExtensionContext): Promise<{ co
   // The free-text option does not compose with checkbox selection, so it is single-select only.
   const allOptions: DisplayOption[] = multiSelect ? [...params.options] : [...params.options, { label: 'Type something.', isOther: true }]
 
-  const result = await ctx.ui.custom<{ answer: string; wasCustom: boolean; index?: number } | null>((tui: Parameters<Parameters<ExtensionContext['ui']['custom']>[0]>[0], theme: Theme, _kb: unknown, done: (value: { answer: string; wasCustom: boolean; index?: number } | null) => void) => {
+  // ui.custom() is terminal-only: with a UI but no terminal (RPC mode) it resolves
+  // undefined immediately, which would read as a cancel without ever asking. Ask
+  // through the dialog primitives there instead.
+  const result = ctx.mode === 'tui' ? await askViaOverlay(params, ctx, allOptions, multiSelect) : await askViaDialogs(params, ctx, allOptions, multiSelect)
+
+  // Build simple options list for details; header/multiSelect appear only when set,
+  // so single-select details are unchanged.
+  const simpleOptions = params.options.map((o) => o.label)
+  const base = { question: params.question, options: simpleOptions, ...(params.header ? { header: shortHeader(params.header) } : {}), ...(multiSelect ? { multiSelect: true } : {}) }
+
+  if (!result) {
+    return {
+      content: [{ type: 'text', text: 'User cancelled the selection' }],
+      details: { ...base, answer: null } as QuestionDetails,
+    }
+  }
+
+  if (result.wasCustom) {
+    return {
+      content: [{ type: 'text', text: `User wrote: ${result.answer}` }],
+      details: { ...base, answer: result.answer, wasCustom: true } as QuestionDetails,
+    }
+  }
+  const selectionText = multiSelect ? `User selected: ${result.answer || '(none)'}` : `User selected: ${result.index}. ${result.answer}`
+  return {
+    content: [{ type: 'text', text: selectionText }],
+    details: { ...base, answer: result.answer, wasCustom: false } as QuestionDetails,
+  }
+}
+
+/** Terminal path: the full custom overlay (options list, checkboxes, inline editor). */
+function askViaOverlay(params: QuestionSpec, ctx: ExtensionContext, allOptions: DisplayOption[], multiSelect: boolean): Promise<{ answer: string; wasCustom: boolean; index?: number } | null> {
+  return ctx.ui.custom<{ answer: string; wasCustom: boolean; index?: number } | null>((tui: Parameters<Parameters<ExtensionContext['ui']['custom']>[0]>[0], theme: Theme, _kb: unknown, done: (value: { answer: string; wasCustom: boolean; index?: number } | null) => void) => {
     let optionIndex = 0
     let editMode = false
     const checked: boolean[] = allOptions.map(() => false)
@@ -339,28 +371,29 @@ async function askOne(params: QuestionSpec, ctx: ExtensionContext): Promise<{ co
       handleInput,
     }
   })
+}
 
-  // Build simple options list for details; header/multiSelect appear only when set,
-  // so single-select details are unchanged.
-  const simpleOptions = params.options.map((o) => o.label)
-  const base = { question: params.question, options: simpleOptions, ...(params.header ? { header: shortHeader(params.header) } : {}), ...(multiSelect ? { multiSelect: true } : {}) }
-
-  if (!result) {
-    return {
-      content: [{ type: 'text', text: 'User cancelled the selection' }],
-      details: { ...base, answer: null } as QuestionDetails,
-    }
+/** Dialog-primitive fallback for UI without a terminal (RPC mode supports
+ * select/input/notify but not custom components). Mirrors the overlay's result
+ * shape; a dismissed dialog reads as a cancel, same as Escape in the overlay. */
+async function askViaDialogs(params: QuestionSpec, ctx: ExtensionContext, allOptions: DisplayOption[], multiSelect: boolean): Promise<{ answer: string; wasCustom: boolean; index?: number } | null> {
+  const header = shortHeader(params.header)
+  const title = header ? `[${header}] ${params.question}` : params.question
+  // Number the labels: ctx.ui.select returns the chosen label string, so duplicate
+  // labels (or a model-supplied option named like the free-text entry) would be
+  // ambiguous by text alone; the number is the unambiguous way back to the option.
+  const labels = allOptions.map((option, i) => `${i + 1}. ${option.label}`)
+  const choice = await ctx.ui.select(title, labels)
+  if (choice === undefined) return null
+  const index = labels.indexOf(choice)
+  const chosen = allOptions[index]
+  if (!multiSelect && chosen?.isOther === true) {
+    const typed = await ctx.ui.input(params.question, 'Your answer')
+    // A dismissed dialog cancels; a submitted empty answer is an (empty) answer, not a
+    // cancel, so one accidental blank Enter does not abort the rest of a question batch.
+    if (typed === undefined) return null
+    return { answer: typed.trim(), wasCustom: true }
   }
-
-  if (result.wasCustom) {
-    return {
-      content: [{ type: 'text', text: `User wrote: ${result.answer}` }],
-      details: { ...base, answer: result.answer, wasCustom: true } as QuestionDetails,
-    }
-  }
-  const selectionText = multiSelect ? `User selected: ${result.answer || '(none)'}` : `User selected: ${result.index}. ${result.answer}`
-  return {
-    content: [{ type: 'text', text: selectionText }],
-    details: { ...base, answer: result.answer, wasCustom: false } as QuestionDetails,
-  }
+  const answer = chosen?.label ?? choice
+  return multiSelect ? { answer, wasCustom: false } : { answer, wasCustom: false, index: index + 1 }
 }

--- a/extensions/todo.ts
+++ b/extensions/todo.ts
@@ -84,6 +84,9 @@ const listMark = (status: TodoStatus): string => {
   return '[ ]'
 }
 
+/** Plain-text list, shared by the list action and the non-terminal /todos path. */
+const plainTodoList = (todos: Todo[]): string => (todos.length ? todos.map((t) => `${listMark(t.status)} #${t.id}: ${t.text}`).join('\n') : 'No todos')
+
 const overlayLabel = (todo: Todo, theme: Theme): string => {
   if (todo.status === 'completed') return theme.fg('dim', todo.text)
   if (todo.status === 'in_progress') return theme.fg('text', todo.activeForm ?? todo.text)
@@ -433,7 +436,7 @@ export default function todoExtension(pi: ExtensionAPI) {
     return ok('clear', `Cleared ${count} todos`)
   }
 
-  const handleList = () => ok('list', todos.length ? todos.map((t) => `${listMark(t.status)} #${t.id}: ${t.text}`).join('\n') : 'No todos')
+  const handleList = () => ok('list', plainTodoList(todos))
 
   // Register the todo tool for the LLM
   pi.registerTool({
@@ -513,6 +516,13 @@ export default function todoExtension(pi: ExtensionAPI) {
     handler: async (_args, ctx) => {
       if (!ctx.hasUI) {
         ctx.ui.notify('/todos requires interactive mode', 'error')
+        return
+      }
+
+      // ui.custom() is terminal-only: with a UI but no terminal (RPC mode) it
+      // resolves undefined without showing anything, so notify the plain list.
+      if (ctx.mode !== 'tui') {
+        ctx.ui.notify(plainTodoList(todos), 'info')
         return
       }
 

--- a/extensions/web.ts
+++ b/extensions/web.ts
@@ -9,6 +9,7 @@
 import type { LookupAddress } from 'node:dns'
 import { lookup } from 'node:dns/promises'
 import type { LookupFunction } from 'node:net'
+import type { Usage } from '@earendil-works/pi-ai'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { Type } from 'typebox'
 
@@ -252,16 +253,16 @@ function rememberFetch(cache: FetchCache, url: string, body: string, now: number
 }
 
 /** Claude's WebFetch runs the prompt over the page with a fast model and returns
- * that answer, not the raw page. Best-effort: any failure (no model, provider error)
+ * that answer, not the raw page, along with the nested call's usage so the tool
+ * result can account for it. Best-effort: any failure (no model, provider error)
  * yields null so the caller falls back to the markdown. */
-async function answerFromPage(model: Parameters<typeof completeText>[0], prompt: string, url: string, body: string, signal?: AbortSignal): Promise<string | null> {
+async function answerFromPage(model: Parameters<typeof completeText>[0], prompt: string, url: string, body: string, signal?: AbortSignal): Promise<{ text: string; usage: Usage } | null> {
   try {
-    const answer = await completeText(model, `${prompt}\n\nAnswer using only the page content below, fetched from ${url}:\n\n${body}`, {
+    return await completeText(model, `${prompt}\n\nAnswer using only the page content below, fetched from ${url}:\n\n${body}`, {
       system: 'You extract and answer questions from a web page. Answer only from the provided content, concisely. If the content does not contain the answer, say so.',
       maxTokens: 1024,
       signal,
     })
-    return answer || null
   } catch {
     return null
   }
@@ -318,14 +319,18 @@ export default function webExtension(pi: ExtensionAPI) {
       }
 
       // Best-effort prompt-over-page: a failure returns null, so web_fetch always
-      // falls back to the raw markdown and returns something.
+      // falls back to the raw markdown and returns something. The nested call's
+      // usage rides on the result either way, so pi counts it in session totals.
+      let usage: Usage | undefined
       if (params.prompt && ctx?.model) {
         const answer = await answerFromPage(ctx.model, params.prompt, params.url, body, signal)
-        if (answer) return { content: [{ type: 'text' as const, text: answer }], details: {} }
+        if (answer?.text) return { content: [{ type: 'text' as const, text: answer.text }], details: {}, usage: answer.usage }
+        // An empty answer still cost the completion; the fallback carries its usage.
+        usage = answer?.usage
       }
       // The char cap alone admits thousands of short lines; pi's tool-output budget
       // bounds lines too, which the shared guard enforces.
-      return { content: [{ type: 'text' as const, text: capForContext(body) || '(empty response)' }], details: {} }
+      return { content: [{ type: 'text' as const, text: capForContext(body) || '(empty response)' }], details: {}, usage }
     },
   })
 }

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -91,6 +91,7 @@ const setup = (cwd: string, trusted = true) => {
   const commands = new Map<string, { description?: string; handler: (args: string, ctx: unknown) => Promise<void> }>()
   const tools = new Map<string, RegisteredTool>()
   const sent: string[] = []
+  const sentOptions: unknown[] = []
   const toolSets: string[][] = []
   const notices: string[] = []
   const execCalls: Array<{ file: string; args: string[]; shell: string; timeout?: number; env?: Record<string, string> }> = []
@@ -104,8 +105,9 @@ const setup = (cwd: string, trusted = true) => {
       execCalls.push({ file, args, shell: args[1], timeout: opts?.timeout, env: opts?.env })
       return { stdout: `ran:${args[1]}`, ...execResult }
     },
-    sendUserMessage: (text: string) => {
+    sendUserMessage: (text: string, options?: unknown) => {
       sent.push(text)
+      sentOptions.push(options)
     },
     getActiveTools: () => active,
     setActiveTools: (next: string[]) => {
@@ -124,10 +126,12 @@ const setup = (cwd: string, trusted = true) => {
     { id: 'claude-fable-5', name: 'Fable' },
   ]
   commandsExtension(pi as never)
+  let idle = true
   const ctx = {
     cwd,
     hasUI: true,
     isProjectTrusted: () => trusted,
+    isIdle: () => idle,
     sessionManager: { getSessionId: () => 'sess-1' },
     thinkingLevel: 'high',
     model: available[0],
@@ -139,7 +143,23 @@ const setup = (cwd: string, trusted = true) => {
       },
     },
   }
-  return { handlers, commands, tools, sent, toolSets, notices, execCalls, ctx, modelSets, activeTools: () => active, failExec: (result: { stderr: string; code: number }) => Object.assign(execResult, result) }
+  return {
+    handlers,
+    commands,
+    tools,
+    sent,
+    sentOptions,
+    toolSets,
+    notices,
+    execCalls,
+    ctx,
+    modelSets,
+    activeTools: () => active,
+    setIdle: (value: boolean) => {
+      idle = value
+    },
+    failExec: (result: { stderr: string; code: number }) => Object.assign(execResult, result),
+  }
 }
 
 describe('commands extension', () => {
@@ -206,6 +226,34 @@ describe('commands extension', () => {
 
     await s.handlers.get('agent_settled')?.({}, s.ctx)
     expect(s.activeTools()).toEqual(['bash', 'read', 'edit', 'write'])
+  })
+
+  it('queues a command invoked mid-stream as a follow-up without touching the in-flight run', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'safe.md', '---\nallowed-tools: Read\n---\nLook only.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    // The agent is streaming: the command must not narrow the in-flight run's tools or
+    // switch its model, and a bare sendUserMessage would throw. It is queued as a
+    // follow-up through pi's own queue instead, with no scoping applied.
+    s.setIdle(false)
+    await s.commands.get('safe')?.handler('', s.ctx)
+    expect(s.sent).toEqual(['Look only.'])
+    expect(s.sentOptions).toEqual([{ deliverAs: 'followUp' }])
+    expect(s.activeTools()).toEqual(['bash', 'read', 'edit', 'write'])
+  })
+
+  it('applies scoping and sends bare when the command is invoked while idle', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'safe.md', '---\nallowed-tools: Read\n---\nLook only.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    await s.commands.get('safe')?.handler('', s.ctx)
+    expect(s.sent).toEqual(['Look only.'])
+    expect(s.sentOptions).toEqual([undefined])
+    expect(s.activeTools()).toEqual(['read'])
   })
 
   it('keeps the restriction through a mid-run turn_end, since pi fires one per assistant step', async () => {
@@ -869,6 +917,16 @@ describe('slash_command tool', () => {
     await s.handlers.get('session_start')?.({}, s.ctx)
 
     await expect(s.tools.get('slash_command')?.execute('t1', { command: '/nope now' }, undefined, undefined, s.ctx)).rejects.toThrow(/nope/)
+  })
+
+  it('caps the tool result so a huge command expansion cannot overflow the context', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'big.md', 'x'.repeat(60_000))
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    const result = await s.tools.get('slash_command')?.execute('t1', { command: '/big' }, undefined, undefined, s.ctx)
+    expect(result?.content[0].text).toContain('[truncated')
   })
 
   it("drops a previous project's commands from the model path on a session switch", async () => {

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -197,6 +197,7 @@ const setupExtension = () => {
       handler('tool_result')({ type: 'tool_result', toolCallId: 't1', toolName, input: opts.input ?? {}, content: opts.content ?? [], details: opts.details, isError: opts.isError ?? false }, defaultCtx),
     input: (text: string, source = 'interactive') => handler('input')({ text, source }, defaultCtx),
     agentEnd: (messages: unknown[] = []) => handler('agent_end')({ messages }, defaultCtx),
+    agentSettled: () => handler('agent_settled')({}, defaultCtx),
     beforeCompact: (reason: string) => handler('session_before_compact')({ reason }, defaultCtx),
     compacted: (reason: string) => handler('session_compact')({ reason }, defaultCtx),
     shutdown: (reason: string) => handler('session_shutdown')({ reason }, defaultCtx),

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -74,17 +74,19 @@ describe('findExistingContextFile', () => {
 const setup = () => {
   const commands = new Map<string, { description?: string; handler: (args: string, ctx: unknown) => Promise<void> }>()
   const sent: string[] = []
+  const sentOptions: unknown[] = []
   const pi = {
     on: () => {},
     registerCommand: (name: string, spec: { description?: string; handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, spec),
-    sendUserMessage: (text: string) => {
+    sendUserMessage: (text: string, options?: unknown) => {
       sent.push(text)
+      sentOptions.push(options)
     },
   }
   initExtension(pi as never)
-  return { commands, sent }
+  return { commands, sent, sentOptions }
 }
-const ctxFor = (cwd: string) => ({ cwd, hasUI: true, ui: { notify: () => {} } })
+const ctxFor = (cwd: string, idle = true) => ({ cwd, hasUI: true, isIdle: () => idle, ui: { notify: () => {} } })
 
 describe('init extension', () => {
   it('registers /init and sends one create prompt for a project with no context file', async () => {
@@ -127,6 +129,14 @@ describe('init extension', () => {
     expect(s.sent[0].toLowerCase()).toContain('propose improvements')
     expect(s.sent[0]).toContain('.cursorrules')
     expect(s.sent[0]).toContain('.github/copilot-instructions.md')
+  })
+
+  it('sends bare while idle but queues as a followUp while the agent is streaming', async () => {
+    const cwd = tempDir()
+    const s = setup()
+    await s.commands.get('init')?.handler('', ctxFor(cwd))
+    await s.commands.get('init')?.handler('', ctxFor(cwd, false))
+    expect(s.sentOptions).toEqual([{}, { deliverAs: 'followUp' }])
   })
 
   it('detects a .cursor/rules directory as cursor rules', async () => {

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -194,6 +194,7 @@ interface Harness {
   warnings: string[]
   emitted: Array<{ channel: string; data: unknown }>
   sent: string[]
+  sentOptions: unknown[]
   home: string
   cwd: string
   sessionStart: (trusted?: boolean | undefined, approve?: boolean) => Promise<void>
@@ -201,7 +202,7 @@ interface Harness {
   mcpCommand: () => Promise<void>
   toolNames: () => string[]
   commandNames: () => string[]
-  runSlash: (name: string, args: string) => Promise<void>
+  runSlash: (name: string, args: string, idle?: boolean) => Promise<void>
 }
 
 const writeServers = (file: string, servers: Record<string, unknown>): void => {
@@ -223,6 +224,7 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
   const warnings: string[] = []
   const emitted: Array<{ channel: string; data: unknown }> = []
   const sent: string[] = []
+  const sentOptions: unknown[] = []
   const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<void>>()
   const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>()
 
@@ -232,7 +234,7 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
 
   // Project config now needs approval as well as trust: pi reports a .claude-shaped repo
   // as trusted without ever asking, so project-approval prompts at the point of use.
-  const makeCtx = (trusted?: boolean, approve = true): unknown => ({
+  const makeCtx = (trusted?: boolean, approve = true, idle = true): unknown => ({
     cwd,
     hasUI: true,
     ui: {
@@ -240,13 +242,17 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
       confirm: async () => approve,
     },
     isProjectTrusted: trusted === undefined ? undefined : () => trusted,
+    isIdle: () => idle,
   })
 
   await mcpExtension({
     on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<void>) => handlers.set(name, fn),
     registerCommand: (name: string, opts2: { handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, opts2),
     registerTool: (tool: RegisteredTool) => tools.push(tool),
-    sendUserMessage: (text: string) => sent.push(text),
+    sendUserMessage: (text: string, options?: unknown) => {
+      sent.push(text)
+      sentOptions.push(options)
+    },
     events: { emit: (channel: string, data: unknown) => emitted.push({ channel, data }), on: () => () => {} },
   } as never)
 
@@ -256,6 +262,7 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
     warnings,
     emitted,
     sent,
+    sentOptions,
     home,
     cwd,
     sessionStart: async (trusted?: boolean, approve = true) => {
@@ -269,8 +276,8 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
     },
     toolNames: () => tools.map((t) => t.name),
     commandNames: () => [...commands.keys()],
-    runSlash: async (name: string, args: string) => {
-      await commands.get(name)?.handler(args, makeCtx(true))
+    runSlash: async (name: string, args: string, idle = true) => {
+      await commands.get(name)?.handler(args, makeCtx(true, true, idle))
     },
   }
 }
@@ -1531,6 +1538,17 @@ describe('mcp prompts as slash commands', () => {
         { type: 'image', data: 'ZZZZ', mimeType: 'image/png' },
       ],
     ])
+  })
+
+  it('sends bare while idle but queues as a followUp while the agent is streaming', async () => {
+    withPrompts([{ name: 'greet' }])
+    hoisted.control.getPrompt = async () => ({ messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }] })
+    const harness = await setupStarted({ user: { demo: { command: 'x' } } })
+
+    await harness.runSlash('mcp__demo__greet', '')
+    await harness.runSlash('mcp__demo__greet', '', false)
+
+    expect(harness.sentOptions).toEqual([{}, { deliverAs: 'followUp' }])
   })
 
   it('reports instead of driving a turn when a prompt returns no content', async () => {

--- a/tests/memory-actions.test.ts
+++ b/tests/memory-actions.test.ts
@@ -1,7 +1,8 @@
-import { chmodSync, existsSync, mkdtempSync, readFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { withFileMutationQueue } from '@earendil-works/pi-coding-agent'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import memoryExtension, { memoryDir } from '../extensions/memory.ts'
@@ -124,6 +125,53 @@ describe('memory index robustness', () => {
 
     expect(result).not.toContain('Saved memory')
     expect(readFileSync(indexPath, 'utf-8')).toContain('- [first](first.md):')
+  })
+
+  it('waits for an in-flight queued index mutation instead of racing it', async () => {
+    const { handlers, tool, cwd, dir } = setup()
+    await start(handlers, cwd)
+    await tool.execute('1', { action: 'save', name: 'first', description: 'existing entry', content: 'kept' })
+    const indexPath = join(dir, 'MEMORY.md')
+
+    // A built-in edit holds the per-file mutation queue across its whole
+    // read-modify-write. A save that does not join that queue reads the same old
+    // index while the edit is parked mid-window, and one of the two updates is lost.
+    let releaseEdit = () => {}
+    const editParked = new Promise<void>((resolve) => {
+      releaseEdit = resolve
+    })
+    let editRead = () => {}
+    const editReadDone = new Promise<void>((resolve) => {
+      editRead = resolve
+    })
+    const edit = withFileMutationQueue(indexPath, async () => {
+      const before = readFileSync(indexPath, 'utf-8')
+      editRead()
+      await editParked
+      writeFileSync(indexPath, before.replace('existing entry', 'edited entry'))
+    })
+
+    await editReadDone
+    const save = tool.execute('2', { action: 'save', name: 'second', description: 'new entry', content: 'body' })
+    // Give the save time to reach the queue (or, unqueued, to run to completion).
+    await new Promise((resolve) => setImmediate(resolve))
+    releaseEdit()
+    await Promise.all([edit, save])
+
+    const index = readFileSync(indexPath, 'utf-8')
+    expect(index).toContain('- [first](first.md): edited entry')
+    expect(index).toContain('- [second](second.md): new entry')
+  })
+
+  it('lands both of two concurrent saves in the index', async () => {
+    const { handlers, tool, cwd, dir } = setup()
+    await start(handlers, cwd)
+
+    await Promise.all([tool.execute('1', { action: 'save', name: 'alpha', description: 'first of a pair', content: 'a' }), tool.execute('2', { action: 'save', name: 'beta', description: 'second of a pair', content: 'b' })])
+
+    const index = readFileSync(join(dir, 'MEMORY.md'), 'utf-8')
+    expect(index).toContain('- [alpha](alpha.md): first of a pair')
+    expect(index).toContain('- [beta](beta.md): second of a pair')
   })
 
   it('refuses to delete while the index is unreadable, keeping the memory file', async () => {

--- a/tests/model-complete.test.ts
+++ b/tests/model-complete.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { assistantText, completeText, setCompleteBackend } from '../extensions/internal/model-complete.ts'
 
-const msg = (parts: Array<{ type: string; text?: string }>) => ({ role: 'assistant', content: parts, api: 'x', provider: 'x', model: 'm', usage: {}, stopReason: 'stop', timestamp: 0 }) as never
+const msg = (parts: Array<{ type: string; text?: string }>, usage: unknown = {}) => ({ role: 'assistant', content: parts, api: 'x', provider: 'x', model: 'm', usage, stopReason: 'stop', timestamp: 0 }) as never
 
 afterEach(() => setCompleteBackend(null))
 
@@ -24,8 +24,15 @@ describe('completeText', () => {
       return msg([{ type: 'text', text: 'the answer' }])
     })
     const out = await completeText({} as never, 'the question', { system: 'be brief', maxTokens: 256 })
-    expect(out).toBe('the answer')
+    expect(out.text).toBe('the answer')
     expect(seen).toEqual({ system: 'be brief', user: 'the question', maxTokens: 256 })
+  })
+
+  it('returns the assistant usage so a tool result can account for the nested call', async () => {
+    const usage = { input: 12, output: 4, cacheRead: 0, cacheWrite: 0, totalTokens: 16, cost: { input: 0.001, output: 0.002, cacheRead: 0, cacheWrite: 0, total: 0.003 } }
+    setCompleteBackend(async () => msg([{ type: 'text', text: 'ok' }], usage))
+    const out = await completeText({} as never, 'q')
+    expect(out.usage).toEqual(usage)
   })
 
   it('propagates a backend failure so the caller can fall back', async () => {

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -16,14 +16,14 @@ vi.mock('node:os', async (importOriginal) => {
 
 type Handler = (event: unknown, ctx: unknown) => Promise<void>
 
-function drive(): { sessionStart: (ctx?: unknown) => Promise<void>; input: () => Promise<void>; agentEnd: () => Promise<void> } {
+function drive(): { sessionStart: (ctx?: unknown) => Promise<void>; input: () => Promise<void>; agentEnd: () => Promise<void>; agentSettled: () => Promise<void> } {
   const handlers = new Map<string, Handler>()
   notifyExtension({ on: (name: string, fn: Handler) => handlers.set(name, fn) } as never)
   const call =
     (name: string) =>
     (ctx: unknown = {}) =>
       handlers.get(name)?.({}, ctx) ?? Promise.resolve()
-  return { sessionStart: call('session_start'), input: () => call('input')(), agentEnd: () => call('agent_end')() }
+  return { sessionStart: call('session_start'), input: () => call('input')(), agentEnd: () => call('agent_end')(), agentSettled: () => call('agent_settled')() }
 }
 
 describe('notify', () => {

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -34,6 +34,7 @@ function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
   const shortcuts: Array<(ctx: unknown) => Promise<void>> = []
   const sent: SentMessage[] = []
   const userMessages: string[] = []
+  const userMessageOptions: unknown[] = []
   const appended: Array<{ type: string; data: unknown }> = []
   const emitted: Array<{ channel: string; data: unknown }> = []
   let activeTools = options.activeTools ?? [...ALL_TOOLS]
@@ -53,7 +54,10 @@ function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
     registerShortcut: (_key: unknown, spec: { handler: (ctx: unknown) => Promise<void> }) => shortcuts.push(spec.handler),
     on: (name: string, fn: Handler) => handlers.set(name, fn),
     sendMessage: (message: SentMessage) => sent.push(message),
-    sendUserMessage: (text: string) => userMessages.push(text),
+    sendUserMessage: (text: string, options?: unknown) => {
+      userMessages.push(text)
+      userMessageOptions.push(options)
+    },
     appendEntry: (type: string, data: unknown) => appended.push({ type, data }),
     events: { emit: (channel: string, data: unknown) => emitted.push({ channel, data }), on: () => () => {} },
   }
@@ -65,6 +69,7 @@ function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
   const notices: string[] = []
   const ctx = {
     hasUI: true,
+    isIdle: () => true,
     ui: {
       theme,
       setStatus: (_key: string, text?: string) => status.push(text),
@@ -86,6 +91,7 @@ function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
     notices,
     sent,
     userMessages,
+    userMessageOptions,
     appended,
     emitted,
     shortcuts,
@@ -357,6 +363,19 @@ describe('plan review prompt', () => {
     await s.emit('agent_end', { messages: [assistant('Plan:\n1. Read the config loader')] })
 
     expect(s.userMessages).toEqual(['focus on the parser'])
+  })
+
+  it('sends the refinement bare while idle but queues it as a followUp while streaming', async () => {
+    const s = setup()
+    s.ctx.ui.select = async (_q: string, choices: string[]) => choices[2]
+    s.ctx.ui.editor = async () => 'focus on the parser'
+    await s.runCommand('plan')
+    await s.emit('agent_end', { messages: [assistant('Plan:\n1. Read the config loader')] })
+
+    s.ctx.isIdle = () => false
+    await s.emit('agent_end', { messages: [assistant('Plan:\n1. Read the config loader')] })
+
+    expect(s.userMessageOptions).toEqual([{}, { deliverAs: 'followUp' }])
   })
 
   it('re-extracts the plan from prose after a tool-submitted plan is refined', async () => {

--- a/tests/question.test.ts
+++ b/tests/question.test.ts
@@ -58,13 +58,14 @@ const lines = (text: Text): string[] => text.render(200).map((line) => line.trim
 const OPTIONS: Option[] = [{ label: 'Alpha', description: 'first one' }, { label: 'Beta' }]
 
 /** Resolve ui.custom immediately, without ever building the overlay. */
-const uiCtx = (resolved: unknown) => ({ hasUI: true, ui: { custom: async () => resolved } })
+const uiCtx = (resolved: unknown) => ({ hasUI: true, mode: 'tui', ui: { custom: async () => resolved } })
 
 /** Start execute, capture the live overlay, and hand back the still-pending result. */
 const openOverlay = (tool: QuestionTool, options: Option[] = OPTIONS) => {
   let overlay: Overlay | undefined
   const ctx = {
     hasUI: true,
+    mode: 'tui',
     ui: {
       custom: (factory: CustomFactory) =>
         new Promise((resolve) => {
@@ -82,6 +83,7 @@ const openOverlayWith = (tool: QuestionTool, params: Record<string, unknown>) =>
   let overlay: Overlay | undefined
   const ctx = {
     hasUI: true,
+    mode: 'tui',
     ui: {
       custom: (factory: CustomFactory) =>
         new Promise((resolve) => {
@@ -117,6 +119,7 @@ describe('question execute', () => {
   it('refuses an empty option list without opening the overlay', async () => {
     const ctx = {
       hasUI: true,
+      mode: 'tui',
       ui: {
         custom: () => {
           throw new Error('ui.custom must not be called for an empty option list')
@@ -146,6 +149,94 @@ describe('question execute', () => {
     const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS }, undefined, undefined, uiCtx(typed))
     expect(result.content).toEqual([{ type: 'text', text: 'User wrote: something else' }])
     expect(result.details).toEqual({ question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'something else', wasCustom: true })
+  })
+})
+
+describe('question over dialogs (hasUI without tui)', () => {
+  interface DialogCall {
+    kind: 'select' | 'input' | 'custom'
+    title?: string
+    options?: string[]
+  }
+
+  /** RPC-shaped ctx: hasUI is true, custom() resolves undefined (terminal-only),
+   * select/input answer from canned values. Every UI call is recorded. */
+  const rpcCtx = (selected: string | undefined, typed?: string | undefined) => {
+    const calls: DialogCall[] = []
+    const ctx = {
+      hasUI: true,
+      mode: 'rpc',
+      ui: {
+        custom: async () => {
+          calls.push({ kind: 'custom' })
+          return undefined
+        },
+        select: async (title: string, options: string[]) => {
+          calls.push({ kind: 'select', title, options })
+          return selected
+        },
+        input: async (title: string) => {
+          calls.push({ kind: 'input', title })
+          return typed
+        },
+      },
+    }
+    return { ctx, calls }
+  }
+
+  it('asks through ui.select with numbered labels and reports the picked option', async () => {
+    const { ctx, calls } = rpcCtx('2. Beta')
+    const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS }, undefined, undefined, ctx)
+    expect(calls).toEqual([{ kind: 'select', title: 'Pick one', options: ['1. Alpha', '2. Beta', '3. Type something.'] }])
+    expect(result.content).toEqual([{ type: 'text', text: 'User selected: 2. Beta' }])
+    expect(result.details).toEqual({ question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'Beta', wasCustom: false })
+  })
+
+  it('routes the free-text option through ui.input', async () => {
+    const { ctx, calls } = rpcCtx('3. Type something.', 'my own words')
+    const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS }, undefined, undefined, ctx)
+    expect(calls.map((c) => c.kind)).toEqual(['select', 'input'])
+    expect(result.content).toEqual([{ type: 'text', text: 'User wrote: my own words' }])
+    expect(result.details).toEqual({ question: 'Pick one', options: ['Alpha', 'Beta'], answer: 'my own words', wasCustom: true })
+  })
+
+  it('disambiguates by number when an option is named like the free-text entry', async () => {
+    // The last numbered label is the real free-text entry, even though an option shares
+    // its text; picking it routes through ui.input rather than reporting a plain choice.
+    const { ctx, calls } = rpcCtx('3. Type something.', 'typed answer')
+    const result = await setup().execute('call-1', { question: 'Pick one', options: [{ label: 'Type something.' }, { label: 'Beta' }] as never }, undefined, undefined, ctx)
+    expect((calls[0] as { options: string[] }).options).toEqual(['1. Type something.', '2. Beta', '3. Type something.'])
+    expect(result.details).toMatchObject({ answer: 'typed answer', wasCustom: true })
+  })
+
+  it('reports a dismissed selector as cancelled', async () => {
+    const { ctx } = rpcCtx(undefined)
+    const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS }, undefined, undefined, ctx)
+    expect(result.content).toEqual([{ type: 'text', text: 'User cancelled the selection' }])
+    expect(result.details).toEqual({ question: 'Pick one', options: ['Alpha', 'Beta'], answer: null })
+  })
+
+  it('treats a dismissed free-text input as cancelled', async () => {
+    const { ctx } = rpcCtx('3. Type something.', undefined)
+    const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS }, undefined, undefined, ctx)
+    expect(result.content).toEqual([{ type: 'text', text: 'User cancelled the selection' }])
+    expect(result.details).toEqual({ question: 'Pick one', options: ['Alpha', 'Beta'], answer: null })
+  })
+
+  it('treats an empty free-text submit as an empty answer, not a cancel', async () => {
+    // A blank Enter is a (blank) answer; treating it as a cancel would abort the rest of
+    // a multi-question batch on one accidental keystroke.
+    const { ctx } = rpcCtx('3. Type something.', '  ')
+    const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS }, undefined, undefined, ctx)
+    expect(result.details).toMatchObject({ answer: '', wasCustom: true })
+  })
+
+  it('offers no free-text entry for multiSelect and prefixes the header in the title', async () => {
+    const { ctx, calls } = rpcCtx('1. Alpha')
+    const result = await setup().execute('call-1', { question: 'Pick some', header: 'Scope', options: OPTIONS, multiSelect: true } as never, undefined, undefined, ctx)
+    expect(calls).toEqual([{ kind: 'select', title: '[Scope] Pick some', options: ['1. Alpha', '2. Beta'] }])
+    expect(result.content).toEqual([{ type: 'text', text: 'User selected: Alpha' }])
+    expect(result.details).toEqual({ question: 'Pick some', header: 'Scope', options: ['Alpha', 'Beta'], answer: 'Alpha', wasCustom: false, multiSelect: true })
   })
 })
 
@@ -394,6 +485,7 @@ describe('multiple questions per call', () => {
     const answers = ['Alpha', 'Beta']
     const ctx = {
       hasUI: true,
+      mode: 'tui',
       ui: {
         custom: async () => {
           const answer = answers[asked.length]
@@ -421,6 +513,7 @@ describe('multiple questions per call', () => {
     let calls = 0
     const ctx = {
       hasUI: true,
+      mode: 'tui',
       ui: {
         custom: async () => {
           calls++

--- a/tests/todo-more.test.ts
+++ b/tests/todo-more.test.ts
@@ -502,10 +502,29 @@ describe('/todos command', () => {
     expect(ui.customFactories).toHaveLength(0)
   })
 
+  it('notifies the plain list instead of a custom component in RPC mode', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.call({ action: 'add', text: 'first' })
+    await h.call({ action: 'add', text: 'second' })
+    await h.call({ action: 'complete', id: 1 })
+    await h.runCommand('todos', { hasUI: true, mode: 'rpc', ui: ui.ui })
+    expect(ui.customFactories).toHaveLength(0)
+    expect(ui.notices).toEqual([{ message: '[x] #1: first\n[ ] #2: second', type: 'info' }])
+  })
+
+  it('notifies the empty-list placeholder in RPC mode', async () => {
+    const h = setup()
+    const ui = fakeUI()
+    await h.runCommand('todos', { hasUI: true, mode: 'rpc', ui: ui.ui })
+    expect(ui.customFactories).toHaveLength(0)
+    expect(ui.notices).toEqual([{ message: 'No todos', type: 'info' }])
+  })
+
   it('renders an invitation when the list is empty', async () => {
     const h = setup()
     const ui = fakeUI()
-    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    await h.runCommand('todos', { hasUI: true, mode: 'tui', ui: ui.ui })
     const lines = ui.customFactories[0](null, theme, null, () => {}).render(60)
     expect(lines[3]).toBe('  No todos yet. Ask the agent to add some!')
     expect(lines.at(-2)).toBe('  Press Escape to close')
@@ -518,7 +537,7 @@ describe('/todos command', () => {
     await h.call({ action: 'add', text: 'second' })
     await h.call({ action: 'complete', id: 1 })
     await h.call({ action: 'start', id: 2, activeForm: 'Doing second' })
-    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    await h.runCommand('todos', { hasUI: true, mode: 'tui', ui: ui.ui })
 
     const lines = ui.customFactories[0](null, theme, null, () => {}).render(60)
     expect(lines[0]).toBe('')
@@ -531,7 +550,7 @@ describe('/todos command', () => {
   it('closes the list on escape', async () => {
     const h = setup()
     const ui = fakeUI()
-    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    await h.runCommand('todos', { hasUI: true, mode: 'tui', ui: ui.ui })
     let closed = 0
     const component = ui.customFactories[0](null, theme, null, () => {
       closed++
@@ -543,7 +562,7 @@ describe('/todos command', () => {
   it('closes the list on ctrl+c', async () => {
     const h = setup()
     const ui = fakeUI()
-    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    await h.runCommand('todos', { hasUI: true, mode: 'tui', ui: ui.ui })
     let closed = 0
     const component = ui.customFactories[0](null, theme, null, () => {
       closed++
@@ -555,7 +574,7 @@ describe('/todos command', () => {
   it('ignores unrelated keystrokes', async () => {
     const h = setup()
     const ui = fakeUI()
-    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    await h.runCommand('todos', { hasUI: true, mode: 'tui', ui: ui.ui })
     let closed = 0
     const component = ui.customFactories[0](null, theme, null, () => {
       closed++
@@ -568,7 +587,7 @@ describe('/todos command', () => {
     const h = setup()
     const ui = fakeUI()
     await h.call({ action: 'add', text: 'first' })
-    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    await h.runCommand('todos', { hasUI: true, mode: 'tui', ui: ui.ui })
     const component = ui.customFactories[0](null, theme, null, () => {})
 
     const before = component.render(60)
@@ -583,7 +602,7 @@ describe('/todos command', () => {
     const h = setup()
     const ui = fakeUI()
     await h.call({ action: 'add', text: 'first' })
-    await h.runCommand('todos', { hasUI: true, ui: ui.ui })
+    await h.runCommand('todos', { hasUI: true, mode: 'tui', ui: ui.ui })
     const component = ui.customFactories[0](null, theme, null, () => {})
 
     component.render(60)

--- a/tests/web-more.test.ts
+++ b/tests/web-more.test.ts
@@ -8,7 +8,7 @@ import webExtension, { isPrivateAddress, pinnedLookup } from '../extensions/web.
 vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }))
 vi.mock('../extensions/internal/web-transport.js', () => ({ httpFetch: vi.fn() }))
 
-type ToolResult = { content: Array<{ type: string; text: string }>; details: Record<string, unknown> }
+type ToolResult = { content: Array<{ type: string; text: string }>; details: Record<string, unknown>; usage?: unknown }
 type Execute = (id: string, params: Record<string, unknown>, signal?: unknown, onUpdate?: unknown, ctx?: unknown) => Promise<ToolResult>
 
 /** Register the extension against a stub API and expose both tools by name. */
@@ -71,6 +71,16 @@ describe('web_fetch prompt (in-process summarization)', () => {
     // The page markdown is handed to the model, not returned raw.
     expect(seenPrompt).toContain('The plan costs $9/mo.')
     expect(seenPrompt).toContain('What does the plan cost?')
+  })
+
+  it('carries the nested completion usage on the tool result for session accounting', async () => {
+    fetchMock.mockResolvedValue(respond('<p>page body</p>'))
+    const usage = { input: 200, output: 12, cacheRead: 0, cacheWrite: 0, totalTokens: 212, cost: { input: 0.001, output: 0.002, cacheRead: 0, cacheWrite: 0, total: 0.003 } }
+    setCompleteBackend(async () => ({ role: 'assistant', content: [{ type: 'text', text: 'the answer' }], api: 'x', provider: 'x', model: 'm', usage, stopReason: 'stop', timestamp: 0 }) as never)
+    const r = await setup().fetchWith({ url: 'https://example.com/answered', prompt: 'what is it?' }, { model: {} })
+    expect(r.content[0].text).toBe('the answer')
+    // The nested call's tokens must reach pi's session totals via the tool result.
+    expect(r.usage).toEqual(usage)
   })
 
   it('falls back to the markdown when the completion fails', async () => {


### PR DESCRIPTION
## Summary

Fixes correctness bugs an audit of the pack's use of the pi extension SDK surfaced, checked against the SDK's own documented contracts and the runtime in `node_modules`. Each fix has a regression test written to fail first; `npm run check` is green at 1522 tests, 96% statements and 91% branches. An adversarial review pass reshaped several of the fixes, so the notes below describe the landed behavior.

A slash command invoked while the agent is streaming used to throw (a bare `sendUserMessage` is not allowed mid-stream) and be silently dropped, but only after it had already narrowed the in-flight run's tools and switched its model. It now queues through pi's own follow-up delivery and leaves the running turn untouched; its frontmatter scoping is not applied to a run it does not own.

The memory tool serializes its whole read-modify-write on the index's mutation queue, so two parallel saves can no longer both read the same index and drop one line. The queue keys on the index alone: a second queue on the memory file would self-deadlock whenever a memory name canonicalizes onto the same path as `MEMORY.md` under a case-insensitive filesystem.

WebFetch's prompt-over-page path returns the nested model call's usage on its tool result, so those tokens are counted in the footer and session totals instead of vanishing. In RPC mode the question and todo commands now fall back to `select`/`input`/`notify` rather than calling the terminal-only `custom()` component, which returns undefined there and made the tool report a cancel the user never issued; the offered choices are numbered so duplicate labels resolve unambiguously, and an empty free-text submit is treated as an empty answer rather than a cancel that would abort the rest of a question batch.

Rounding out: the MCP prompt command, `/init`, and the plan-refinement send pass a delivery mode when the agent is busy; the deferred model restore no longer floats an unhandled rejection; and the `slash_command` tool result is capped like every other tool's output.

The one SDK-audit recommendation deliberately not taken is moving the idle notification and Stop hooks to `agent_settled`: a peer extension (plan mode) blocks its own `agent_end` handler on a dialog, and `agent_settled` is only emitted after every `agent_end` handler returns, so the move would starve those exactly when the user has stepped away. They stay on `agent_end`.