### PR TITLE
Cut redundant hot-path work across the extension pack

### DIFF
--- a/extensions/claude-rules.ts
+++ b/extensions/claude-rules.ts
@@ -22,7 +22,7 @@ import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
 import { publishInstructionLoad } from './internal/instruction-events.js'
-import { globToRegExpSource } from './internal/path-rules.js'
+import { type CompiledGlob, compileGlobs, matchesCompiledGlobs } from './internal/path-rules.js'
 import { isProjectApproved } from './internal/project-approval.js'
 import { findNearestDir } from './internal/project-root.js'
 import { stripBlockComments } from './internal/strip-comments.js'
@@ -81,19 +81,7 @@ export function parseFrontmatter(content: string): Frontmatter {
  * the rule set's root.
  */
 export function pathMatchesGlobs(relPath: string, globs: string[]): boolean {
-  const posix = relPath.split(path.sep).join('/')
-  const base = posix.split('/').pop() ?? posix
-  return globs.some((raw) => {
-    let glob = raw.trim()
-    if (!glob) return false
-    if (glob.startsWith('./')) glob = glob.slice(2)
-    else if (glob.startsWith('/')) glob = glob.slice(1)
-    // A trailing slash means the directory's contents, like gitignore; `docs/` alone
-    // would compile to `^docs/$` and match nothing.
-    if (glob.endsWith('/')) glob += '**'
-    const target = glob.includes('/') ? posix : base
-    return new RegExp(`^${globToRegExpSource(glob)}$`).test(target)
-  })
+  return matchesCompiledGlobs(relPath, compileGlobs(globs))
 }
 
 /** A rule pointer line, annotated with its path scope when present. */
@@ -199,8 +187,10 @@ function rulesSection(title: string, rules: RuleSet, base: string): string {
 
 /** A scoped rule resolved to the root its globs match against, ready to attach. */
 interface AttachTarget {
-  key: string
+  /** The rule's `paths:` globs as written, reported on the instruction-events bus. */
   globs: string[]
+  /** The globs precompiled once at session start for the per-tool-result scan. */
+  compiled: CompiledGlob[]
   body: string
   /** The absolute directory `paths:` globs are matched relative to. */
   root: string
@@ -208,6 +198,15 @@ interface AttachTarget {
   file: string
   /** Claude's memory_type for the rule's origin: global rules are User config. */
   memoryType: 'User' | 'Project'
+}
+
+// Module level because the working list lives in each extension instance's closure.
+let pendingScopedRules = 0
+
+/** Test seam: scoped rules still awaiting attachment in the current session, for
+ * asserting that a fully attached rule leaves the per-tool-result working list. */
+export function pendingScopedRuleCount(): number {
+  return pendingScopedRules
 }
 
 export default function claudeRulesExtension(pi: ExtensionAPI) {
@@ -218,10 +217,9 @@ export default function claudeRulesExtension(pi: ExtensionAPI) {
   // The project rules dir may sit at an ancestor of cwd, where a cwd-relative
   // '.claude/rules' would point the read at a path that does not exist.
   let projectRulesBase = '.claude/rules'
-  // Scoped rules ready to attach when a matching file is touched, and the set of
-  // rules already attached this session so each attaches at most once.
+  // Scoped rules still awaiting a matching touch. An attached rule leaves the
+  // list, so each attaches at most once and the per-tool-result scan shrinks.
   let attachTargets: AttachTarget[] = []
-  const attached = new Set<string>()
 
   pi.on('session_start', async (_event, ctx) => {
     globalRules = readRules(globalRulesDir)
@@ -236,13 +234,14 @@ export default function claudeRulesExtension(pi: ExtensionAPI) {
 
     // Global globs are relative to cwd; project globs to the project root (the dir
     // holding .claude), so `db/**` in a repo rule matches repo-relative paths even
-    // from a subdirectory session. Reset per session so a re-run re-attaches.
-    attached.clear()
+    // from a subdirectory session. Globs compile here, once per session, rather
+    // than on every tool result; rebuilt per session so a re-run re-attaches.
     const projectRoot = projectRulesDir ? path.dirname(path.dirname(projectRulesDir)) : ctx.cwd
     attachTargets = [
-      ...globalRules.scoped.map((rule) => ({ key: `global:${rule.rel}`, globs: rule.paths, body: rule.body, root: ctx.cwd, file: path.join(globalRulesDir, rule.rel), memoryType: 'User' as const })),
-      ...projectRules.scoped.map((rule) => ({ key: `project:${rule.rel}`, globs: rule.paths, body: rule.body, root: projectRoot, file: path.join(projectRulesDir ?? path.join(ctx.cwd, '.claude', 'rules'), rule.rel), memoryType: 'Project' as const })),
+      ...globalRules.scoped.map((rule) => ({ globs: rule.paths, compiled: compileGlobs(rule.paths), body: rule.body, root: ctx.cwd, file: path.join(globalRulesDir, rule.rel), memoryType: 'User' as const })),
+      ...projectRules.scoped.map((rule) => ({ globs: rule.paths, compiled: compileGlobs(rule.paths), body: rule.body, root: projectRoot, file: path.join(projectRulesDir ?? path.join(ctx.cwd, '.claude', 'rules'), rule.rel), memoryType: 'Project' as const })),
     ]
+    pendingScopedRules = attachTargets.length
     // Relative to cwd, which the read tool resolves: an ancestor dir yields a
     // `../…/.claude/rules` the model can follow, where a bare '.claude/rules'
     // would point at a nonexistent path under the subdirectory.
@@ -277,21 +276,25 @@ export default function claudeRulesExtension(pi: ExtensionAPI) {
     const abs = path.resolve(ctx.cwd, rel)
 
     const bodies: string[] = []
+    const remaining: AttachTarget[] = []
     for (const target of attachTargets) {
-      if (attached.has(target.key)) continue
       const relativeToRoot = path.relative(target.root, abs)
       // A file outside the rule root cannot match its project-relative globs. Test for
       // a real parent-traversal segment, not a leading '..' (a file named `..config` is
       // inside the root).
-      if (relativeToRoot === '..' || relativeToRoot.startsWith(`..${path.sep}`) || path.isAbsolute(relativeToRoot)) continue
-      if (!pathMatchesGlobs(relativeToRoot, target.globs)) continue
-      attached.add(target.key)
+      const outsideRoot = relativeToRoot === '..' || relativeToRoot.startsWith(`..${path.sep}`) || path.isAbsolute(relativeToRoot)
+      if (outsideRoot || !matchesCompiledGlobs(relativeToRoot, target.compiled)) {
+        remaining.push(target)
+        continue
+      }
       bodies.push(target.body)
       // The lazy attach is Claude's path_glob_match instruction load; the hooks
-      // extension bridges the bus event to the InstructionsLoaded hook. The
-      // once-per-session attach set above also bounds the events to one per rule.
+      // extension bridges the bus event to the InstructionsLoaded hook. Leaving
+      // the working list also bounds the events to one per rule per session.
       publishInstructionLoad(pi.events, { file_path: target.file, memory_type: target.memoryType, load_reason: 'path_glob_match', globs: target.globs, trigger_file_path: abs })
     }
+    attachTargets = remaining
+    pendingScopedRules = attachTargets.length
     if (bodies.length === 0) return
     return { content: [...event.content, ...bodies.map((text) => ({ type: 'text' as const, text }))] }
   })

--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -52,6 +52,7 @@
  * Docs: https://code.claude.com/docs/en/memory.md (imports)
  */
 
+import { createHash } from 'node:crypto'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
@@ -507,6 +508,37 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     publishInstructionLoad(pi.events, event)
   }
 
+  // before_agent_start fires every turn, but its inputs almost never change
+  // mid-session. The settings-derived environment (managed settings, exclude
+  // globs, repo root) is cached per cwd, and the whole import expansion is
+  // memoized on its inputs and revalidated by a stat token (mtime and size): a
+  // turn where nothing changed costs a handful of stats instead of re-reading and
+  // re-recursing every @import. A brand-new file satisfying a previously missing
+  // @import is picked up when any recorded stat token moves (or next session),
+  // which is already fresher than Claude, which loads context once at session start.
+  let envCache: { cwd: string; managed: Record<string, unknown>; excludeGlobs: string[]; projectRoot: string } | undefined
+  let importMemo:
+    | {
+        key: string
+        extras: Array<{ path: string; content: string; dir: string }>
+        imported: ImportedFile[]
+        budget: ImportBudget
+        tokens: Array<[string, string]>
+      }
+    | undefined
+  // mtime plus size, so a same-mtime rewrite of a different length still invalidates.
+  const statToken = (file: string): string => {
+    const stat = fs.statSync(file)
+    return `${stat.mtimeMs}:${stat.size}`
+  }
+  const memoIsFresh = (memo: NonNullable<typeof importMemo>): boolean => {
+    try {
+      return memo.tokens.every(([file, token]) => statToken(file) === token)
+    } catch {
+      return false // a recorded file vanished: re-expand
+    }
+  }
+
   // Claude's --add-dir. Only the memory-loading half is meaningful here: pi has
   // no path-based permission system, so there is no access grant to mirror.
   // Optional-called so the extension still wires under stub hosts without flags.
@@ -520,6 +552,8 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     // a reload anyway; a reload simply re-fires InstructionsLoaded once per file,
     // which is fine, since a reload re-loads the instruction files.
     announced.clear()
+    envCache = undefined
+    importMemo = undefined
     // CLAUDE.local.md is Claude Code's personal sidecar of CLAUDE.md; pi's own loader
     // skips it. A cloned repo can ship one, so it is gated like other project config.
     // Claude loads local context from the whole hierarchy above the working
@@ -545,10 +579,12 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     const cwd = event.systemPromptOptions?.cwd ?? process.cwd()
     const native: Array<{ path: string; content: string }> = event.systemPromptOptions?.contextFiles ?? []
 
-    const managed = readManagedSettings()
-    const excludeGlobs = readClaudeMdExcludes(claudeMdExcludeFiles(cwd, home, projectApproved), managed)
+    if (!envCache || envCache.cwd !== cwd) {
+      const managedNow = readManagedSettings()
+      envCache = { cwd, managed: managedNow, excludeGlobs: readClaudeMdExcludes(claudeMdExcludeFiles(cwd, home, projectApproved), managedNow), projectRoot: repoRoot(cwd) ?? cwd }
+    }
+    const { managed, excludeGlobs, projectRoot } = envCache
     const excluded = (absPath: string): boolean => isExcludedPath(absPath, excludeGlobs, home)
-    const projectRoot = repoRoot(cwd) ?? cwd
 
     // claudeMdExcludes drops an excluded file's block from the assembled prompt and
     // from import expansion; surviving blocks get block-level comments stripped.
@@ -575,21 +611,48 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     const keptLocals = localContexts.filter((local) => !excluded(local.path)).map((local) => ({ path: local.path, content: stripBlockComments(local.content) }))
     const contextFiles = [...rewrite.kept, ...keptLocals]
 
-    // Seed with every loaded context file path, excluded ones included, so pi's own
-    // files are never re-imported and an excluded file cannot return as an import.
-    const seenSet = new Set(realRoots([...native, ...localContexts].map((file) => file.path)))
+    // Everything the expansion depends on, hashed: a turn whose inputs match the memo
+    // and whose recorded mtimes are unchanged reuses the previous expansion outright.
+    const addDirsRaw = additionalDirsClaudeMdEnabled() ? String(pi.getFlag?.('add-dir') ?? '') : ''
+    const keyHash = createHash('sha256')
+    keyHash.update(`${cwd}\0${home}\0${projectApproved}\0${addDirsRaw}\0${excludeGlobs.join(',')}\0`)
+    for (const file of [...native, ...localContexts]) keyHash.update(`${file.path}\0`)
+    for (const file of contextFiles) keyHash.update(`${file.path}\0${file.content}\0`)
+    const memoKey = keyHash.digest('hex')
 
-    // Claude's --add-dir memory loading, env-gated. The files join the seen set
-    // before import expansion so an @import cannot pull one in twice, and they get
-    // the same exclude and comment-strip treatment as native context files.
-    const addDirs = additionalDirsClaudeMdEnabled() ? parseAdditionalDirs(pi.getFlag?.('add-dir'), home, cwd) : []
-    const extras = additionalDirExtras(addDirs, seenSet, excluded, projectApproved)
+    let extras: Array<{ path: string; content: string; dir: string }>
+    let budget: ImportBudget
+    let imported: ImportedFile[]
+    if (importMemo && importMemo.key === memoKey && memoIsFresh(importMemo)) {
+      ;({ extras, budget, imported } = importMemo)
+    } else {
+      // Seed with every loaded context file path, excluded ones included, so pi's own
+      // files are never re-imported and an excluded file cannot return as an import.
+      const seenSet = new Set(realRoots([...native, ...localContexts].map((file) => file.path)))
 
-    // One budget for the whole run, so N context files cannot each spend a full one.
-    // Exclusion applies inside the recursion: an excluded @import is skipped before
-    // it is read, so its transitive imports never load and it spends no budget.
-    const budget = createImportBudget()
-    const imported = expandImports(contextFiles, extras, home, cwd, seenSet, excluded, budget)
+      // Claude's --add-dir memory loading, env-gated. The files join the seen set
+      // before import expansion so an @import cannot pull one in twice, and they get
+      // the same exclude and comment-strip treatment as native context files.
+      const addDirs = additionalDirsClaudeMdEnabled() ? parseAdditionalDirs(pi.getFlag?.('add-dir'), home, cwd) : []
+      extras = additionalDirExtras(addDirs, seenSet, excluded, projectApproved)
+
+      // One budget for the whole run, so N context files cannot each spend a full one.
+      // Exclusion applies inside the recursion: an excluded @import is skipped before
+      // it is read, so its transitive imports never load and it spends no budget.
+      budget = createImportBudget()
+      imported = expandImports(contextFiles, extras, home, cwd, seenSet, excluded, budget)
+
+      // Revalidation set: every file the expansion read, plus each add-dir itself
+      // (a directory's mtime moves when a memory file is added or removed there).
+      const tokens: Array<[string, string]> = []
+      try {
+        for (const file of [...extras.map((extra) => extra.path), ...imported.map((entry) => entry.path)]) tokens.push([file, statToken(file)])
+        for (const dir of addDirs) tokens.push([dir, statToken(dir)])
+        importMemo = { key: memoKey, extras, budget, imported, tokens }
+      } catch {
+        importMemo = undefined // a file moved mid-expansion: just recompute next turn
+      }
+    }
 
     let addition = localContextAddition(keptLocals, announce)
     addition += additionalDirsAddition(extras, announce)

--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -538,6 +538,50 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
       return false // a recorded file vanished: re-expand
     }
   }
+  // Memo lookup or recompute: a turn whose key matches the previous expansion and
+  // whose recorded stat tokens are all unchanged reuses that expansion outright;
+  // otherwise the imports are re-expanded and the memo (with a fresh revalidation
+  // set) is rebuilt for next turn.
+  const resolveImports = (
+    memoKey: string,
+    native: Array<{ path: string; content: string }>,
+    contextFiles: Array<{ path: string; content: string }>,
+    home: string,
+    cwd: string,
+    excluded: (absPath: string) => boolean,
+  ): { extras: Array<{ path: string; content: string; dir: string }>; budget: ImportBudget; imported: ImportedFile[] } => {
+    if (importMemo?.key === memoKey && memoIsFresh(importMemo)) {
+      const { extras, budget, imported } = importMemo
+      return { extras, budget, imported }
+    }
+    // Seed with every loaded context file path, excluded ones included, so pi's own
+    // files are never re-imported and an excluded file cannot return as an import.
+    const seenSet = new Set(realRoots([...native, ...localContexts].map((file) => file.path)))
+
+    // Claude's --add-dir memory loading, env-gated. The files join the seen set
+    // before import expansion so an @import cannot pull one in twice, and they get
+    // the same exclude and comment-strip treatment as native context files.
+    const addDirs = additionalDirsClaudeMdEnabled() ? parseAdditionalDirs(pi.getFlag?.('add-dir'), home, cwd) : []
+    const extras = additionalDirExtras(addDirs, seenSet, excluded, projectApproved)
+
+    // One budget for the whole run, so N context files cannot each spend a full one.
+    // Exclusion applies inside the recursion: an excluded @import is skipped before
+    // it is read, so its transitive imports never load and it spends no budget.
+    const budget = createImportBudget()
+    const imported = expandImports(contextFiles, extras, home, cwd, seenSet, excluded, budget)
+
+    // Revalidation set: every file the expansion read, plus each add-dir itself
+    // (a directory's mtime moves when a memory file is added or removed there).
+    const tokens: Array<[string, string]> = []
+    try {
+      for (const file of [...extras.map((extra) => extra.path), ...imported.map((entry) => entry.path)]) tokens.push([file, statToken(file)])
+      for (const dir of addDirs) tokens.push([dir, statToken(dir)])
+      importMemo = { key: memoKey, extras, budget, imported, tokens }
+    } catch {
+      importMemo = undefined // a file moved mid-expansion: just recompute next turn
+    }
+    return { extras, budget, imported }
+  }
 
   // Claude's --add-dir. Only the memory-loading half is meaningful here: pi has
   // no path-based permission system, so there is no access grant to mirror.
@@ -579,7 +623,7 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     const cwd = event.systemPromptOptions?.cwd ?? process.cwd()
     const native: Array<{ path: string; content: string }> = event.systemPromptOptions?.contextFiles ?? []
 
-    if (!envCache || envCache.cwd !== cwd) {
+    if (envCache?.cwd !== cwd) {
       const managedNow = readManagedSettings()
       envCache = { cwd, managed: managedNow, excludeGlobs: readClaudeMdExcludes(claudeMdExcludeFiles(cwd, home, projectApproved), managedNow), projectRoot: repoRoot(cwd) ?? cwd }
     }
@@ -620,39 +664,7 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     for (const file of contextFiles) keyHash.update(`${file.path}\0${file.content}\0`)
     const memoKey = keyHash.digest('hex')
 
-    let extras: Array<{ path: string; content: string; dir: string }>
-    let budget: ImportBudget
-    let imported: ImportedFile[]
-    if (importMemo && importMemo.key === memoKey && memoIsFresh(importMemo)) {
-      ;({ extras, budget, imported } = importMemo)
-    } else {
-      // Seed with every loaded context file path, excluded ones included, so pi's own
-      // files are never re-imported and an excluded file cannot return as an import.
-      const seenSet = new Set(realRoots([...native, ...localContexts].map((file) => file.path)))
-
-      // Claude's --add-dir memory loading, env-gated. The files join the seen set
-      // before import expansion so an @import cannot pull one in twice, and they get
-      // the same exclude and comment-strip treatment as native context files.
-      const addDirs = additionalDirsClaudeMdEnabled() ? parseAdditionalDirs(pi.getFlag?.('add-dir'), home, cwd) : []
-      extras = additionalDirExtras(addDirs, seenSet, excluded, projectApproved)
-
-      // One budget for the whole run, so N context files cannot each spend a full one.
-      // Exclusion applies inside the recursion: an excluded @import is skipped before
-      // it is read, so its transitive imports never load and it spends no budget.
-      budget = createImportBudget()
-      imported = expandImports(contextFiles, extras, home, cwd, seenSet, excluded, budget)
-
-      // Revalidation set: every file the expansion read, plus each add-dir itself
-      // (a directory's mtime moves when a memory file is added or removed there).
-      const tokens: Array<[string, string]> = []
-      try {
-        for (const file of [...extras.map((extra) => extra.path), ...imported.map((entry) => entry.path)]) tokens.push([file, statToken(file)])
-        for (const dir of addDirs) tokens.push([dir, statToken(dir)])
-        importMemo = { key: memoKey, extras, budget, imported, tokens }
-      } catch {
-        importMemo = undefined // a file moved mid-expansion: just recompute next turn
-      }
-    }
+    const { extras, budget, imported } = resolveImports(memoKey, native, contextFiles, home, cwd, excluded)
 
     let addition = localContextAddition(keptLocals, announce)
     addition += additionalDirsAddition(extras, announce)

--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -148,7 +148,11 @@ async function restoreConversation(ctx: ExtensionCommandContext, entryId: string
 
 export default function gitCheckpointExtension(pi: ExtensionAPI) {
   const checkpoints = new Map<string, Checkpoint>()
-  let pending: { ref: string; createdAt: string } | undefined
+  let pending: Promise<{ ref: string; createdAt: string } | undefined> | undefined
+  // A run (one user message) needs a single pre-run snapshot, no matter how many
+  // assistant turns it drives. before_agent_start starts a run; the first turn_start
+  // then snapshots and clears this, so turns 2..n skip the wasted git work.
+  let runNeedsSnapshot = true
   let shadowDir: string | undefined
   let workTree: string | undefined
 
@@ -258,15 +262,24 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
     }
   })
 
-  // Snapshot code state before the LLM acts in this turn. The user message
-  // that started the turn is not persisted yet at turn_start (it lands on
-  // message_end), so the checkpoint is only keyed and saved at turn_end.
+  // A new user message starts a run: the next turn_start snapshots the pre-run tree.
+  pi.on('before_agent_start', async () => {
+    runNeedsSnapshot = true
+  })
+
+  // Snapshot code state before the LLM acts, once per run. The user message that
+  // started the turn is not persisted yet at turn_start (it lands on message_end), so
+  // the checkpoint is only keyed and saved at turn_end. The snapshot is NOT awaited
+  // here: kicking it off and awaiting the promise at turn_end overlaps the git work
+  // with the model call instead of blocking it.
   pi.on('turn_start', async () => {
-    pending = await snapshot()
+    if (!runNeedsSnapshot) return
+    runNeedsSnapshot = false
+    pending = snapshot()
   })
 
   pi.on('turn_end', async (_event, ctx) => {
-    const snap = pending
+    const snap = await pending
     pending = undefined
     if (!snap) return
 

--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -148,7 +148,7 @@ async function restoreConversation(ctx: ExtensionCommandContext, entryId: string
 
 export default function gitCheckpointExtension(pi: ExtensionAPI) {
   const checkpoints = new Map<string, Checkpoint>()
-  let pending: Promise<{ ref: string; createdAt: string } | undefined> | undefined
+  let pending: { ref: string; createdAt: string } | undefined
   // A run (one user message) needs a single pre-run snapshot, no matter how many
   // assistant turns it drives. before_agent_start starts a run; the first turn_start
   // then snapshots and clears this, so turns 2..n skip the wasted git work.
@@ -262,24 +262,29 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
     }
   })
 
-  // A new user message starts a run: the next turn_start snapshots the pre-run tree.
-  pi.on('before_agent_start', async () => {
+  // A new agent loop starts a run: the next turn_start snapshots the pre-run tree.
+  // agent_start, not before_agent_start: before_agent_start does not fire for a queued
+  // follow-up message delivered through agent.continue, so gating on it would leave that
+  // follow-up's user message with no checkpoint. agent_start re-fires per agent.continue
+  // (a retry, a compaction, or a follow-up), and the extra snapshot a retry produces is
+  // discarded at turn_end, since that user message already has its checkpoint.
+  pi.on('agent_start', async () => {
     runNeedsSnapshot = true
   })
 
   // Snapshot code state before the LLM acts, once per run. The user message that
   // started the turn is not persisted yet at turn_start (it lands on message_end), so
-  // the checkpoint is only keyed and saved at turn_end. The snapshot is NOT awaited
-  // here: kicking it off and awaiting the promise at turn_end overlaps the git work
-  // with the model call instead of blocking it.
+  // the checkpoint is only keyed and saved at turn_end. The snapshot is awaited here so
+  // `git add -A` captures the tree before the model's first edit; turn_end reads the
+  // resolved value.
   pi.on('turn_start', async () => {
     if (!runNeedsSnapshot) return
     runNeedsSnapshot = false
-    pending = snapshot()
+    pending = await snapshot()
   })
 
   pi.on('turn_end', async (_event, ctx) => {
-    const snap = await pending
+    const snap = pending
     pending = undefined
     if (!snap) return
 

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -260,15 +260,23 @@ function foldName(name: string): string {
   return name.toLowerCase().replaceAll('-', '_')
 }
 
-function exactListApplies(matcher: string, names: readonly string[]): boolean {
-  const tokens = new Set(
+/** A matcher string's compiled form: a set of folded exact names, or a regex. */
+type CompiledMatcher = { tokens: Set<string> } | { regex: RegExp }
+
+function exactTokens(matcher: string): Set<string> {
+  return new Set(
     matcher
       .split(/[|,]/)
       .map((token) => foldName(token.trim()))
       .filter(Boolean),
   )
-  return names.some((name) => tokens.has(foldName(name)))
 }
+
+/** Hook config is static per session and dispatch consults every matcher on every
+ * event, so each matcher string compiles once. Matchers are few; the bound is a
+ * safety net, clearing the (cheap to rebuild) cache rather than evicting. */
+const compiledMatchers = new Map<string, CompiledMatcher>()
+const COMPILED_MATCHER_BOUND = 1000
 
 /** A matcher entry pi-code can run: an object whose `hooks` is a list. Anything else
  * is reported by name and skipped, so one bad entry costs its own hooks, not the
@@ -290,15 +298,48 @@ function isUsableMatcher(entry: unknown, file: string, event: string): entry is 
   return true
 }
 
+let matcherCompiles = 0
+
+/** Test seam: matcher compilations performed, for asserting memoization. */
+export function matcherCompileCount(): number {
+  return matcherCompiles
+}
+
+/** Test seam: drop compiled matchers so a test observes fresh compiles. */
+export function resetMatcherCache(): void {
+  compiledMatchers.clear()
+  matcherCompiles = 0
+}
+
+function compileMatcher(matcher: string): CompiledMatcher {
+  const cached = compiledMatchers.get(matcher)
+  if (cached !== undefined) return cached
+  matcherCompiles += 1
+  let compiled: CompiledMatcher
+  if (EXACT_MATCHER.test(matcher)) {
+    compiled = { tokens: exactTokens(matcher) }
+  } else {
+    try {
+      compiled = { regex: new RegExp(matcher, 'i') }
+    } catch {
+      // An invalid regex matcher falls back to exact-name matching, as before.
+      compiled = { tokens: exactTokens(matcher) }
+    }
+  }
+  if (compiledMatchers.size >= COMPILED_MATCHER_BOUND) compiledMatchers.clear()
+  compiledMatchers.set(matcher, compiled)
+  return compiled
+}
+
 function matcherApplies(matcher: string | undefined, names: readonly string[]): boolean {
   if (!matcher || matcher === '*') return true
-  if (EXACT_MATCHER.test(matcher)) return exactListApplies(matcher, names)
-  try {
-    const regex = new RegExp(matcher, 'i')
+  const compiled = compileMatcher(matcher)
+  if ('regex' in compiled) {
+    const { regex } = compiled
     return names.some((name) => regex.test(name))
-  } catch {
-    return exactListApplies(matcher, names)
   }
+  const { tokens } = compiled
+  return names.some((name) => tokens.has(foldName(name)))
 }
 
 /** A hook entry pi-code can run: a shell command, an http POST, an in-process

--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -132,6 +132,51 @@ function resolveRule(rule: string, anchors: PathAnchors): string {
   return path.join(anchors.cwd, rel)
 }
 
+/** One rule glob precompiled for repeated matching: its anchored regex, and whether
+ * it applies to the basename (a slashless pattern, gitignore-style) or the full
+ * root-relative path. */
+export interface CompiledGlob {
+  regex: RegExp
+  matchesBasename: boolean
+}
+
+let globsCompiled = 0
+let globsEvaluated = 0
+
+/** Test seam: cumulative compiled-glob work, for asserting that callers compile
+ * each glob once upfront and stop evaluating rules that no longer apply. */
+export function globCompileStats(): { compiled: number; evaluated: number } {
+  return { compiled: globsCompiled, evaluated: globsEvaluated }
+}
+
+/** Rule `paths:` globs compiled once for repeated matching, with claude-rules'
+ * pathMatchesGlobs semantics: `./` and leading `/` anchors are stripped, a trailing
+ * slash scopes to the directory's contents, and blank entries drop out. */
+export function compileGlobs(globs: string[]): CompiledGlob[] {
+  const compiled: CompiledGlob[] = []
+  for (const raw of globs) {
+    let glob = raw.trim()
+    if (!glob) continue
+    if (glob.startsWith('./')) glob = glob.slice(2)
+    else if (glob.startsWith('/')) glob = glob.slice(1)
+    // A trailing slash means the directory's contents, like gitignore; `docs/` alone
+    // would compile to `^docs/$` and match nothing.
+    if (glob.endsWith('/')) glob += '**'
+    globsCompiled += 1
+    compiled.push({ regex: new RegExp(`^${globToRegExpSource(glob)}$`), matchesBasename: !glob.includes('/') })
+  }
+  return compiled
+}
+
+/** Whether a root-relative path matches at least one compiled glob. No globs means
+ * no match. */
+export function matchesCompiledGlobs(relPath: string, globs: CompiledGlob[]): boolean {
+  globsEvaluated += 1
+  const posix = relPath.split(path.sep).join('/')
+  const base = posix.split('/').pop() ?? posix
+  return globs.some((glob) => glob.regex.test(glob.matchesBasename ? base : posix))
+}
+
 /** Whether the accessed file matches at least one rule. No rules means no match:
  * a granted-but-scoped tool with an empty scope set stays blocked, never open. */
 export function matchesPathRules(filePath: string, rules: string[], anchors: PathAnchors): boolean {

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -90,16 +90,70 @@ function pluginConfigsMap(settingsFiles: string[]): Record<string, Record<string
   return merged
 }
 
+/** Memoized discovery per (home, extra settings files), revalidated by fingerprint. */
+const pluginCache = new Map<string, { fingerprint: string; plugins: InstalledPlugin[] }>()
+
+/** Drop every memoized discovery; the next installedPlugins call walks afresh. */
+export function resetInstalledPluginsCache(): void {
+  pluginCache.clear()
+}
+
+/** mtime plus size, so a same-instant rewrite with different content still differs. */
+function statToken(target: string): string {
+  try {
+    const stat = fs.statSync(target)
+    return `${stat.mtimeMs}:${stat.size}`
+  } catch {
+    return 'missing'
+  }
+}
+
+/**
+ * A cheap change signature for one home's plugin config: the settings files' stat
+ * tokens plus the cache tree's directory names and mtimes down through each plugin's
+ * version directories, and the stat token of the resolved (newest) version's manifest
+ * so an in-place edit of it invalidates the cache. Costs a few stats where the full
+ * walk reads and parses the settings and every manifest.
+ */
+function pluginFingerprint(cacheDir: string, settingsFiles: string[]): string {
+  const parts = settingsFiles.map(statToken)
+  for (const marketplace of listDirs(cacheDir)) {
+    const marketplaceDir = path.join(cacheDir, marketplace)
+    parts.push(`${marketplace}:${statToken(marketplaceDir)}`)
+    for (const pluginDir of listDirs(marketplaceDir)) {
+      const pluginPath = path.join(marketplaceDir, pluginDir)
+      parts.push(`${marketplace}/${pluginDir}:${statToken(pluginPath)}`)
+      const versions = listDirs(pluginPath)
+      for (const version of versions) {
+        parts.push(`${marketplace}/${pluginDir}/${version}:${statToken(path.join(pluginPath, version))}`)
+      }
+      // resolvePlugin reads only the newest version's manifest, so its stat token is
+      // what an in-place edit (no directory entry changing) must move.
+      const newest = newestVersion(versions)
+      if (newest) parts.push(`${marketplace}/${pluginDir}/${newest}/manifest:${statToken(path.join(pluginPath, newest, '.claude-plugin', 'plugin.json'))}`)
+    }
+  }
+  return parts.join('\n')
+}
+
 /**
  * Enabled plugins from the cache. Enablement is decided by the user's own
  * settings only: plugins install to the user's machine and carry code (hook
  * scripts, MCP server commands), so a checked-out repo must not be able to flip
  * which of them run. `extraSettingsFiles`, when given, are additional
  * user-controlled settings sources, not project files.
+ *
+ * Several extensions call this at session start and per discovery, so the walk
+ * is memoized behind the fingerprint above; callers always see current data
+ * because any settings edit or cache-tree change invalidates it.
  */
 export function installedPlugins(home: string, extraSettingsFiles: string[] = []): InstalledPlugin[] {
   const cacheDir = path.join(home, '.claude', 'plugins', 'cache')
   const settingsFiles = [path.join(home, '.claude', 'settings.json'), ...extraSettingsFiles]
+  const key = [home, ...extraSettingsFiles].join('\n')
+  const fingerprint = pluginFingerprint(cacheDir, settingsFiles)
+  const cached = pluginCache.get(key)
+  if (cached && cached.fingerprint === fingerprint) return cached.plugins
   const enabled = enabledMap(settingsFiles)
   const configs = pluginConfigsMap(settingsFiles)
   const plugins: InstalledPlugin[] = []
@@ -109,6 +163,7 @@ export function installedPlugins(home: string, extraSettingsFiles: string[] = []
       if (plugin) plugins.push(plugin)
     }
   }
+  pluginCache.set(key, { fingerprint, plugins })
   return plugins
 }
 

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -153,7 +153,7 @@ export function installedPlugins(home: string, extraSettingsFiles: string[] = []
   const key = [home, ...extraSettingsFiles].join('\n')
   const fingerprint = pluginFingerprint(cacheDir, settingsFiles)
   const cached = pluginCache.get(key)
-  if (cached && cached.fingerprint === fingerprint) return cached.plugins
+  if (cached?.fingerprint === fingerprint) return cached.plugins
   const enabled = enabledMap(settingsFiles)
   const configs = pluginConfigsMap(settingsFiles)
   const plugins: InstalledPlugin[] = []

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -649,6 +649,23 @@ type HttpFamilyTransport = SSEClientTransport | StreamableHTTPClientTransport //
 
 type MakeTransport = (authProvider?: OAuthClientProvider) => HttpFamilyTransport
 
+/** Interactive OAuth logins block on a confirm dialog and open a browser tab, so two
+ * at once (a user-scope and a consented project-scope server both 401ing, connecting in
+ * parallel) would stack dialogs and browser tabs. This chains them so a second
+ * interactive login waits for the first to settle; the tail is reset to a resolved
+ * promise regardless of outcome, so a failed login never poisons the queue. Silent
+ * (stored-token) connects do not pass through here and stay fully parallel. */
+let oauthQueue: Promise<unknown> = Promise.resolve()
+
+function serializeInteractiveOAuth<T>(run: () => Promise<T>): Promise<T> {
+  const result = oauthQueue.then(run, run)
+  oauthQueue = result.then(
+    () => {},
+    () => {},
+  )
+  return result
+}
+
 /**
  * Connect an http-family server, running Claude's OAuth login when the server
  * demands one. Stored tokens ride the first attempt so the SDK refreshes
@@ -671,7 +688,7 @@ async function connectHttpFamily(name: string, config: { url: string }, makeTran
   } catch (error) {
     if (bearerToken || !isUnauthorized(error)) throw error
     if (!authUi) throw new OAuthRequiredError(`${name} requires a login; run pi interactively to authenticate`)
-    return await runInteractiveOAuth(name, config, makeTransport, label, authUi, newClient)
+    return await serializeInteractiveOAuth(() => runInteractiveOAuth(name, config, makeTransport, label, authUi, newClient))
   }
 }
 
@@ -1113,17 +1130,11 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     )
   }
 
-  /** Connect the project scope under the per-server policy. Returns whether the scope
-   * is settled, so a refused confirm can be retried on a later session start. */
-  async function connectProjectScope(ctx: ExtensionContext): Promise<boolean> {
-    // The stored decision, read without prompting: consent recorded inside the
-    // project only counts once the project itself has been approved.
-    const approved = isProjectApprovedSilently(ctx)
-    const policy = projectServerPolicy(ctx.cwd, os.homedir(), approved)
-    const { allowed, denied } = mcpAllowDeny()
-    const { consented, gated } = splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), allowed, denied), policy)
-    const authUi = authUiFor(ctx)
-    if (Object.keys(consented).length > 0) await connectServers(consented, authUi)
+  /** Connect the approval-gated project servers, behind the whole-project confirm.
+   * Returns whether the scope is settled, so a refused confirm can be retried on a
+   * later session start. The consented half of the project scope connects earlier,
+   * concurrently with the user scope, from session_start itself. */
+  async function connectGatedProjectServers(ctx: ExtensionContext, gated: Record<string, ServerConfig>, authUi?: AuthUi): Promise<boolean> {
     if (Object.keys(gated).length === 0) return true
     if (!(await isProjectApproved(ctx))) return false
     await connectServers(gated, authUi)
@@ -1148,16 +1159,28 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // entry cannot shadow a trusted user server by reusing its name. A gated project
     // server still awaiting the approval prompt does not preempt the user server: that is
     // a deliberate narrowing of Claude's rule to keep the safe default.
+    // The stored project decision, read without prompting: consent recorded inside
+    // the project only counts once the project itself has been approved.
     const projectPolicy = projectServerPolicy(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
-    const projectWinners = new Set(Object.keys(splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), allowed, denied), projectPolicy).consented))
+    const { consented, gated } = splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), allowed, denied), projectPolicy)
+    const projectWinners = new Set(Object.keys(consented))
     const userServers = Object.fromEntries(Object.entries(scoped).filter(([name]) => !clients.has(name) && !projectWinners.has(name)))
-    if (Object.keys(userServers).length > 0) await connectServers(userServers, authUiFor(ctx))
+    const authUi = authUiFor(ctx)
+    // The consented project servers carry no ordering dependency on the user scope:
+    // projectWinners already excludes their names from userServers, so the two batches
+    // are disjoint and connect concurrently, and startup pays the slower scope rather
+    // than the sum of both. Reconnect attempts after a refused confirm are safe:
+    // connectServers skips names that already connected.
+    const connects: Promise<void>[] = []
+    if (Object.keys(userServers).length > 0) connects.push(connectServers(userServers, authUi))
+    if (!projectConnected && Object.keys(consented).length > 0) connects.push(connectServers(consented, authUi))
+    await Promise.all(connects)
     // A project .mcp.json can run arbitrary commands on connect, so only honor it once
     // the project is trusted. Per-server settings refine that: disabled servers never
-    // connect, servers the user consented to individually connect without the
-    // whole-project confirm, and the rest stay behind it. Reconnect attempts after a
-    // refusal are safe: connectServers skips names that already connected.
-    if (!projectConnected) projectConnected = await connectProjectScope(ctx)
+    // connect, servers the user consented to individually connected above without the
+    // whole-project confirm, and the rest stay behind it, sequentially after both
+    // scopes so the confirm dialog never races a connect.
+    if (!projectConnected) projectConnected = await connectGatedProjectServers(ctx, gated, authUi)
 
     pi.events.emit(MCP_TOOLS_CHANNEL, [...aliases])
 

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -327,7 +327,7 @@ export default function memoryExtension(pi: ExtensionAPI) {
 
   const readIndexCached = (): string => {
     const token = indexStatToken()
-    if (indexCache === null || indexCache.token !== token) indexCache = { token, index: readIndexQuietly(dir) }
+    if (indexCache?.token !== token) indexCache = { token, index: readIndexQuietly(dir) }
     return indexCache.index
   }
 

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -310,6 +310,27 @@ export default function memoryExtension(pi: ExtensionAPI) {
   let dir = memoryDir(process.cwd())
   let enabled = true
 
+  // The index is injected every turn but changes only through the tool or an external
+  // edit, so a turn costs one stat instead of a full read. The stat token (mtime plus
+  // size) catches external edits; save and delete drop the cache outright, since a
+  // rename landing within one mtime tick at the same size would slip past the token.
+  let indexCache: { token: string; index: string } | null = null
+
+  const indexStatToken = (): string => {
+    try {
+      const stat = fs.statSync(path.join(dir, INDEX_FILE))
+      return `${stat.mtimeMs}:${stat.size}`
+    } catch {
+      return 'missing'
+    }
+  }
+
+  const readIndexCached = (): string => {
+    const token = indexStatToken()
+    if (indexCache === null || indexCache.token !== token) indexCache = { token, index: readIndexQuietly(dir) }
+    return indexCache.index
+  }
+
   // These extensions also load inside spawned subagent processes, which carry the
   // PI_CODE_SUBAGENT marker. Claude does not load the main conversation's auto memory
   // into subagents (they get their own store through the agent `memory:` field), so
@@ -325,6 +346,7 @@ export default function memoryExtension(pi: ExtensionAPI) {
     enabled = autoMemoryEnabled(settings.autoMemoryEnabled, process.env)
     const override = typeof settings.autoMemoryDirectory === 'string' ? settings.autoMemoryDirectory : undefined
     dir = enabled ? resolveMemoryDir(ctx.cwd, override) : memoryDir(ctx.cwd)
+    indexCache = null
     if (!enabled) return
     const count = readIndexQuietly(dir)
       .split('\n')
@@ -334,7 +356,7 @@ export default function memoryExtension(pi: ExtensionAPI) {
 
   pi.on('before_agent_start', async (event) => {
     if (inSubagent() || !enabled) return
-    const index = readIndexQuietly(dir)
+    const index = readIndexCached()
     if (!index.trim()) return
     return {
       systemPrompt: `${event.systemPrompt}\n\n## Memory\n\nPersistent memories from earlier sessions (index):\n\n${capIndexForPrompt(index)}\nUse the memory tool with action "read" to load a memory's full content when relevant.`,
@@ -362,6 +384,8 @@ export default function memoryExtension(pi: ExtensionAPI) {
           return await saveMemory(dir, indexPath, name, params.description, params.content)
         } catch (error) {
           return { content: [{ type: 'text' as const, text: `Memory save failed: ${error instanceof Error ? error.message : String(error)}. The index was left untouched.` }], details: {} }
+        } finally {
+          indexCache = null
         }
       }
 
@@ -372,7 +396,13 @@ export default function memoryExtension(pi: ExtensionAPI) {
 
       if (params.action === 'delete') {
         if (!name) return { content: [{ type: 'text' as const, text: 'delete requires name.' }], details: {} }
-        return deleteMemory(dir, indexPath, name)
+        // In a finally like the save path: a delete that throws mid-write must still
+        // drop the cache, or the next turn injects a stale index.
+        try {
+          return await deleteMemory(dir, indexPath, name)
+        } finally {
+          indexCache = null
+        }
       }
 
       const index = readIndexQuietly(dir)

--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -13,8 +13,10 @@
  * the built-in segment stands in.
  *
  * Without a configured statusLine, the built-in segment shows turn state plus
- * running session cost, summed from per-message usage on the current branch so it
- * stays correct across /tree navigation and forks. The built-in segment is also
+ * running session cost: a total seeded from the branch's per-message usage at
+ * session start, accumulated per message_end, and reseeded when compaction or
+ * /tree navigation reshapes the branch, so it stays correct across navigation
+ * and forks without re-walking the branch on every render. The built-in segment is also
  * the fallback while a configured command produces no output. Multi-line output
  * is truncated to its first line: the segment is one footer row in pi.
  *
@@ -48,6 +50,8 @@ interface UsageEntry {
   message?: { usage?: { cost?: { total?: number } } }
 }
 
+/** Full branch walk: used only to (re)seed the running total, at session start
+ * and on the events that reshape the branch. Renders read the total instead. */
 function sessionCost(ctx: ExtensionContext): number {
   let total = 0
   for (const entry of ctx.sessionManager.getBranch() as UsageEntry[]) {
@@ -95,8 +99,17 @@ export default function statusLine(pi: ExtensionAPI) {
   let sessionCtx: ExtensionContext | undefined
   let commandLine: string | undefined
   let permissionMode = 'default'
-  let projectApproved = false
   let sessionStartMs = Date.now()
+  // Running session cost; seeded and reseeded by sessionCost(), see below.
+  let costTotal = 0
+  // The output-style settings chain and active style name, resolved once at
+  // session start: the chain's upward walk and per-file reads are too costly for
+  // every refresh tick. /output-style persists a choice straight to settings with
+  // no bus event, and the new style applies from the next turn anyway, so the
+  // cached name is re-read lazily at most once per turn (styleDirty, turn_start).
+  let styleFiles: string[] = []
+  let styleName: string | undefined
+  let styleDirty = false
   // Lines changed, counted from successful edit/write inputs: newText and content
   // lines add, oldText lines remove. An approximation of Claude's counters, which
   // is honest for the tools pi has; bash-side changes are invisible to both.
@@ -114,8 +127,7 @@ export default function statusLine(pi: ExtensionAPI) {
 
   function segmentText(ctx: ExtensionContext, symbol: string): string {
     const theme = ctx.ui.theme
-    const cost = sessionCost(ctx)
-    const costText = cost > 0 ? theme.fg('muted', ` ${formatCost(cost)}`) : ''
+    const costText = costTotal > 0 ? theme.fg('muted', ` ${formatCost(costTotal)}`) : ''
     const turnText = turnCount > 0 ? theme.fg('dim', ` turn ${turnCount}`) : theme.fg('dim', ' ready')
     return symbol + turnText + costText
   }
@@ -128,9 +140,11 @@ export default function statusLine(pi: ExtensionAPI) {
   function buildPayload(ctx: ExtensionContext): Record<string, unknown> {
     const usage = ctx.getContextUsage() ?? { tokens: null, contextWindow: 0, percent: null }
     const model = ctx.model as { id?: string; name?: string } | undefined
-    // Same gate as the config read above: an unapproved project's style is not applied,
-    // so reporting it here would describe a style the session is not using.
-    const styleName = readActiveStyleName(settingsFiles(ctx.cwd, os.homedir(), projectApproved))
+    // Refresh the cached style name only when a turn boundary may have changed it.
+    if (styleDirty) {
+      styleName = readActiveStyleName(styleFiles)
+      styleDirty = false
+    }
     const payload: Record<string, unknown> = {
       hook_event_name: 'Status',
       session_id: ctx.sessionManager.getSessionId(),
@@ -141,7 +155,7 @@ export default function statusLine(pi: ExtensionAPI) {
       // read .model.display_name and render the literal "null" when it is missing.
       model: { id: model?.id ?? '', display_name: model?.name ?? model?.id ?? '' },
       cost: {
-        total_cost_usd: sessionCost(ctx),
+        total_cost_usd: costTotal,
         total_duration_ms: Date.now() - sessionStartMs,
         total_api_duration_ms: apiDurationMs,
         total_lines_added: linesAdded,
@@ -250,10 +264,13 @@ export default function statusLine(pi: ExtensionAPI) {
     if (requestStartMs !== undefined) apiDurationMs += Date.now() - requestStartMs
     requestStartMs = undefined
   })
-  // The last message's token usage, for the breakdown getContextUsage() omits.
+  // The last message's token usage, for the breakdown getContextUsage() omits,
+  // and the running cost total, so renders never re-walk the branch.
   pi.on('message_end', async (event) => {
-    const usage = (event as { message?: { usage?: NonNullable<typeof lastUsage> } }).message?.usage
-    if (usage) lastUsage = usage
+    const usage = (event as { message?: { usage?: NonNullable<typeof lastUsage> & { cost?: { total?: number } } } }).message?.usage
+    if (!usage) return
+    lastUsage = usage
+    costTotal += usage.cost?.total ?? 0
   })
 
   pi.on('session_start', async (_event, ctx) => {
@@ -268,11 +285,18 @@ export default function statusLine(pi: ExtensionAPI) {
     requestStartMs = undefined
     lastUsage = undefined
     clearInterval(refreshTimer)
+    // Seed the running cost from the branch: a resumed or forked session starts
+    // with history, and message_end only accumulates from here on.
+    costTotal = sessionCost(ctx)
     // Reading config must never open a trust dialog: several extensions resolve
     // approval at session start, and a second prompt stacks over the first and eats
     // the keys meant for it. An undecided project simply skips project settings.
     const trusted = isProjectApprovedSilently(ctx)
-    projectApproved = trusted
+    // Same gate for the style chain: an unapproved project's style is not applied,
+    // so reporting it in the payload would describe a style the session is not using.
+    styleFiles = settingsFiles(ctx.cwd, os.homedir(), trusted)
+    styleName = readActiveStyleName(styleFiles)
+    styleDirty = false
     const files = hookFiles(ctx.cwd, os.homedir(), trusted)
     // Claude's disableAllHooks also turns off the custom statusLine command; the
     // built-in segment still renders as the fallback.
@@ -286,6 +310,9 @@ export default function statusLine(pi: ExtensionAPI) {
 
   pi.on('turn_start', async (_event, ctx) => {
     turnCount++
+    // A /output-style between turns lands in settings silently; its style applies
+    // from this turn, so this is the moment the cached name can go stale.
+    styleDirty = true
     const theme = ctx.ui.theme
     show(ctx, theme.fg('accent', '●') + theme.fg('dim', ` turn ${turnCount}...`))
   })
@@ -300,8 +327,15 @@ export default function statusLine(pi: ExtensionAPI) {
     scheduleRefresh()
   })
 
-  pi.on('session_compact', async (_event, _ctx) => {
+  pi.on('session_compact', async (_event, ctx) => {
+    // Compaction replaces the branch entries; reseed the total from what remains.
+    costTotal = sessionCost(ctx)
     scheduleRefresh()
+  })
+
+  pi.on('session_tree', async (_event, ctx) => {
+    // Tree navigation swaps the branch wholesale with no message_end events.
+    costTotal = sessionCost(ctx)
   })
 
   pi.on('session_shutdown', async () => {

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -1352,7 +1352,16 @@ export default function subagentExtension(pi: ExtensionAPI) {
   // available model list are captured per session so a hook run lands in the right repo.
   let hookCwd = process.cwd()
   let hookModels: ReadonlyArray<{ id: string }> = []
+
+  // Discovery walks the plugin cache, the builtin dir, and every agent dir, parsing
+  // each file: dozens of fs ops per call. The roster injection below runs every turn
+  // for a list that almost never changes mid-session, so it reuses one discovery per
+  // (cwd, scope), dropped on session_start. The tool's execute() keeps rediscovering
+  // per invocation, so a just-added agent is still runnable without a restart.
+  let rosterCache: { key: string; agents: AgentConfig[] } | null = null
+
   pi.on('session_start', async (_event, ctx) => {
+    rosterCache = null
     hookCwd = ctx.cwd
     try {
       hookModels = ctx.modelRegistry?.getAvailable?.() ?? []
@@ -1378,12 +1387,15 @@ export default function subagentExtension(pi: ExtensionAPI) {
   })
 
   // Claude surfaces each agent's description so the model can pick one autonomously.
-  // Rebuilt per turn (agents are rediscovered per invocation too); project agents are
-  // included only when the project is already approved, read without prompting, since
-  // a trust dialog must not appear mid-turn and their descriptions are project text.
+  // Served from the session-level cache above (keyed on cwd and scope, so an approval
+  // granted mid-session still widens it); project agents are included only when the
+  // project is already approved, read without prompting, since a trust dialog must
+  // not appear mid-turn and their descriptions are project text.
   pi.on('before_agent_start', async (event, ctx) => {
-    const scope = isProjectApprovedSilently(ctx) ? 'both' : 'user'
-    const { agents } = discoverAgents(ctx.cwd, scope)
+    const scope: AgentScope = isProjectApprovedSilently(ctx) ? 'both' : 'user'
+    const key = `${scope}\n${ctx.cwd}`
+    if (rosterCache?.key !== key) rosterCache = { key, agents: discoverAgents(ctx.cwd, scope).agents }
+    const { agents } = rosterCache
     if (agents.length === 0) return
     const line = (text: string): string => text.replace(/\s+/g, ' ').trim().slice(0, 200)
     const roster = agents.map((agent) => `- ${agent.name} (${agent.source}): ${line(agent.description)}`).join('\n')

--- a/tests/claude-rules.test.ts
+++ b/tests/claude-rules.test.ts
@@ -4,8 +4,9 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import claudeRules, { formatRulePointer, parseFrontmatter, pathMatchesGlobs } from '../extensions/claude-rules.ts'
+import claudeRules, { formatRulePointer, parseFrontmatter, pathMatchesGlobs, pendingScopedRuleCount } from '../extensions/claude-rules.ts'
 import { INSTRUCTIONS_CHANNEL } from '../extensions/internal/instruction-events.ts'
+import { globCompileStats } from '../extensions/internal/path-rules.ts'
 
 // Global rules load from the home directory; point it at a throwaway dir so the
 // developer's real ~/.claude/rules cannot influence assertions.
@@ -160,6 +161,43 @@ describe('extension wiring', () => {
 
     const edited = await handlers.get('tool_result')?.({ toolName: 'edit', input: { path: 'db/schema.sql' }, content: [], isError: false }, { cwd })
     expect(injectedTexts(edited).join('\n')).toContain('Use parameterized queries.')
+  })
+
+  it('compiles scoped-rule globs once at session start, not on every tool result', async () => {
+    const cwd = projectWithRule('---\npaths:\n  - "db/**"\n---\nUse parameterized queries.')
+    const handlers = wire()
+    const before = globCompileStats().compiled
+    await handlers.get('session_start')?.({}, approvedCtx(cwd))
+    expect(globCompileStats().compiled - before).toBe(1)
+
+    await handlers.get('tool_result')?.(readResult('src/a.ts'), { cwd })
+    await handlers.get('tool_result')?.(readResult('src/b.ts'), { cwd })
+    await handlers.get('tool_result')?.(readResult('src/c.ts'), { cwd })
+    expect(globCompileStats().compiled - before).toBe(1)
+  })
+
+  it('drops a fully attached rule from the working list so later touches skip it', async () => {
+    const cwd = projectWithRule('---\npaths:\n  - "db/**"\n---\nUse parameterized queries.')
+    writeFileSync(join(cwd, '.claude', 'rules', 'docs.md'), '---\npaths:\n  - "docs/**"\n---\nKeep docs current.')
+    const handlers = wire()
+    await handlers.get('session_start')?.({}, approvedCtx(cwd))
+    expect(pendingScopedRuleCount()).toBe(2)
+
+    await handlers.get('tool_result')?.(readResult('db/schema.sql'), { cwd })
+    expect(pendingScopedRuleCount()).toBe(1)
+
+    // Only the docs rule is still pending, so this touch evaluates one rule, not two.
+    const evaluated = globCompileStats().evaluated
+    await handlers.get('tool_result')?.(readResult('db/other.sql'), { cwd })
+    expect(globCompileStats().evaluated - evaluated).toBe(1)
+
+    await handlers.get('tool_result')?.(readResult('docs/readme.md'), { cwd })
+    expect(pendingScopedRuleCount()).toBe(0)
+
+    // With every rule attached, a later touch compiles and evaluates nothing.
+    const done = globCompileStats()
+    await handlers.get('tool_result')?.(readResult('db/third.sql'), { cwd })
+    expect(globCompileStats()).toEqual(done)
   })
 
   it('strips block comments from an inlined rule body', async () => {

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -915,6 +915,67 @@ describe('--add-dir additional directories', () => {
     const prompt = await wire(extra).fire(tempDir())
 
     expect(prompt).not.toContain('EXTRA DIR RULES')
+  })
+
+  it('reuses the expanded imports across turns until an imported file actually changes', async () => {
+    // before_agent_start fires every turn; re-reading and re-recursing every @import
+    // per turn is wasted I/O when nothing changed. The expansion is memoized and
+    // validated by mtime: an edit that bumps the mtime is picked up, and the memo
+    // serves the run when mtimes are unchanged.
+    const cwd = tempDir()
+    writeFileSync(join(cwd, 'extra.md'), 'ORIGINAL IMPORT BODY')
+    // Pin the mtime to a whole second: the filesystem stores sub-ms precision that
+    // utimesSync cannot reproduce, and the memo compares mtimeMs exactly.
+    const pinned = new Date(Math.floor(Date.now() / 1000) * 1000)
+    utimesSync(join(cwd, 'extra.md'), pinned, pinned)
+    const files = [{ path: join(cwd, 'CLAUDE.md'), content: 'Rules.\n@extra.md' }]
+    const handlers = new Map<string, (event: unknown) => Promise<unknown>>()
+    contextImports({ on: (name: string, fn: (event: unknown) => Promise<unknown>) => handlers.set(name, fn) } as never)
+    const fireOnce = async () => (await handlers.get('before_agent_start')?.({ systemPrompt: 'BASE', systemPromptOptions: { cwd, contextFiles: files } })) as { systemPrompt: string } | undefined
+
+    const first = await fireOnce()
+    expect(first?.systemPrompt).toContain('ORIGINAL IMPORT BODY')
+
+    // Rewrite the import with the SAME mtime AND the same byte length: the stat token
+    // (mtime plus size) is unchanged, so the memo must serve the cached body (this is
+    // the perf property under test; a per-turn re-read would see the edit). A
+    // different-length edit would trip the size half of the token, covered separately.
+    const sameLengthEdit = 'SILENT SAME EDIT'.padEnd('ORIGINAL IMPORT BODY'.length, '.')
+    expect(Buffer.byteLength(sameLengthEdit)).toBe(Buffer.byteLength('ORIGINAL IMPORT BODY'))
+    writeFileSync(join(cwd, 'extra.md'), sameLengthEdit)
+    utimesSync(join(cwd, 'extra.md'), pinned, pinned)
+    const second = await fireOnce()
+    expect(second?.systemPrompt).toContain('ORIGINAL IMPORT BODY')
+    expect(second?.systemPrompt).not.toContain(sameLengthEdit)
+
+    // An edit that bumps the mtime invalidates the memo and is picked up.
+    writeFileSync(join(cwd, 'extra.md'), 'UPDATED IMPORT BODY')
+    utimesSync(join(cwd, 'extra.md'), new Date(Date.now() + 5000), new Date(Date.now() + 5000))
+    const third = await fireOnce()
+    expect(third?.systemPrompt).toContain('UPDATED IMPORT BODY')
+  })
+
+  it('invalidates the memo when an imported file changes size at the same mtime', async () => {
+    // The memo revalidates on mtime AND size, like memory.ts's stat token: a
+    // length-changing rewrite that lands within one mtime tick would otherwise be
+    // served stale. Pin the same whole-second mtime across the edit so only the size
+    // differs, and the memo must still invalidate.
+    const cwd = tempDir()
+    writeFileSync(join(cwd, 'extra.md'), 'SHORT BODY')
+    const pinned = new Date(Math.floor(Date.now() / 1000) * 1000)
+    utimesSync(join(cwd, 'extra.md'), pinned, pinned)
+    const files = [{ path: join(cwd, 'CLAUDE.md'), content: 'Rules.\n@extra.md' }]
+    const handlers = new Map<string, (event: unknown) => Promise<unknown>>()
+    contextImports({ on: (name: string, fn: (event: unknown) => Promise<unknown>) => handlers.set(name, fn) } as never)
+    const fireOnce = async () => (await handlers.get('before_agent_start')?.({ systemPrompt: 'BASE', systemPromptOptions: { cwd, contextFiles: files } })) as { systemPrompt: string } | undefined
+
+    const first = await fireOnce()
+    expect(first?.systemPrompt).toContain('SHORT BODY')
+
+    writeFileSync(join(cwd, 'extra.md'), 'A MUCH LONGER REPLACEMENT BODY')
+    utimesSync(join(cwd, 'extra.md'), pinned, pinned)
+    const second = await fireOnce()
+    expect(second?.systemPrompt).toContain('A MUCH LONGER REPLACEMENT BODY')
   })
 
   it('publishes session_start and include instruction events once per session', async () => {

--- a/tests/git-checkpoint-more.test.ts
+++ b/tests/git-checkpoint-more.test.ts
@@ -688,6 +688,7 @@ describe('resume from a different working directory', () => {
     const t = setup()
     const { other } = await resumeElsewhere(t)
 
+    await t.handlers.get('before_agent_start')?.({}, t.makeCtx({ cwd: other }))
     await t.handlers.get('turn_start')?.({ turnIndex: 1 }, t.makeCtx({ cwd: other }))
     await t.handlers.get('turn_end')?.({ turnIndex: 1 }, t.makeCtx({ cwd: other, branch: [messageEntry('user0002', 'work here')] }))
     expect(t.appended).toHaveLength(2)

--- a/tests/git-checkpoint-more.test.ts
+++ b/tests/git-checkpoint-more.test.ts
@@ -688,7 +688,7 @@ describe('resume from a different working directory', () => {
     const t = setup()
     const { other } = await resumeElsewhere(t)
 
-    await t.handlers.get('before_agent_start')?.({}, t.makeCtx({ cwd: other }))
+    await t.handlers.get('agent_start')?.({}, t.makeCtx({ cwd: other }))
     await t.handlers.get('turn_start')?.({ turnIndex: 1 }, t.makeCtx({ cwd: other }))
     await t.handlers.get('turn_end')?.({ turnIndex: 1 }, t.makeCtx({ cwd: other, branch: [messageEntry('user0002', 'work here')] }))
     expect(t.appended).toHaveLength(2)

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -158,13 +158,25 @@ describe('shadow-repo checkpoint lifecycle', () => {
     expect(t.appended).toHaveLength(1)
   })
 
+  it('awaits the pre-run snapshot in turn_start so it captures the tree before the model acts', async () => {
+    // The snapshot must capture the tree before the model's first edit, so turn_start
+    // awaits it to completion rather than deferring the git work to turn_end. By the
+    // time turn_start resolves, the commit has run; an un-awaited kickoff would still
+    // be mid-flight, having reached only `git add -A`.
+    const t = setup()
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx([], [], []))
+    await t.handlers.get('turn_start')?.({ turnIndex: 0 }, t.makeCtx([], [], []))
+
+    expect(t.execLog.some((c) => c[0] === 'git' && c.includes('commit'))).toBe(true)
+  })
+
   it('snapshots once per run, not once per turn, and still records the checkpoint', async () => {
     // A `git add -A` before every assistant turn (awaited, so it blocks the model call)
     // is wasted when the run has already checkpointed the pre-run tree; snapshot once per
-    // run (gated by before_agent_start) instead.
+    // run (gated by agent_start) instead.
     const t = setup()
     await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx([], [], []))
-    await t.handlers.get('before_agent_start')?.({}, t.makeCtx([], [], []))
+    await t.handlers.get('agent_start')?.({}, t.makeCtx([], [], []))
     await t.handlers.get('turn_start')?.({ turnIndex: 0 }, t.makeCtx([], [], []))
     await t.handlers.get('turn_end')?.({ turnIndex: 0 }, t.makeCtx([], [userEntry], []))
     await t.handlers.get('turn_start')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry], []))
@@ -182,7 +194,7 @@ describe('shadow-repo checkpoint lifecycle', () => {
     // A distinct prompt in a new run gets past the per-entry dedupe, so the snapshot
     // runs again; with an untouched work tree it must resolve to the same commit.
     const secondPrompt = { ...userEntry, id: 'user0002', message: { role: 'user', content: 'now add a regression test for it' } }
-    await t.handlers.get('before_agent_start')?.({}, t.makeCtx([], [], []))
+    await t.handlers.get('agent_start')?.({}, t.makeCtx([], [], []))
     await t.handlers.get('turn_start')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry, secondPrompt], []))
     await t.handlers.get('turn_end')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry, secondPrompt], []))
 

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -42,6 +42,7 @@ function setup() {
   const commands = new Map<string, { handler: (args: string, ctx: any) => Promise<void> }>()
   const appended: Array<{ type: string; customType: string; data: any }> = []
   const notifications: string[] = []
+  const execLog: string[][] = []
 
   const repo = mkdtempSync(join(tmpdir(), 'gcs-test-'))
   hoisted.home = mkdtempSync(join(tmpdir(), 'gcs-home-'))
@@ -57,6 +58,7 @@ function setup() {
     registerCommand: (name: string, opts: any) => commands.set(name, opts),
     appendEntry: (customType: string, data: any) => appended.push({ type: 'custom', customType, data }),
     exec: async (cmd: string, args: string[], options?: { cwd?: string }) => {
+      execLog.push([cmd, ...args])
       try {
         return { stdout: execFileSync(cmd, args, { cwd: options?.cwd ?? repo, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }), stderr: '', code: 0, killed: false }
       } catch (err: any) {
@@ -77,7 +79,7 @@ function setup() {
     navigateTree: async () => ({ editorText: 'restored prompt', cancelled: false }),
   })
 
-  return { handlers, commands, appended, notifications, repo, makeCtx }
+  return { handlers, commands, appended, notifications, execLog, repo, makeCtx }
 }
 
 type Harness = ReturnType<typeof setup>
@@ -156,13 +158,31 @@ describe('shadow-repo checkpoint lifecycle', () => {
     expect(t.appended).toHaveLength(1)
   })
 
+  it('snapshots once per run, not once per turn, and still records the checkpoint', async () => {
+    // A `git add -A` before every assistant turn (awaited, so it blocks the model call)
+    // is wasted when the run has already checkpointed the pre-run tree; snapshot once per
+    // run (gated by before_agent_start) instead.
+    const t = setup()
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx([], [], []))
+    await t.handlers.get('before_agent_start')?.({}, t.makeCtx([], [], []))
+    await t.handlers.get('turn_start')?.({ turnIndex: 0 }, t.makeCtx([], [], []))
+    await t.handlers.get('turn_end')?.({ turnIndex: 0 }, t.makeCtx([], [userEntry], []))
+    await t.handlers.get('turn_start')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry], []))
+    await t.handlers.get('turn_end')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry], []))
+
+    const addCalls = t.execLog.filter((c) => c[0] === 'git' && c.includes('add') && c.includes('-A')).length
+    expect(addCalls).toBe(1)
+    expect(t.appended).toHaveLength(1)
+  })
+
   it('reuses the existing HEAD ref when the tree has not changed', async () => {
     const t = setup()
     await checkpointOneTurn(t, 0)
 
-    // A distinct prompt gets past the per-entry dedupe, so the snapshot runs
-    // again; with an untouched work tree it must resolve to the same commit.
+    // A distinct prompt in a new run gets past the per-entry dedupe, so the snapshot
+    // runs again; with an untouched work tree it must resolve to the same commit.
     const secondPrompt = { ...userEntry, id: 'user0002', message: { role: 'user', content: 'now add a regression test for it' } }
+    await t.handlers.get('before_agent_start')?.({}, t.makeCtx([], [], []))
     await t.handlers.get('turn_start')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry, secondPrompt], []))
     await t.handlers.get('turn_end')?.({ turnIndex: 1 }, t.makeCtx([], [userEntry, secondPrompt], []))
 

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -5,7 +5,26 @@ import { join } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { formatHooksSummary, type HookRunner, hookFiles, httpUrlAllowed, interpretHookResult, lastAssistantText, loadHooks, matchingCommands, readAllowedHttpHookUrls, readDisableAllHooks, runAgentHook, runHookCommand, runHttpHook, runMcpToolHook, runPreToolUse, runPromptHook } from '../extensions/hooks.ts'
+import {
+  formatHooksSummary,
+  type HookRunner,
+  hookFiles,
+  httpUrlAllowed,
+  interpretHookResult,
+  lastAssistantText,
+  loadHooks,
+  matcherCompileCount,
+  matchingCommands,
+  readAllowedHttpHookUrls,
+  readDisableAllHooks,
+  resetMatcherCache,
+  runAgentHook,
+  runHookCommand,
+  runHttpHook,
+  runMcpToolHook,
+  runPreToolUse,
+  runPromptHook,
+} from '../extensions/hooks.ts'
 import { setAgentRunner } from '../extensions/internal/agent-run.ts'
 import { setMcpToolCaller } from '../extensions/internal/mcp-call.ts'
 import { setCompleteBackend } from '../extensions/internal/model-complete.ts'
@@ -386,6 +405,39 @@ describe('matchingCommands', () => {
     expect(matchingCommands([hook], 'startup')).toEqual([{ command: 'setup.sh' }])
     expect(matchingCommands([hook], 'resume')).toEqual([])
     expect(matchingCommands([hook], '')).toEqual([])
+  })
+})
+
+describe('matcher compilation', () => {
+  it('compiles each distinct matcher once across repeated dispatches, not once per event', () => {
+    resetMatcherCache()
+    const matchers = [
+      { matcher: 'Edit, Write', hooks: [{ command: 'fmt' }] },
+      { matcher: 'Edit.*', hooks: [{ command: 'lint' }] },
+    ]
+    for (let i = 0; i < 5; i += 1) {
+      expect(matchingCommands(matchers, 'write').map((hook) => hook.command)).toEqual(['fmt'])
+      expect(matchingCommands(matchers, 'notebookedit').map((hook) => hook.command)).toEqual(['lint'])
+    }
+    expect(matcherCompileCount()).toBe(2)
+  })
+
+  it('memoizes the exact-list fallback of an invalid regex without changing its outcome', () => {
+    resetMatcherCache()
+    // `Bash(, Edit` fails the exact-matcher shape and does not compile as a regex,
+    // so it falls back to exact-name matching on its comma-split tokens.
+    const invalid = [{ matcher: 'Bash(, Edit', hooks: [{ command: 'guard.sh' }] }]
+    for (let i = 0; i < 5; i += 1) {
+      expect(matchingCommands(invalid, 'edit')).toEqual([{ command: 'guard.sh' }])
+      expect(matchingCommands(invalid, 'bash')).toEqual([])
+    }
+    expect(matcherCompileCount()).toBe(1)
+  })
+
+  it('does not compile an absent or wildcard matcher', () => {
+    resetMatcherCache()
+    matchingCommands([{ hooks: [{ command: 'a' }] }, { matcher: '*', hooks: [{ command: 'b' }] }], 'anything')
+    expect(matcherCompileCount()).toBe(0)
   })
 })
 

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -211,7 +211,7 @@ const writeServers = (file: string, servers: Record<string, unknown>): void => {
 }
 
 /** Boots a fresh extension instance against temp-dir user/project config. */
-const setup = async (opts: { user?: Record<string, unknown>; project?: Record<string, unknown> } = {}): Promise<Harness> => {
+const setup = async (opts: { user?: Record<string, unknown>; project?: Record<string, unknown>; confirm?: () => Promise<boolean> } = {}): Promise<Harness> => {
   const home = mkdtempSync(join(tmpdir(), 'mcp-home-'))
   const cwd = mkdtempSync(join(tmpdir(), 'mcp-proj-'))
   tempDirs.push(home, cwd)
@@ -239,7 +239,7 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
     hasUI: true,
     ui: {
       notify: (message: string, level: string) => notifications.push({ message, level }),
-      confirm: async () => approve,
+      confirm: opts.confirm ?? (async () => approve),
     },
     isProjectTrusted: trusted === undefined ? undefined : () => trusted,
     isIdle: () => idle,
@@ -462,6 +462,33 @@ describe('mcp startup config scoping', () => {
 
     expect(harness.toolNames()).toEqual(['proj_query'])
     expect(hoisted.transports).toHaveLength(1)
+  })
+
+  it('initiates the user scope and consented project scope connects concurrently', async () => {
+    withTools([{ name: 'go' }])
+    // Defer every connect: neither resolves until the test releases it, so the
+    // assertion below observes which transports exist while both are still pending.
+    const release = new Map<string, () => void>()
+    hoisted.control.connect = (transport) =>
+      new Promise<void>((resolve) => {
+        release.set(String(transport.options.command), resolve)
+      })
+    const harness = await setup({ user: { local: { command: 'user-server' } }, project: { proj: { command: 'proj-server' } } })
+    mkdirSync(join(harness.home, '.claude'), { recursive: true })
+    writeFileSync(join(harness.home, '.claude', 'settings.json'), JSON.stringify({ enabledMcpjsonServers: ['proj'] }))
+
+    const started = harness.sessionStart(true)
+    // Drain microtasks without resolving either connect. The consented project server
+    // has no ordering dependency on the user scope, so its transport must already be
+    // constructed instead of waiting behind the unresolved user connect.
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    expect(hoisted.transports.map((t) => t.options.command).sort()).toEqual(['proj-server', 'user-server'])
+
+    release.get('user-server')?.()
+    release.get('proj-server')?.()
+    await started
+    expect(harness.toolNames().sort()).toEqual(['local_go', 'proj_go'])
+    expect(hoisted.transports).toHaveLength(2)
   })
 })
 
@@ -717,6 +744,48 @@ describe('mcp transport selection', () => {
     const [line] = await statusLinesOf(harness)
     expect(line.startsWith('remote: failed: ')).toBe(true)
     expect(line.endsWith(' (0 tools)')).toBe(true)
+  })
+})
+
+describe('interactive OAuth serialization', () => {
+  it('runs interactive OAuth logins one at a time, and both servers still connect', async () => {
+    // The user scope and consented project scope connect concurrently, so two servers
+    // that both 401 would otherwise pop two confirm dialogs and open two browser tabs
+    // at once. The interactive flow is serialized: the second confirm must not fire
+    // until the first login settles. Silent connects stay parallel.
+    withTools([{ name: 'go' }])
+    // A silent connect (no authProvider) 401s; the interactive retry carries an
+    // authProvider, so it succeeds and the server ends connected.
+    hoisted.control.connect = async (transport) => {
+      if ((transport.options as { authProvider?: unknown }).authProvider === undefined) {
+        throw Object.assign(new Error('needs login'), { code: 401 })
+      }
+    }
+
+    let confirmCount = 0
+    let releaseFirst!: (value: boolean) => void
+    const firstGate = new Promise<boolean>((resolve) => {
+      releaseFirst = resolve
+    })
+    const confirm = async (): Promise<boolean> => {
+      confirmCount++
+      return confirmCount === 1 ? firstGate : true
+    }
+
+    const harness = await setup({ user: { alpha: { url: 'https://alpha.example/mcp' }, beta: { url: 'https://beta.example/mcp' } }, confirm })
+    const started = harness.sessionStart()
+
+    // Both silent connects 401 in parallel and both reach the interactive stage, but
+    // only the first login's confirm has fired; the second is queued behind it.
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(confirmCount).toBe(1)
+
+    releaseFirst(true)
+    await started
+
+    // The queued login proceeded once the first settled, and both servers connected.
+    expect(confirmCount).toBe(2)
+    expect(harness.toolNames().sort()).toEqual(['alpha_go', 'beta_go'])
   })
 })
 

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -11,6 +11,18 @@ vi.mock('node:os', async (importOriginal) => {
   return { ...actual, homedir: () => hoisted.home || actual.homedir() }
 })
 
+// Records every readFileSync path, so the index-cache test can count index reads.
+// The builtin namespace is not spyable either, so the module is wrapped like os.
+const fsHoisted = vi.hoisted(() => ({ reads: [] as string[] }))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  const readFileSync = ((...args: Parameters<typeof actual.readFileSync>) => {
+    fsHoisted.reads.push(String(args[0]))
+    return actual.readFileSync(...args)
+  }) as typeof actual.readFileSync
+  return { ...actual, readFileSync }
+})
+
 import memoryExtension, { autoMemoryEnabled, capIndexForPrompt, INDEX_MAX_BYTES, INDEX_MAX_LINES, indexWouldOverflow, memoryDir, migrateLegacyStore, projectSlug, removeIndexLine, resolveMemoryDir, slugifyName, stampModified, stripNonLoaded, upsertIndexLine } from '../extensions/memory.ts'
 
 describe('memory helpers', () => {
@@ -297,6 +309,42 @@ describe('memory extension', () => {
       if (savedMarker === undefined) delete process.env.PI_CODE_SUBAGENT
       else process.env.PI_CODE_SUBAGENT = savedMarker
     }
+  })
+
+  it('reads the index once across turns, re-reading only after a change', async () => {
+    const cwd = cwdDir()
+    const dir = memoryDir(cwd)
+    mkdirSync(dir, { recursive: true })
+    const indexPath = join(dir, 'MEMORY.md')
+    writeFileSync(indexPath, '# Memory index\n- [a](a.md): first\n')
+
+    const { handlers, getTool } = wire()
+    await handlers.get('session_start')?.({}, ctxFor(cwd))
+
+    const indexReads = () => fsHoisted.reads.filter((p) => p === indexPath).length
+    const mark = indexReads()
+    for (let i = 0; i < 3; i++) {
+      const injected = (await handlers.get('before_agent_start')?.({ systemPrompt: 'BASE' }, {})) as { systemPrompt: string }
+      expect(injected.systemPrompt).toContain('- [a](a.md): first')
+    }
+    // One read for the first turn; the later turns revalidate with a stat only.
+    expect(indexReads()).toBe(mark + 1)
+
+    // A save invalidates the cache, so the next turn carries the new entry.
+    await getTool().execute('id', { action: 'save', name: 'b', description: 'second', content: 'body' })
+    const afterSave = (await handlers.get('before_agent_start')?.({ systemPrompt: 'BASE' }, {})) as { systemPrompt: string }
+    expect(afterSave.systemPrompt).toContain('- [b](b.md): second')
+
+    // An external rewrite (different size) is caught by the stat gate.
+    writeFileSync(indexPath, '# Memory index\n- [c](c.md): replaced externally\n')
+    const afterEdit = (await handlers.get('before_agent_start')?.({ systemPrompt: 'BASE' }, {})) as { systemPrompt: string }
+    expect(afterEdit.systemPrompt).toContain('- [c](c.md): replaced externally')
+    expect(afterEdit.systemPrompt).not.toContain('- [b](b.md)')
+
+    // The delete invalidates too: the next turn no longer lists the removed entry.
+    await getTool().execute('id', { action: 'delete', name: 'c' })
+    const afterDelete = (await handlers.get('before_agent_start')?.({ systemPrompt: 'BASE' }, {})) as { systemPrompt: string }
+    expect(afterDelete.systemPrompt).not.toContain('- [c](c.md)')
   })
 
   it('stamps a modified timestamp when saving a memory that has frontmatter', async () => {

--- a/tests/path-rules.test.ts
+++ b/tests/path-rules.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { globToRegExpSource, matchesPathRules } from '../extensions/internal/path-rules.ts'
+import { compileGlobs, globCompileStats, globToRegExpSource, matchesCompiledGlobs, matchesPathRules } from '../extensions/internal/path-rules.ts'
 
 const anchors = { cwd: '/repo/app', projectRoot: '/repo', home: '/home/alex' }
 
@@ -86,5 +86,25 @@ describe('brace expansion', () => {
     expect(overRegExp.test('abcd.ts')).toBe(false)
     const atLimit = `${group.repeat(3)}.ts` // exactly 1000, still expands
     expect(new RegExp(`^${globToRegExpSource(atLimit)}$`).test('adg.ts')).toBe(true)
+  })
+})
+
+describe('compileGlobs', () => {
+  it('compiles each glob once; matching compiled globs performs no further compilation', () => {
+    const before = globCompileStats().compiled
+    const compiled = compileGlobs(['db/**', '*.sql', 'docs/'])
+    expect(globCompileStats().compiled - before).toBe(3)
+    expect(matchesCompiledGlobs('db/schema.sql', compiled)).toBe(true)
+    expect(matchesCompiledGlobs('lib/deep/x.sql', compiled)).toBe(true)
+    expect(matchesCompiledGlobs('docs/api/v1.md', compiled)).toBe(true)
+    expect(matchesCompiledGlobs('src/app.ts', compiled)).toBe(false)
+    expect(globCompileStats().compiled - before).toBe(3)
+  })
+
+  it('matches like pathMatchesGlobs: anchors stripped, blank globs dropped, no globs match nothing', () => {
+    expect(matchesCompiledGlobs('src/app.ts', compileGlobs(['./src/**']))).toBe(true)
+    expect(matchesCompiledGlobs('src/app.ts', compileGlobs(['/src/**']))).toBe(true)
+    expect(compileGlobs(['', '   '])).toEqual([])
+    expect(matchesCompiledGlobs('anything', [])).toBe(false)
   })
 })

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -1,10 +1,22 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { installedPlugins, substitutePluginVars } from '../extensions/internal/plugins.ts'
+// Counts file reads so the cache tests can assert a repeat call re-reads nothing.
+// The builtin namespace is not spyable, so the module is wrapped instead, like os.
+const fsHoisted = vi.hoisted(() => ({ reads: 0 }))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  const readFileSync = ((...args: Parameters<typeof actual.readFileSync>) => {
+    fsHoisted.reads++
+    return actual.readFileSync(...args)
+  }) as typeof actual.readFileSync
+  return { ...actual, readFileSync }
+})
+
+import { installedPlugins, resetInstalledPluginsCache, substitutePluginVars } from '../extensions/internal/plugins.ts'
 
 describe('substitutePluginVars user_config', () => {
   const plugin = { name: 'p', root: '/r', dataDir: '/d', manifest: {}, userConfig: { token: 'secret-x', region: 'eu' } }
@@ -87,5 +99,73 @@ describe('installedPlugins', () => {
     // sources) is user settings alone, and no surface passes a project file.
     expect(installedPlugins(h, [join(later, 'settings.json')])).toEqual([])
     expect(installedPlugins(h)).toHaveLength(1)
+  })
+})
+
+describe('installedPlugins cache', () => {
+  it('serves a repeat call without re-reading settings or manifests', () => {
+    const h = home()
+    install(h, 'community', 'formatter', '1.0.0')
+    enable(h, { formatter: true })
+    const first = installedPlugins(h)
+    expect(first).toHaveLength(1)
+
+    const mark = fsHoisted.reads
+    expect(installedPlugins(h)).toEqual(first)
+    // The walk is memoized; a repeat call revalidates with stats, not file reads.
+    expect(fsHoisted.reads).toBe(mark)
+  })
+
+  it('re-reads after resetInstalledPluginsCache', () => {
+    const h = home()
+    install(h, 'community', 'formatter', '1.0.0')
+    enable(h, { formatter: true })
+    installedPlugins(h)
+
+    resetInstalledPluginsCache()
+    const mark = fsHoisted.reads
+    expect(installedPlugins(h)).toHaveLength(1)
+    expect(fsHoisted.reads).toBeGreaterThan(mark)
+  })
+
+  it('sees a settings edit on the next call', () => {
+    const h = home()
+    install(h, 'community', 'formatter', '1.0.0')
+    enable(h, { formatter: true })
+    expect(installedPlugins(h)).toHaveLength(1)
+
+    enable(h, { formatter: false })
+    expect(installedPlugins(h)).toEqual([])
+  })
+
+  it('sees a plugin installed under an existing marketplace on the next call', () => {
+    const h = home()
+    install(h, 'community', 'formatter', '1.0.0')
+    enable(h, { formatter: true, linter: true })
+    expect(installedPlugins(h)).toHaveLength(1)
+
+    install(h, 'community', 'linter', '1.0.0')
+    expect(
+      installedPlugins(h)
+        .map((p) => p.name)
+        .sort(),
+    ).toEqual(['formatter', 'linter'])
+  })
+
+  it('sees an in-place edit of the resolved manifest on the next call', () => {
+    const h = home()
+    const dir = install(h, 'community', 'formatter', '1.0.0', { displayName: 'Original' })
+    enable(h, { formatter: true })
+    expect(installedPlugins(h)[0].manifest.displayName).toBe('Original')
+
+    // Rewrite plugin.json in place: no cache-tree directory entry changes, so only a
+    // fingerprint that stats the manifest itself can notice. Pin a distinct mtime so
+    // the stat token differs even for a same-instant rewrite.
+    const manifest = join(dir, '.claude-plugin', 'plugin.json')
+    writeFileSync(manifest, JSON.stringify({ name: 'formatter', displayName: 'Edited' }))
+    const future = new Date(Date.now() + 5000)
+    utimesSync(manifest, future, future)
+
+    expect(installedPlugins(h)[0].manifest.displayName).toBe('Edited')
   })
 })

--- a/tests/status-line-command.test.ts
+++ b/tests/status-line-command.test.ts
@@ -7,11 +7,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setManagedSettingsPath } from '../extensions/internal/managed-settings.ts'
 import statusLine, { readStatusLineConfig } from '../extensions/status-line.ts'
 
-const hoisted = vi.hoisted(() => ({ home: '', runs: [] as Array<{ command: string; payload: unknown }>, result: { code: 0, stdout: '', stderr: '', timedOut: false }, gate: undefined as Promise<void> | undefined }))
+const hoisted = vi.hoisted(() => ({ home: '', runs: [] as Array<{ command: string; payload: unknown }>, result: { code: 0, stdout: '', stderr: '', timedOut: false }, gate: undefined as Promise<void> | undefined, fsReads: [] as string[] }))
 
 vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:os')>()
   return { ...actual, homedir: () => hoisted.home }
+})
+
+// Pass-through readFileSync that records every path, so tests can assert the
+// settings chain is not re-read per refresh (deterministic, no wall-clock).
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  const readFileSync = (...args: Parameters<typeof actual.readFileSync>) => {
+    hoisted.fsReads.push(String(args[0]))
+    return actual.readFileSync(...args)
+  }
+  return { ...actual, readFileSync: readFileSync as typeof actual.readFileSync }
 })
 
 vi.mock('../extensions/hooks.js', async (importOriginal) => {
@@ -48,6 +59,7 @@ beforeEach(() => {
   hoisted.runs.length = 0
   hoisted.result = { code: 0, stdout: '', stderr: '', timedOut: false }
   hoisted.gate = undefined
+  hoisted.fsReads.length = 0
   // Hermetic managed settings: the disableAllHooks read must never resolve to this
   // machine's real policy file.
   setManagedSettingsPath(join(hoisted.home, 'managed-settings.json'))
@@ -338,5 +350,53 @@ describe('statusLine model payload', () => {
     await vi.advanceTimersByTimeAsync(400)
 
     expect((hoisted.runs[0].payload as { model: { display_name: string } }).model.display_name).toBe('bare-id')
+  })
+})
+
+describe('statusLine settings caching', () => {
+  const styleOf = (run: { payload: unknown } | undefined) => (run?.payload as { output_style?: { name: string } } | undefined)?.output_style?.name
+  const settingsReads = () => hoisted.fsReads.filter((p) => p.includes('settings')).length
+
+  it('does not re-read the settings chain on interval refreshes', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh', refreshInterval: 1 }, outputStyle: 'Explanatory' })
+    hoisted.result = { code: 0, stdout: 'seg', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(hoisted.runs).toHaveLength(1)
+    expect(styleOf(hoisted.runs[0])).toBe('Explanatory')
+
+    // Three interval ticks, each debounced into a command run: the style name and
+    // the resolved settings-file list come from the session cache, not the disk.
+    const afterFirstRun = settingsReads()
+    await vi.advanceTimersByTimeAsync(3400)
+    expect(hoisted.runs.length).toBeGreaterThan(1)
+    expect(settingsReads()).toBe(afterFirstRun)
+    await handlers.get('session_shutdown')?.({}, ctx)
+  })
+
+  it('re-reads the active style at the next turn, not on refreshes between turns', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' }, outputStyle: 'Explanatory' })
+    hoisted.result = { code: 0, stdout: 'seg', stderr: '', timedOut: false }
+    const { handlers, busHandlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(styleOf(hoisted.runs.at(-1))).toBe('Explanatory')
+
+    // /output-style persists straight to settings with no bus event, and the new
+    // style applies from the next turn; a refresh between turns keeps the old name.
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' }, outputStyle: 'Terse' })
+    busHandlers.get('pi-code:plan-mode')?.({ active: true })
+    await vi.advanceTimersByTimeAsync(400)
+    expect(styleOf(hoisted.runs.at(-1))).toBe('Explanatory')
+
+    await handlers.get('turn_start')?.({}, ctx)
+    await handlers.get('turn_end')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(styleOf(hoisted.runs.at(-1))).toBe('Terse')
   })
 })

--- a/tests/status-line.test.ts
+++ b/tests/status-line.test.ts
@@ -28,11 +28,13 @@ function setup() {
     cwd: mkdtempSync(join(tmpdir(), 'sl-cwd-')),
     isProjectTrusted: () => true,
     ui: { theme, setStatus: (_key: string, text: string) => status.push(text), confirm: async () => true, notify: () => {} },
-    sessionManager: { getBranch: () => branch, getSessionId: () => 's', getSessionFile: () => undefined },
+    sessionManager: { getBranch: vi.fn(() => branch), getSessionId: () => 's', getSessionFile: () => undefined },
     getContextUsage: () => ({ tokens: 0, contextWindow: 0, percent: 0 }),
   })
   return { handlers, status, makeCtx }
 }
+
+const usageEntry = (total: number) => ({ type: 'message', message: { usage: { cost: { total } } } })
 
 describe('status-line', () => {
   it('shows "ready" with no turns or cost at session start', async () => {
@@ -50,19 +52,54 @@ describe('status-line', () => {
   })
 
   it('sums session cost from branch usage and formats it to cents', async () => {
+    // The branch is walked once at session start (a resumed or forked session
+    // carries history); renders reuse the running total.
     const { handlers, status, makeCtx } = setup()
-    const branch = [
-      { type: 'message', message: { usage: { cost: { total: 0.5 } } } },
-      { type: 'message', message: { usage: { cost: { total: 0.25 } } } },
-    ]
-    await handlers.get('turn_end')?.({}, makeCtx(branch))
+    const ctx = makeCtx([usageEntry(0.5), usageEntry(0.25)])
+    await handlers.get('session_start')?.({}, ctx)
+    await handlers.get('turn_end')?.({}, ctx)
     expect(status.at(-1)).toContain('$0.75')
   })
 
   it('uses four decimals for sub-cent costs', async () => {
     const { handlers, status, makeCtx } = setup()
-    await handlers.get('turn_end')?.({}, makeCtx([{ type: 'message', message: { usage: { cost: { total: 0.0012 } } } }]))
+    const ctx = makeCtx([usageEntry(0.0012)])
+    await handlers.get('session_start')?.({}, ctx)
+    await handlers.get('turn_end')?.({}, ctx)
     expect(status.at(-1)).toContain('$0.0012')
+  })
+
+  it('accumulates cost from message_end usage without re-walking the branch per render', async () => {
+    const { handlers, status, makeCtx } = setup()
+    const ctx = makeCtx([])
+    await handlers.get('session_start')?.({}, ctx)
+    await handlers.get('message_end')?.({ type: 'message_end', message: { usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15, cost: { total: 0.5 } } } }, ctx)
+    await handlers.get('turn_end')?.({}, ctx)
+    expect(status.at(-1)).toContain('$0.50')
+    await handlers.get('message_end')?.({ type: 'message_end', message: { usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15, cost: { total: 0.25 } } } }, ctx)
+    await handlers.get('agent_end')?.({}, ctx)
+    expect(status.at(-1)).toContain('$0.75')
+    // Only the session_start seed touched the branch; renders must not walk it.
+    expect(ctx.sessionManager.getBranch.mock.calls.length).toBe(1)
+  })
+
+  it('reseeds the cost from the branch when compaction or tree navigation reshapes it', async () => {
+    const { handlers, status, makeCtx } = setup()
+    const branch = [usageEntry(0.75)]
+    const ctx = makeCtx(branch)
+    await handlers.get('session_start')?.({}, ctx)
+    // Compaction replaces the branch; the running total must follow it, not double.
+    branch.splice(0, branch.length, usageEntry(0.1))
+    await handlers.get('session_compact')?.({ reason: 'manual' }, ctx)
+    await handlers.get('turn_end')?.({}, ctx)
+    expect(status.at(-1)).toContain('$0.10')
+    // Tree navigation swaps the branch wholesale with no message_end events.
+    branch.push(usageEntry(0.05))
+    await handlers.get('session_tree')?.({ newLeafId: null, oldLeafId: null }, ctx)
+    await handlers.get('agent_end')?.({}, ctx)
+    expect(status.at(-1)).toContain('$0.15')
+    // One walk per reshaping event (start, compact, tree), none per render.
+    expect(ctx.sessionManager.getBranch.mock.calls.length).toBe(3)
   })
 
   it('keeps the running turn count after agent_end', async () => {

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -1045,6 +1045,31 @@ describe('agent roster', () => {
     // Discovery is module-mocked here; builtin discovery is covered in the agents suite.
     expect(result.systemPrompt).toMatch(/- scout \(user\): /)
   })
+
+  it('discovers the roster once and reuses it across turns until the next session', async () => {
+    discoverAgentsMock.mockClear()
+    for (let i = 0; i < 3; i++) {
+      const result = (await eventHandlers.get('before_agent_start')?.({ systemPrompt: 'BASE' }, trustedCtx)) as { systemPrompt: string }
+      expect(result.systemPrompt).toContain('## Subagents')
+    }
+    expect(discoverAgentsMock).toHaveBeenCalledTimes(1)
+
+    // A new session drops the cache, so an agent added between sessions shows up.
+    await eventHandlers.get('session_start')?.({}, { cwd: '/repo', modelRegistry: { getAvailable: () => [] } })
+    await eventHandlers.get('before_agent_start')?.({ systemPrompt: 'BASE' }, trustedCtx)
+    expect(discoverAgentsMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps per-invocation discovery in execute() while the roster is cached', async () => {
+    discoverAgentsMock.mockClear()
+    await eventHandlers.get('before_agent_start')?.({ systemPrompt: 'BASE' }, trustedCtx)
+    expect(discoverAgentsMock).toHaveBeenCalledTimes(1)
+
+    // Mid-session freshness matters for actual runs: the tool still rediscovers per call.
+    await execute('c1', { status: true }, undefined, undefined, trustedCtx)
+    await execute('c2', { status: true }, undefined, undefined, trustedCtx)
+    expect(discoverAgentsMock).toHaveBeenCalledTimes(3)
+  })
 })
 
 describe('single mode', () => {


### PR DESCRIPTION
## Summary

Cuts the redundant work a performance audit found on the pack's hot paths, each fix pinned by a deterministic test that counts the underlying calls (git invocations, file reads, regex compilations) rather than wall clock. `npm run check` is green at 1547 tests, 96% statements and 91% branches. An adversarial review pass reshaped two fixes, noted below.

The largest win is checkpointing: `turn_start` ran `git add -A` over the whole working tree and awaited it before every assistant turn, then discarded the result whenever the run had already checkpointed. It now snapshots once per run, gated on `agent_start` (which also fires for queued follow-up messages, so those keep getting their own checkpoint), and the snapshot is still awaited so it is guaranteed to capture the tree before the model's first edit; the review caught that overlapping it with the turn traded away that guarantee.

Context imports cache the settings-derived environment (managed settings, exclude globs, repo root) per session and memoize the whole import expansion, revalidated per imported file by an mtime-and-size stat token; a turn where nothing changed costs a handful of stats instead of re-reading and re-recursing every `@import`. The statusline resolves its settings chain and active output style once per session with a lazy once-per-turn re-read, and accumulates session cost incrementally from `message_end` instead of walking the entire branch on every render. The subagent roster, installed plugins, and the memory index are cached the same stat-token way; the review caught that the plugin fingerprint missed in-place manifest edits, and it now stats the version directories and the resolved manifest too. Hook matchers and rule path-globs compile once per config instead of per dispatch, and a fully attached rule drops out of the per-tool-result loop.

MCP session start connects the user scope and the consented project scope concurrently instead of back to back, so startup pays the slower of the two rather than their sum; approval-gated project servers still wait for the confirm, and interactive OAuth logins are serialized so two login dialogs cannot appear at once.

Staleness semantics are deliberate: caches serve at most what Claude Code's own load-once-per-session behavior would, and everything that can change mid-session revalidates by stat token or re-reads at the next turn boundary.
