### PR TITLE
Add settings env, CLAUDE_CONFIG_DIR, CLAUDE.md scopes, and command parity

### DIFF
--- a/extensions/claude-rules.ts
+++ b/extensions/claude-rules.ts
@@ -21,6 +21,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
+import { claudeConfigDir } from './internal/config-dir.js'
 import { publishInstructionLoad } from './internal/instruction-events.js'
 import { type CompiledGlob, compileGlobs, matchesCompiledGlobs } from './internal/path-rules.js'
 import { isProjectApproved } from './internal/project-approval.js'
@@ -210,7 +211,7 @@ export function pendingScopedRuleCount(): number {
 }
 
 export default function claudeRulesExtension(pi: ExtensionAPI) {
-  const globalRulesDir = path.join(os.homedir(), '.claude', 'rules')
+  const globalRulesDir = path.join(claudeConfigDir(os.homedir()), 'rules')
   let globalRules: RuleSet = EMPTY_RULES
   let projectRules: RuleSet = EMPTY_RULES
   // The base a scoped-rule pointer is written against, so the model's read resolves.

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -45,6 +45,7 @@ import { Type } from 'typebox'
 
 import { matchesBashRules } from './internal/bash-rules.js'
 import { type CommandExec, type DiscoveredCommand, discoverCommandFiles, expandDynamicContent, type ParsedCommand, parseCommandFile, resolvePowershellBinary, spanExec, substituteArgsDetailed, substituteVars } from './internal/command-file.js'
+import { claudeConfigDir } from './internal/config-dir.js'
 import { readManagedSettings } from './internal/managed-settings.js'
 import { capForContext } from './internal/output-guard.js'
 import { matchesPathRules } from './internal/path-rules.js'
@@ -115,7 +116,7 @@ function isDirectory(target: string): boolean {
  * directory is the nearest at or above cwd (bounded at the repository root, matching
  * the approval walk) and is included only for approved projects. */
 export function commandDirs(cwd: string, home: string, trusted: boolean): string[] {
-  const candidates = [path.join(home, '.claude', 'commands')]
+  const candidates = [path.join(claudeConfigDir(home), 'commands')]
   if (trusted) candidates.push(findNearestDir(cwd, path.join('.claude', 'commands')) ?? path.join(cwd, '.claude', 'commands'))
   const dirs: string[] = []
   for (const dir of candidates) {
@@ -165,7 +166,7 @@ type CommandPlugin = NonNullable<DiscoveredCommand['plugin']>
  */
 export function shellExecutionDisabled(cwd: string, home: string, trusted: boolean): boolean {
   if (readManagedSettings().disableSkillShellExecution === true) return true
-  const files = [path.join(home, '.claude', 'settings.json')]
+  const files = [path.join(claudeConfigDir(home), 'settings.json')]
   if (trusted) {
     for (const name of ['settings.json', 'settings.local.json']) {
       files.push(findNearestFile(cwd, path.join('.claude', name)) ?? path.join(cwd, '.claude', name))
@@ -244,6 +245,8 @@ export interface SlashCommandEntry {
   name: string
   description: string
   argumentHint?: string
+  /** `when_to_use:` trigger text, appended to this entry's line in the tool listing. */
+  whenToUse?: string
 }
 
 /** One listed command's cap inside the tool description, as Claude cuts an
@@ -271,7 +274,10 @@ export function slashCommandToolDescription(commands: SlashCommandEntry[], budge
   let omitted = 0
   for (const command of commands) {
     const hintSuffix = command.argumentHint ? ` (${command.argumentHint})` : ''
-    const entry = `/${command.name} - ${command.description}${hintSuffix}`.slice(0, ENTRY_CHAR_CAP)
+    // when_to_use is model-facing trigger text, appended after the description and before
+    // the argument hint; it shares the per-entry cap and never reaches the user surface.
+    const whenSuffix = command.whenToUse ? ` ${command.whenToUse}` : ''
+    const entry = `/${command.name} - ${command.description}${whenSuffix}${hintSuffix}`.slice(0, ENTRY_CHAR_CAP)
     if (used + entry.length + 1 > budget) {
       omitted++
       continue // a shorter later entry may still fit the remaining budget
@@ -303,6 +309,8 @@ export default function commandsExtension(pi: ExtensionAPI) {
   let pendingPathRules: Partial<Record<PathRuleTool, string[]>> | undefined
   /** The session model to restore after a command's `model:` override drove its run. */
   let pendingModelRestore: ModelLike | undefined
+  /** The thinking level to restore after a command's `effort:` override drove its run. */
+  let pendingEffortRestore: string | undefined
 
   // Claude's contract is "the grant clears when you send your next message", and
   // pi's turn_end fires after every assistant step: restoring there stripped a
@@ -322,6 +330,11 @@ export default function commandsExtension(pi: ExtensionAPI) {
       // escape as unhandled; surface it instead of leaving the session silently on the
       // command's override model.
       void pi.setModel(restore).catch(() => {})
+    }
+    if (pendingEffortRestore) {
+      const level = pendingEffortRestore as Parameters<typeof pi.setThinkingLevel>[0]
+      pendingEffortRestore = undefined
+      pi.setThinkingLevel(level)
     }
     if (pendingRestore) {
       pi.setActiveTools(pendingRestore)
@@ -404,6 +417,19 @@ export default function commandsExtension(pi: ExtensionAPI) {
     }
   }
 
+  /** Claude's `effort:` frontmatter overrides the thinking level for this run only, then
+   * the session level resumes; restore happens on agent_settled like the model restore.
+   * Applied before sendUserMessage so the run it drives happens at the new level. Only the
+   * first override in a turn records the restore target, so a second command restores to
+   * the original session level rather than the first command's override (as pendingModelRestore). */
+  function applyEffortOverride(parsed: ParsedCommand, varCtx: VarContext): void {
+    const target = parsed.effort
+    if (target && varCtx.thinkingLevel && target !== varCtx.thinkingLevel) {
+      pendingEffortRestore = pendingEffortRestore ?? varCtx.thinkingLevel
+      pi.setThinkingLevel(target as Parameters<typeof pi.setThinkingLevel>[0])
+    }
+  }
+
   async function runCommand(parsed: ParsedCommand, args: string, ctx: ExtensionCommandContext, filePath: string, plugin?: CommandPlugin): Promise<void> {
     const varCtx = ctx as unknown as VarContext
     const vars = commandVars(ctx, filePath, plugin)
@@ -435,6 +461,7 @@ export default function commandsExtension(pi: ExtensionAPI) {
     applyAllowedTools(parsed, vars)
     applyDisallowedTools(parsed)
     await applyModelOverride(parsed, varCtx)
+    applyEffortOverride(parsed, varCtx)
     pi.sendUserMessage(expanded)
   }
 
@@ -463,7 +490,11 @@ export default function commandsExtension(pi: ExtensionAPI) {
       discovered.set(command.name, command)
       // A user-only command stays off the tool description; it is still in the
       // map so a model attempt gets the explicit refusal, not "unknown command".
-      if (!parsed.disableModelInvocation) invocable.push({ name: command.name, description: parsed.description, argumentHint: parsed.argumentHint })
+      if (!parsed.disableModelInvocation) invocable.push({ name: command.name, description: parsed.description, argumentHint: parsed.argumentHint, whenToUse: parsed.whenToUse })
+      // user-invocable:false is the inverse of disable-model-invocation: the command is
+      // hidden from the user slash-command surface but stays in `discovered` and the tool
+      // description above, so the model can still run it through the slash_command tool.
+      if (!parsed.userInvocable) continue
       // pi has no unregister, so a command already registered this process keeps its
       // original file binding; re-registering would only add a numbered duplicate.
       if (registered.has(command.name)) continue

--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -541,6 +541,64 @@ function importedAddition(imported: ImportedFile[], budget: ImportBudget, home: 
   return `\n\n## Imported context (@)\n\n${section}${notice}`
 }
 
+/** Prepend the managed and user memory blocks Claude loads ahead of pi's native project
+ * context, top to bottom: managed file, managed key, then the user CLAUDE.md. withTopBlock
+ * prepends, so they are inserted bottom-up (user, then managed key, then managed file just
+ * below) to land in that order. keptUser was already exclude-checked and comment-stripped by
+ * the caller like every other file; the managed claudeMd is never excludable and comes from
+ * two managed-only surfaces, the settings key (ignored in user/project settings) and the file
+ * IT deploys beside managed-settings.json, re-read every turn so a policy change applies
+ * immediately (only its announce is deduped per session). Returns the grown prompt, whether
+ * anything was added, and the managed file body (reused for the import memo key). */
+function prependMemoryBlocks(prompt: string, changed: boolean, keptUser: { path: string; content: string } | undefined, managed: Record<string, unknown>, announce: (event: InstructionLoadEvent) => void): { prompt: string; changed: boolean; managedFile: string } {
+  if (keptUser !== undefined && keptUser.content.trim().length > 0) {
+    prompt = withTopBlock(prompt, instructionsBlock(keptUser.path, keptUser.content.trim()))
+    changed = true
+    announce({ file_path: keptUser.path, memory_type: 'User', load_reason: 'session_start' })
+  }
+  const managedKey = typeof managed.claudeMd === 'string' ? stripBlockComments(managed.claudeMd).trim() : ''
+  if (managedKey.length > 0) {
+    prompt = withTopBlock(prompt, instructionsBlock(MANAGED_CLAUDE_MD_PATH, managedKey))
+    changed = true
+  }
+  const managedFile = stripBlockComments(readManagedClaudeMdFile()).trim()
+  if (managedFile.length > 0) {
+    prompt = withTopBlock(prompt, instructionsBlock(managedClaudeMdPath(), managedFile))
+    changed = true
+    announce({ file_path: managedClaudeMdPath(), memory_type: 'Managed', load_reason: 'session_start' })
+  }
+  return { prompt, changed, managedFile }
+}
+
+/** Everything the import expansion depends on, hashed to a memo key: a turn whose inputs
+ * match a prior key and whose recorded mtimes are unchanged reuses the previous expansion
+ * outright. The native/local paths, the user/project-.claude additions, and the managed file
+ * body seed the "seen" set, so a change in which of them exist (even an excluded one that
+ * never reaches contextFiles) changes the key; the managed file is re-read every turn, so a
+ * change in its content re-expands and keeps the seed self-consistent. */
+function buildImportMemoKey(input: {
+  cwd: string
+  home: string
+  projectApproved: boolean
+  addDirsRaw: string
+  excludeGlobs: string[]
+  native: Array<{ path: string; content: string }>
+  localContexts: Array<{ path: string; content: string }>
+  userContext: { path: string; content: string } | undefined
+  projectDotClaude: { path: string; content: string } | undefined
+  managedFile: string
+  contextFiles: Array<{ path: string; content: string }>
+}): string {
+  const keyHash = createHash('sha256')
+  keyHash.update(`${input.cwd}\0${input.home}\0${input.projectApproved}\0${input.addDirsRaw}\0${input.excludeGlobs.join(',')}\0`)
+  for (const file of [...input.native, ...input.localContexts]) keyHash.update(`${file.path}\0`)
+  if (input.userContext !== undefined) keyHash.update(`${input.userContext.path}\0`)
+  if (input.projectDotClaude !== undefined) keyHash.update(`${input.projectDotClaude.path}\0`)
+  keyHash.update(`${input.managedFile}\0`)
+  for (const file of input.contextFiles) keyHash.update(`${file.path}\0${file.content}\0`)
+  return keyHash.digest('hex')
+}
+
 export default function contextImportsExtension(pi: ExtensionAPI) {
   let localContexts: Array<{ path: string; content: string }> = []
   // ~/.claude/CLAUDE.md, Claude's user-scope memory (all projects). The user's own
@@ -728,38 +786,19 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
       announce({ file_path: file.path, memory_type: memoryTypeForPath(file.path, home, projectRoot), load_reason: 'session_start' })
     }
 
-    // The blocks Claude loads ahead of pi's native project context, top to bottom:
-    // managed file, managed key, the user CLAUDE.md, then native. withTopBlock
-    // prepends, so they are inserted bottom-up (user, then managed key, then managed
-    // file just below) to land in that order.
-    //
     // The user CLAUDE.md is the user's own file (no approval gate) but respects
-    // claudeMdExcludes and comment-stripping like every other file.
+    // claudeMdExcludes and comment-stripping like every other file. It is kept here so it
+    // both gets its own block (via prependMemoryBlocks) and joins the import-expansion set
+    // below, so its @imports resolve.
     const keptUser = userContext !== undefined && !excluded(userContext.path) ? { path: userContext.path, content: stripBlockComments(userContext.content) } : undefined
-    if (keptUser !== undefined && keptUser.content.trim().length > 0) {
-      prompt = withTopBlock(prompt, instructionsBlock(keptUser.path, keptUser.content.trim()))
-      changed = true
-      announce({ file_path: keptUser.path, memory_type: 'User', load_reason: 'session_start' })
-    }
 
-    // Managed claudeMd loads before user and project context and is never excludable.
-    // It comes from two managed-only surfaces in this order, file first: the managed
-    // CLAUDE.md file IT deploys next to managed-settings.json, then the claudeMd
-    // settings key (ignored in user/project settings). withTopBlock prepends, so the
-    // key is inserted before the file to leave the file block highest of all. The file
-    // is re-read every turn, so a policy change applies immediately (fresher than the
-    // session-start user/project reads); only its announce is deduped per session.
-    const managedKey = typeof managed.claudeMd === 'string' ? stripBlockComments(managed.claudeMd).trim() : ''
-    if (managedKey.length > 0) {
-      prompt = withTopBlock(prompt, instructionsBlock(MANAGED_CLAUDE_MD_PATH, managedKey))
-      changed = true
-    }
-    const managedFile = stripBlockComments(readManagedClaudeMdFile()).trim()
-    if (managedFile.length > 0) {
-      prompt = withTopBlock(prompt, instructionsBlock(managedClaudeMdPath(), managedFile))
-      changed = true
-      announce({ file_path: managedClaudeMdPath(), memory_type: 'Managed', load_reason: 'session_start' })
-    }
+    // Prepend the managed and user memory blocks (managed file, managed key, user), the
+    // blocks Claude loads ahead of pi's native project context. managedFile comes back
+    // because it also seeds the import memo key below.
+    const top = prependMemoryBlocks(prompt, changed, keptUser, managed, announce)
+    prompt = top.prompt
+    changed = top.changed
+    const managedFile = top.managedFile
 
     const keptLocals = localContexts.filter((local) => !excluded(local.path)).map((local) => ({ path: local.path, content: stripBlockComments(local.content) }))
 
@@ -778,19 +817,7 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     // Everything the expansion depends on, hashed: a turn whose inputs match the memo
     // and whose recorded mtimes are unchanged reuses the previous expansion outright.
     const addDirsRaw = additionalDirsClaudeMdEnabled() ? String(pi.getFlag?.('add-dir') ?? '') : ''
-    const keyHash = createHash('sha256')
-    keyHash.update(`${cwd}\0${home}\0${projectApproved}\0${addDirsRaw}\0${excludeGlobs.join(',')}\0`)
-    // Paths that seed the seen set (native, locals, and the user/project-.claude
-    // additions), so a change in which of them exist changes the key even for an
-    // excluded one that never reaches contextFiles.
-    for (const file of [...native, ...localContexts]) keyHash.update(`${file.path}\0`)
-    if (userContext !== undefined) keyHash.update(`${userContext.path}\0`)
-    if (projectDotClaude !== undefined) keyHash.update(`${projectDotClaude.path}\0`)
-    // The managed file seeds the seen set, so a change in its content (it is re-read
-    // every turn) changes the key and re-expands, keeping the seed self-consistent.
-    keyHash.update(`${managedFile}\0`)
-    for (const file of contextFiles) keyHash.update(`${file.path}\0${file.content}\0`)
-    const memoKey = keyHash.digest('hex')
+    const memoKey = buildImportMemoKey({ cwd, home, projectApproved, addDirsRaw, excludeGlobs, native, localContexts, userContext, projectDotClaude, managedFile, contextFiles })
 
     const { extras, budget, imported } = resolveImports(memoKey, native, contextFiles, home, cwd, excluded)
 

--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -10,14 +10,23 @@
  * imported content plus the approval-gated CLAUDE.local.md body. The base
  * files pi already injected are never re-appended.
  *
+ * It also loads the Claude Code memory locations pi's own loader misses, each
+ * through the same exclude/strip/announce/import pipeline: the user-scope
+ * ~/.claude/CLAUDE.md (the user's own file, no approval gate, @imports at
+ * user-config roots), the project-scope alternate ./.claude/CLAUDE.md (nearest at
+ * or above cwd, approval-gated, deduped against pi's native blocks, @imports at
+ * project roots), and the enterprise managed CLAUDE.md file deployed beside
+ * managed-settings.json.
+ *
  * It also rewrites the context blocks pi assembled, by exact-substring
  * replacement of the wrapper reconstructed from each file's path+content (a
- * wrapper that is not found is skipped, never guessed at): a managed-settings
- * `claudeMd` block is prepended at the top of <project_context> (managed
- * settings only; the key is ignored elsewhere and the block is never
- * excludable), files matching the merged `claudeMdExcludes` globs are removed
- * along with their imports, and block-level HTML comments are stripped from
- * every surviving body (see internal/strip-comments).
+ * wrapper that is not found is skipped, never guessed at): the managed claudeMd
+ * (the managed CLAUDE.md file first, then the managed-settings `claudeMd` key)
+ * and the user CLAUDE.md are prepended at the top of <project_context> in Claude's
+ * order (managed, user, then pi's native project blocks; managed is managed-source
+ * only and never excludable), files matching the merged `claudeMdExcludes` globs
+ * are removed along with their imports, and block-level HTML comments are stripped
+ * from every surviving body (see internal/strip-comments).
  *
  * Security: context files can come from an untrusted project, so imports are
  * confined (after resolving symlinks) to the working directory plus its
@@ -43,11 +52,13 @@
  *
  * Loads are also announced on the shared instruction-events bus for the
  * InstructionsLoaded hook: `include` for each resolved @import, `session_start`
- * for the native context files that survived claudeMdExcludes plus
- * CLAUDE.local.md and additional-dir files, once per file per session. This
- * extension owns exclusion, so it owns the announcements too: a file the
- * exclusion removed never announces, and the hooks extension only consumes the
- * bus (emit is synchronous, so extension order does not matter).
+ * for the native context files that survived claudeMdExcludes plus CLAUDE.local.md,
+ * the user (User) and project ./.claude/CLAUDE.md (Project), the managed file
+ * (Managed) and additional-dir files, once per file per session. This extension
+ * owns exclusion, so it owns the announcements too: a file the exclusion removed
+ * never announces, and the hooks extension only consumes the bus (emit is
+ * synchronous, so extension order does not matter). The managed-settings `claudeMd`
+ * key is not a file pi loaded, so like today it is inserted but not announced.
  *
  * Docs: https://code.claude.com/docs/en/memory.md (imports)
  */
@@ -58,8 +69,9 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
+import { claudeConfigDir } from './internal/config-dir.js'
 import { type InstructionLoadEvent, memoryTypeForPath, publishInstructionLoad } from './internal/instruction-events.js'
-import { readManagedSettings } from './internal/managed-settings.js'
+import { managedSettingsPath, readManagedSettings } from './internal/managed-settings.js'
 import { globToRegExpSource } from './internal/path-rules.js'
 import { isProjectApproved, isProjectApprovedSilently } from './internal/project-approval.js'
 import { ancestorFiles, findNearestFile, repoRoot } from './internal/project-root.js'
@@ -223,7 +235,7 @@ export function collectImports(content: string, fromDir: string, home: string, a
  * would let it read them into the system prompt.
  */
 export function rootsForImporter(importer: string, home: string, cwd: string): string[] {
-  const userRoots = realRoots([path.join(home, '.claude'), path.join(home, '.pi')])
+  const userRoots = realRoots([claudeConfigDir(home), path.join(home, '.pi')])
   const [real] = realRoots([importer])
   const fromUserConfig = real !== undefined && isUnder(real, userRoots)
   if (fromUserConfig) return realRoots([cwd, ...userRoots])
@@ -287,8 +299,33 @@ export function additionalDirContextFiles(dir: string, includeLocal: boolean): A
   return files
 }
 
-/** Path label given to the managed claudeMd block; not a file pi loaded. */
+/** Path label given to the managed claudeMd settings-key block; not a file pi loaded. */
 export const MANAGED_CLAUDE_MD_PATH = 'managed-settings.json (claudeMd)'
+
+let managedClaudeMdPathOverride: string | undefined
+
+/** Test seam mirroring setManagedSettingsPath: point the managed CLAUDE.md file
+ * readers consult at a writable directory. */
+export function setManagedClaudeMdPath(file?: string): void {
+  managedClaudeMdPathOverride = file
+}
+
+/** The managed CLAUDE.md file path: alongside managed-settings.json, in the same OS
+ * directory IT deploys the enterprise policy to (managed-settings.ts owns that
+ * directory per platform). Organizations ship a CLAUDE.md there to load before user
+ * and project context. Overridable for tests. */
+export function managedClaudeMdPath(): string {
+  return managedClaudeMdPathOverride ?? path.join(path.dirname(managedSettingsPath()), 'CLAUDE.md')
+}
+
+/** The managed CLAUDE.md file body, or '' when absent or unreadable. */
+export function readManagedClaudeMdFile(): string {
+  try {
+    return fs.readFileSync(managedClaudeMdPath(), 'utf-8')
+  } catch {
+    return ''
+  }
+}
 
 /** pi's exact per-file wrapper inside <project_context>, reconstructed from
  * path+content for exact-substring rewriting. tests/context-imports.test.ts pins
@@ -318,10 +355,12 @@ function replaceBlock(prompt: string, wrapper: string, replacement: string): str
   return prompt.slice(0, at) + replacement + prompt.slice(at + wrapper.length)
 }
 
-/** Insert the managed claudeMd block at the top of <project_context>, before the
- * files pi loaded (Claude documents managed claudeMd loading before user and
- * project CLAUDE.md); when pi assembled no context block, add one in pi's shape. */
-function withManagedBlock(prompt: string, block: string): string {
+/** Insert a block at the top of <project_context>, before the files pi loaded;
+ * when pi assembled no context block, add one in pi's shape. Used for the blocks
+ * Claude loads ahead of pi's native project context: managed claudeMd (file then
+ * key) and the user CLAUDE.md. Each call prepends, so the last block inserted ends
+ * up highest, which is how the managed/user/native order is built (see caller). */
+function withTopBlock(prompt: string, block: string): string {
   for (const anchor of [CONTEXT_OPENER, '<project_context>\n\n']) {
     const at = prompt.indexOf(anchor)
     if (at === -1) continue
@@ -336,7 +375,7 @@ function withManagedBlock(prompt: string, block: string): string {
  * settings.local.json (nearest at or above cwd) only when the project is
  * approved. Managed settings are read separately by the caller. */
 export function claudeMdExcludeFiles(cwd: string, home: string, approved: boolean): string[] {
-  const files = [path.join(home, '.claude', 'settings.json')]
+  const files = [path.join(claudeConfigDir(home), 'settings.json')]
   if (!approved) return files
   for (const name of ['settings.json', 'settings.local.json']) {
     files.push(findNearestFile(cwd, path.join('.claude', name)) ?? path.join(cwd, '.claude', name))
@@ -454,6 +493,16 @@ function expandImports(contextFiles: Array<{ path: string; content: string }>, e
   return imported
 }
 
+/** The project-scope ./.claude/CLAUDE.md appended as a project_instructions block,
+ * announced as it is added (only when non-empty, matching what reaches the prompt).
+ * Claude reads project instructions from ./CLAUDE.md OR ./.claude/CLAUDE.md; pi loads
+ * the former natively, so this fills the alternate location as an extra project block. */
+function projectContextAddition(kept: { path: string; content: string } | undefined, home: string, projectRoot: string, announce: (event: InstructionLoadEvent) => void): string {
+  if (kept === undefined || kept.content.trim().length === 0) return ''
+  announce({ file_path: kept.path, memory_type: memoryTypeForPath(kept.path, home, projectRoot), load_reason: 'session_start' })
+  return `\n\n${instructionsBlock(kept.path, kept.content.trim())}`
+}
+
 /** The CLAUDE.local.md bodies appended after the native context, announced as they
  * are added (only the non-empty ones, matching what actually reaches the prompt). */
 function localContextAddition(keptLocals: Array<{ path: string; content: string }>, announce: (event: InstructionLoadEvent) => void): string {
@@ -494,6 +543,14 @@ function importedAddition(imported: ImportedFile[], budget: ImportBudget, home: 
 
 export default function contextImportsExtension(pi: ExtensionAPI) {
   let localContexts: Array<{ path: string; content: string }> = []
+  // ~/.claude/CLAUDE.md, Claude's user-scope memory (all projects). The user's own
+  // file, so it needs no project approval; read once at session start like the
+  // locals, so a mid-session body edit applies next session, matching Claude.
+  let userContext: { path: string; content: string } | undefined
+  // The project-scope alternate location ./.claude/CLAUDE.md. pi loads ./CLAUDE.md
+  // natively but not this one; repo-controlled, so it is approval-gated like the
+  // locals and read once at session start.
+  let projectDotClaude: { path: string; content: string } | undefined
   // Whether project settings may contribute claudeMdExcludes; decided at session
   // start with the silent check, so no prompt fires mid-flight.
   let projectApproved = false
@@ -556,7 +613,13 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     }
     // Seed with every loaded context file path, excluded ones included, so pi's own
     // files are never re-imported and an excluded file cannot return as an import.
-    const seenSet = new Set(realRoots([...native, ...localContexts].map((file) => file.path)))
+    // The user, project-.claude and managed-file additions join the seed too, so a
+    // context file's @import cannot pull any of them in a second time.
+    const ownPaths = [...native, ...localContexts].map((file) => file.path)
+    if (userContext !== undefined) ownPaths.push(userContext.path)
+    if (projectDotClaude !== undefined) ownPaths.push(projectDotClaude.path)
+    ownPaths.push(managedClaudeMdPath())
+    const seenSet = new Set(realRoots(ownPaths))
 
     // Claude's --add-dir memory loading, env-gated. The files join the seen set
     // before import expansion so an @import cannot pull one in twice, and they get
@@ -598,17 +661,39 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     announced.clear()
     envCache = undefined
     importMemo = undefined
+    localContexts = []
+    userContext = undefined
+    projectDotClaude = undefined
+
+    // ~/.claude/CLAUDE.md, Claude's user-scope memory. The user's own file, so no
+    // project approval is required; a missing file simply leaves it unset.
+    try {
+      const userClaudeMd = path.join(claudeConfigDir(os.homedir()), 'CLAUDE.md')
+      userContext = { path: userClaudeMd, content: fs.readFileSync(userClaudeMd, 'utf-8') }
+    } catch {
+      // no user CLAUDE.md
+    }
+
     // CLAUDE.local.md is Claude Code's personal sidecar of CLAUDE.md; pi's own loader
     // skips it. A cloned repo can ship one, so it is gated like other project config.
     // Claude loads local context from the whole hierarchy above the working
     // directory, ordered root down to cwd; the walk is bounded at the repository
-    // root like every other project-config search here.
-    localContexts = []
+    // root like every other project-config search here. The project-scope alternate
+    // ./.claude/CLAUDE.md (nearest at or above cwd) is repo-controlled too, so both
+    // ride the one approval decision.
     const candidates = ancestorFiles(ctx.cwd, 'CLAUDE.local.md')
-    if (candidates.length > 0 && (await isProjectApproved(ctx))) {
+    const dotClaudeMd = findNearestFile(ctx.cwd, path.join('.claude', 'CLAUDE.md'))
+    if ((candidates.length > 0 || dotClaudeMd !== null) && (await isProjectApproved(ctx))) {
       for (const candidate of candidates) {
         try {
           localContexts.push({ path: candidate, content: fs.readFileSync(candidate, 'utf-8') })
+        } catch {
+          // unreadable: treat as absent
+        }
+      }
+      if (dotClaudeMd !== null) {
+        try {
+          projectDotClaude = { path: dotClaudeMd, content: fs.readFileSync(dotClaudeMd, 'utf-8') }
         } catch {
           // unreadable: treat as absent
         }
@@ -643,30 +728,76 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
       announce({ file_path: file.path, memory_type: memoryTypeForPath(file.path, home, projectRoot), load_reason: 'session_start' })
     }
 
-    // Managed claudeMd is honored from managed settings ONLY (the key is ignored in
-    // user and project settings) and is never excludable; it loads before user and
-    // project context, so it goes to the top of the <project_context> block.
-    const managedClaudeMd = typeof managed.claudeMd === 'string' ? stripBlockComments(managed.claudeMd).trim() : ''
-    if (managedClaudeMd.length > 0) {
-      prompt = withManagedBlock(prompt, instructionsBlock(MANAGED_CLAUDE_MD_PATH, managedClaudeMd))
+    // The blocks Claude loads ahead of pi's native project context, top to bottom:
+    // managed file, managed key, the user CLAUDE.md, then native. withTopBlock
+    // prepends, so they are inserted bottom-up (user, then managed key, then managed
+    // file just below) to land in that order.
+    //
+    // The user CLAUDE.md is the user's own file (no approval gate) but respects
+    // claudeMdExcludes and comment-stripping like every other file.
+    const keptUser = userContext !== undefined && !excluded(userContext.path) ? { path: userContext.path, content: stripBlockComments(userContext.content) } : undefined
+    if (keptUser !== undefined && keptUser.content.trim().length > 0) {
+      prompt = withTopBlock(prompt, instructionsBlock(keptUser.path, keptUser.content.trim()))
       changed = true
+      announce({ file_path: keptUser.path, memory_type: 'User', load_reason: 'session_start' })
+    }
+
+    // Managed claudeMd loads before user and project context and is never excludable.
+    // It comes from two managed-only surfaces in this order, file first: the managed
+    // CLAUDE.md file IT deploys next to managed-settings.json, then the claudeMd
+    // settings key (ignored in user/project settings). withTopBlock prepends, so the
+    // key is inserted before the file to leave the file block highest of all. The file
+    // is re-read every turn, so a policy change applies immediately (fresher than the
+    // session-start user/project reads); only its announce is deduped per session.
+    const managedKey = typeof managed.claudeMd === 'string' ? stripBlockComments(managed.claudeMd).trim() : ''
+    if (managedKey.length > 0) {
+      prompt = withTopBlock(prompt, instructionsBlock(MANAGED_CLAUDE_MD_PATH, managedKey))
+      changed = true
+    }
+    const managedFile = stripBlockComments(readManagedClaudeMdFile()).trim()
+    if (managedFile.length > 0) {
+      prompt = withTopBlock(prompt, instructionsBlock(managedClaudeMdPath(), managedFile))
+      changed = true
+      announce({ file_path: managedClaudeMdPath(), memory_type: 'Managed', load_reason: 'session_start' })
     }
 
     const keptLocals = localContexts.filter((local) => !excluded(local.path)).map((local) => ({ path: local.path, content: stripBlockComments(local.content) }))
-    const contextFiles = [...rewrite.kept, ...keptLocals]
+
+    // ./.claude/CLAUDE.md, deduped against pi's native context so that if pi ever
+    // loads it too there is no double block, then exclude-checked and comment-stripped
+    // like the rest. Its @imports resolve at project roots (rootsForImporter).
+    const nativeReal = new Set(realRoots(native.map((file) => file.path)))
+    const [dotReal] = projectDotClaude !== undefined ? realRoots([projectDotClaude.path]) : []
+    const keptProjectDotClaude = projectDotClaude !== undefined && !(dotReal !== undefined && nativeReal.has(dotReal)) && !excluded(projectDotClaude.path) ? { path: projectDotClaude.path, content: stripBlockComments(projectDotClaude.content) } : undefined
+
+    // The user CLAUDE.md and ./.claude/CLAUDE.md join the import-expansion set so their
+    // @imports resolve (each at roots scoped to it, via rootsForImporter); their own
+    // bodies are placed separately, so expansion only surfaces what they import.
+    const contextFiles = [...rewrite.kept, ...(keptUser !== undefined ? [keptUser] : []), ...(keptProjectDotClaude !== undefined ? [keptProjectDotClaude] : []), ...keptLocals]
 
     // Everything the expansion depends on, hashed: a turn whose inputs match the memo
     // and whose recorded mtimes are unchanged reuses the previous expansion outright.
     const addDirsRaw = additionalDirsClaudeMdEnabled() ? String(pi.getFlag?.('add-dir') ?? '') : ''
     const keyHash = createHash('sha256')
     keyHash.update(`${cwd}\0${home}\0${projectApproved}\0${addDirsRaw}\0${excludeGlobs.join(',')}\0`)
+    // Paths that seed the seen set (native, locals, and the user/project-.claude
+    // additions), so a change in which of them exist changes the key even for an
+    // excluded one that never reaches contextFiles.
     for (const file of [...native, ...localContexts]) keyHash.update(`${file.path}\0`)
+    if (userContext !== undefined) keyHash.update(`${userContext.path}\0`)
+    if (projectDotClaude !== undefined) keyHash.update(`${projectDotClaude.path}\0`)
+    // The managed file seeds the seen set, so a change in its content (it is re-read
+    // every turn) changes the key and re-expands, keeping the seed self-consistent.
+    keyHash.update(`${managedFile}\0`)
     for (const file of contextFiles) keyHash.update(`${file.path}\0${file.content}\0`)
     const memoKey = keyHash.digest('hex')
 
     const { extras, budget, imported } = resolveImports(memoKey, native, contextFiles, home, cwd, excluded)
 
-    let addition = localContextAddition(keptLocals, announce)
+    // Project memory precedes local memory, so the ./.claude/CLAUDE.md block leads the
+    // additions, ahead of the CLAUDE.local.md bodies.
+    let addition = projectContextAddition(keptProjectDotClaude, home, projectRoot, announce)
+    addition += localContextAddition(keptLocals, announce)
     addition += additionalDirsAddition(extras, announce)
     addition += importedAddition(imported, budget, home, projectRoot, announce)
     if (!changed && addition.length === 0) return

--- a/extensions/context-usage.ts
+++ b/extensions/context-usage.ts
@@ -1,0 +1,45 @@
+/**
+ * Context Usage Command
+ *
+ * Claude Code's `/context` reports how much of the model's context window the
+ * current session occupies. This registers a `context` command that reads pi's
+ * live ContextUsage and renders a concise breakdown through notify. pi exposes
+ * three fields (tokens, contextWindow, percent); the used/window/free lines and
+ * the percentage are built from exactly those, with the model's window as a
+ * fallback when the usage snapshot does not carry one.
+ */
+
+import type { ContextUsage, ExtensionAPI } from '@earendil-works/pi-coding-agent'
+
+const fmt = (n: number): string => n.toLocaleString('en-US')
+
+/** The breakdown text for a usage snapshot, or a friendly line when there is none.
+ * `tokens` is null right after a compaction (before the next response recounts), so
+ * that case reports a recalculating state instead of a bogus zero. */
+export function formatContextUsage(usage: ContextUsage | undefined, modelWindow?: number): string {
+  if (!usage) {
+    return 'Context usage is not available yet. It appears once the model has responded (and resets right after a compaction).'
+  }
+  const window = usage.contextWindow || modelWindow || 0
+  if (usage.tokens === null) {
+    const tail = window > 0 ? ` Window: ${fmt(window)} tokens.` : ''
+    return `Context usage: recalculating the token count (e.g. right after a compaction).${tail}`
+  }
+  const tokens = usage.tokens
+  const percent = usage.percent ?? (window > 0 ? (tokens / window) * 100 : null)
+  const lines = ['Context usage', `  Used:   ${fmt(tokens)} tokens${percent === null ? '' : ` (${percent.toFixed(1)}%)`}`]
+  if (window > 0) {
+    lines.push(`  Window: ${fmt(window)} tokens`)
+    lines.push(`  Free:   ${fmt(Math.max(window - tokens, 0))} tokens`)
+  }
+  return lines.join('\n')
+}
+
+export default function contextUsageExtension(pi: ExtensionAPI) {
+  pi.registerCommand('context', {
+    description: 'Show how much of the model context window this session is using',
+    handler: async (_args, ctx) => {
+      ctx.ui.notify(formatContextUsage(ctx.getContextUsage(), ctx.model?.contextWindow), 'info')
+    },
+  })
+}

--- a/extensions/context-usage.ts
+++ b/extensions/context-usage.ts
@@ -27,10 +27,10 @@ export function formatContextUsage(usage: ContextUsage | undefined, modelWindow?
   }
   const tokens = usage.tokens
   const percent = usage.percent ?? (window > 0 ? (tokens / window) * 100 : null)
-  const lines = ['Context usage', `  Used:   ${fmt(tokens)} tokens${percent === null ? '' : ` (${percent.toFixed(1)}%)`}`]
+  const percentSuffix = percent === null ? '' : ` (${percent.toFixed(1)}%)`
+  const lines = ['Context usage', `  Used:   ${fmt(tokens)} tokens${percentSuffix}`]
   if (window > 0) {
-    lines.push(`  Window: ${fmt(window)} tokens`)
-    lines.push(`  Free:   ${fmt(Math.max(window - tokens, 0))} tokens`)
+    lines.push(`  Window: ${fmt(window)} tokens`, `  Free:   ${fmt(Math.max(window - tokens, 0))} tokens`)
   }
   return lines.join('\n')
 }

--- a/extensions/env-settings.ts
+++ b/extensions/env-settings.ts
@@ -73,7 +73,7 @@ export function mergeEnvScopes(managed: Record<string, string>, user: Record<str
 export function applyEnvSettings(merged: Record<string, string>, env: NodeJS.ProcessEnv, owned: Set<string>, managedKeys: ReadonlySet<string> = new Set()): void {
   // Unset any key an earlier apply set that the current merge dropped. Iterate a copy
   // since `owned` is mutated. A shell export this module never owned is left in place.
-  for (const key of [...owned]) {
+  for (const key of Array.from(owned)) {
     if (!(key in merged)) {
       delete env[key]
       owned.delete(key)

--- a/extensions/env-settings.ts
+++ b/extensions/env-settings.ts
@@ -1,0 +1,130 @@
+/**
+ * settings.json `env` injection.
+ *
+ * Claude Code lets any settings scope carry an `env` object whose keys are exported
+ * into the session's environment. This extension applies that chain to process.env:
+ * managed-settings.json (enterprise policy), ~/.claude/settings.json (user), and the
+ * project's .claude/settings.json plus settings.local.json.
+ *
+ * Two things run this. The factory body applies managed + user immediately (as pi
+ * loads extensions), so those variables are present before the first turn; a session
+ * that never approves a project still gets them. session_start refreshes and, only
+ * when the project is approved, folds in the project scope. The project scope stays
+ * approval-gated on purpose: a checked-out repository's env can redirect providers
+ * (ANTHROPIC_BASE_URL and friends), so an untrusted repo must not reach process.env.
+ *
+ * Precedence is per key, managed > user > project, matching Claude's merge: a scope
+ * only supplies keys it names and never wipes another scope's keys. Values must be
+ * strings; a number or boolean is coerced via String, anything else is skipped.
+ *
+ * A variable already present in the real environment that this module did not set is
+ * left untouched for the user and project scopes: a shell `export` outranks them. The
+ * managed scope is the exception: an org policy env must win over an ambient export, so
+ * a managed key overwrites a preexisting shell value. The keys this module sets are
+ * recorded so a later refresh can update them without clobbering unrelated env, and a
+ * key an earlier apply set that the current merge no longer defines is unset (deleted
+ * from process.env), so an approved project's env cannot leak into a later session or
+ * project that does not define it. A managed overwrite of a shell var is owned like any
+ * other set key; its original shell value cannot be restored, so on unset it is deleted.
+ *
+ * Docs: https://code.claude.com/docs/en/settings.md
+ */
+
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
+
+import { claudeConfigDir } from './internal/config-dir.js'
+import { readManagedSettings } from './internal/managed-settings.js'
+import { isProjectApprovedSilently } from './internal/project-approval.js'
+import { findNearestFile } from './internal/project-root.js'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** The `env` object of one settings scope, coerced to string values. A string is kept
+ * as-is, a number or boolean becomes its String() form, and anything else (object,
+ * array, null) is dropped, matching Claude which only injects string-valued env. */
+export function envFromSettings(settings: unknown): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!isRecord(settings) || !isRecord(settings.env)) return out
+  for (const [key, value] of Object.entries(settings.env)) {
+    if (typeof value === 'string') out[key] = value
+    else if (typeof value === 'number' || typeof value === 'boolean') out[key] = String(value)
+  }
+  return out
+}
+
+/** Merge the three env scopes with Claude's per-key precedence managed > user >
+ * project: lower scopes are laid down first and higher ones overlay, so each key
+ * takes its highest-precedence value and no scope wipes another's keys. */
+export function mergeEnvScopes(managed: Record<string, string>, user: Record<string, string>, project: Record<string, string>): Record<string, string> {
+  return { ...project, ...user, ...managed }
+}
+
+/** Assign the merged env into `env`, recording each key set into `owned`. A key already
+ * present that this module did not set (a shell export) is left untouched for user and
+ * project keys; a `managedKeys` entry overwrites it (an org policy outranks the shell).
+ * A key this module set before is updated. A previously-owned key that the current
+ * `merged` no longer defines is unset (deleted from `env` and `owned`), so an approved
+ * project's env cannot leak into a later apply that does not define it. */
+export function applyEnvSettings(merged: Record<string, string>, env: NodeJS.ProcessEnv, owned: Set<string>, managedKeys: ReadonlySet<string> = new Set()): void {
+  // Unset any key an earlier apply set that the current merge dropped. Iterate a copy
+  // since `owned` is mutated. A shell export this module never owned is left in place.
+  for (const key of [...owned]) {
+    if (!(key in merged)) {
+      delete env[key]
+      owned.delete(key)
+    }
+  }
+  for (const [key, value] of Object.entries(merged)) {
+    // A shell export outranks user/project (skip), but a managed key outranks even the
+    // shell. Once owned, updates always apply. A managed overwrite is owned like any
+    // set key: its shell value is gone and cannot be restored, so on unset it is deleted.
+    if (key in env && !owned.has(key) && !managedKeys.has(key)) continue
+    env[key] = value
+    owned.add(key)
+  }
+}
+
+function readSettingsFile(file: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(file, 'utf-8'))
+    if (isRecord(parsed)) return parsed
+  } catch {
+    // missing or invalid file: no env from this scope
+  }
+  return {}
+}
+
+/** The user scope's env: ~/.claude/settings.json (relocated by CLAUDE_CONFIG_DIR). */
+function userEnv(home: string): Record<string, string> {
+  return envFromSettings(readSettingsFile(path.join(claudeConfigDir(home), 'settings.json')))
+}
+
+/** The project scope's env: .claude/settings.json with settings.local.json overlaid,
+ * each the nearest of its name at or above cwd (matching the hooks settings chain). */
+function projectEnv(cwd: string): Record<string, string> {
+  const base = envFromSettings(readSettingsFile(findNearestFile(cwd, path.join('.claude', 'settings.json')) ?? path.join(cwd, '.claude', 'settings.json')))
+  const local = envFromSettings(readSettingsFile(findNearestFile(cwd, path.join('.claude', 'settings.local.json')) ?? path.join(cwd, '.claude', 'settings.local.json')))
+  return { ...base, ...local }
+}
+
+export default function envSettingsExtension(pi: ExtensionAPI) {
+  const owned = new Set<string>()
+
+  const apply = (home: string, project: Record<string, string>): void => {
+    const managed = envFromSettings(readManagedSettings())
+    applyEnvSettings(mergeEnvScopes(managed, userEnv(home), project), process.env, owned, new Set(Object.keys(managed)))
+  }
+
+  // Factory time: managed + user only. Approval needs the session ctx, so the project
+  // scope waits for session_start; running here means these vars land before the first turn.
+  apply(os.homedir(), {})
+
+  pi.on('session_start', async (_event, ctx: ExtensionContext) => {
+    apply(os.homedir(), isProjectApprovedSilently(ctx) ? projectEnv(ctx.cwd) : {})
+  })
+}

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -62,6 +62,7 @@ import * as path from 'node:path'
 import type { Api, Model } from '@earendil-works/pi-ai'
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
 import { runAgent } from './internal/agent-run.js'
+import { claudeConfigDir } from './internal/config-dir.js'
 import { INSTRUCTIONS_CHANNEL, isInstructionLoadEvent } from './internal/instruction-events.js'
 import { readManagedSettings } from './internal/managed-settings.js'
 import { isMcpToolAliases, MCP_TOOLS_CHANNEL } from './internal/mcp-alias.js'
@@ -83,6 +84,9 @@ const DEFAULT_TIMEOUT_S = 60
 interface HookCommand {
   type?: string
   command: string
+  /** exec-form: spawn `command` directly with these args and no shell (shell-form when
+   * absent). $ARGUMENTS in each arg is replaced with the event JSON. */
+  args?: string[]
   timeout?: number
   /** http entries: the endpoint POSTed to; `command` mirrors it for dedup and display. */
   url?: string
@@ -122,14 +126,15 @@ export interface HookRunResult {
 }
 /** Runs one configured hook entry, whatever its type; boundRunner dispatches. */
 export type HookRunner = (hook: HookCommand, payload: unknown, timeoutMs: number) => Promise<HookRunResult>
-/** The shell path specifically; the statusline reuses it for its own command. */
-export type HookCommandRunner = (command: string, payload: unknown, timeoutMs: number, projectDir?: string) => Promise<HookRunResult>
+/** The shell path specifically; the statusline reuses it for its own command. With an
+ * `args` array it becomes the exec path: `command` is spawned directly with those args. */
+export type HookCommandRunner = (command: string, payload: unknown, timeoutMs: number, projectDir?: string, args?: string[]) => Promise<HookRunResult>
 
 /** Settings files to read, newest-winning. Project files load only when trusted, each
  * the nearest of its name at or above cwd (bounded at the repository root, matching
  * the approval walk), so a subdirectory session reads the settings that gated it. */
 export function hookFiles(cwd: string, home: string, trusted: boolean): string[] {
-  const files = [path.join(home, '.claude', 'settings.json')]
+  const files = [path.join(claudeConfigDir(home), 'settings.json')]
   if (!trusted) return files
   for (const name of ['settings.json', 'settings.local.json']) {
     files.push(findNearestFile(cwd, path.join('.claude', name)) ?? path.join(cwd, '.claude', name))
@@ -472,14 +477,23 @@ function killTree(child: ChildProcess): void {
   child.kill('SIGKILL')
 }
 
-export const runHookCommand: HookCommandRunner = (command, payload, timeoutMs, projectDir) =>
+export const runHookCommand: HookCommandRunner = (command, payload, timeoutMs, projectDir, args) =>
   new Promise((resolve) => {
     // Absolute path so the shell can't be resolved through an attacker-controlled PATH.
     // `detached` makes the shell its own process group leader so the timeout can kill
     // the descendants too. CLAUDE_PROJECT_DIR is Claude's documented way for a hook to
-    // reference project files regardless of the shell's cwd.
-    const env = projectDir ? { ...process.env, CLAUDE_PROJECT_DIR: projectDir } : process.env
-    const child = spawn('/bin/sh', ['-c', command], { stdio: ['pipe', 'pipe', 'pipe'], detached: true, env })
+    // reference project files regardless of the shell's cwd. CLAUDECODE=1 marks every
+    // subprocess Claude spawns, so it is set on the child unconditionally.
+    const env: NodeJS.ProcessEnv = { ...process.env, CLAUDECODE: '1' }
+    if (projectDir) env.CLAUDE_PROJECT_DIR = projectDir
+    // An exec-form hook (an `args` array) spawns the executable directly with those args
+    // and no shell, so shell metacharacters in the args arrive literally; $ARGUMENTS in
+    // each arg is replaced with the event JSON by a replacer function (so $$/$& in the
+    // payload survive verbatim). Without args it stays the shell path. Both share the
+    // same detached process group, so killTree reaches the descendants either way.
+    const file = Array.isArray(args) ? command : '/bin/sh'
+    const spawnArgs = Array.isArray(args) ? args.map((arg) => substituteArguments(arg, payload)) : ['-c', command]
+    const child = spawn(file, spawnArgs, { stdio: ['pipe', 'pipe', 'pipe'], detached: true, env })
     let stdout = ''
     let stderr = ''
     let settled = false
@@ -673,6 +687,18 @@ export function lastAssistantText(messages: ReadonlyArray<{ role: string; conten
   return ''
 }
 
+/** Claude overrides a Stop hook after it blocks this many times in a row with no user
+ * progress, ending the turn with a warning rather than looping forever. */
+const DEFAULT_STOP_HOOK_BLOCK_CAP = 8
+
+/** The consecutive-block cap for the Stop hook: CLAUDE_CODE_STOP_HOOK_BLOCK_CAP when it
+ * is a positive integer, else the default. A non-positive or malformed value falls back
+ * to the default rather than capping at zero (which would suppress the very first block). */
+export function stopHookBlockCap(env: Record<string, string | undefined> = process.env): number {
+  const override = Number.parseInt(env.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP ?? '', 10)
+  return Number.isInteger(override) && override > 0 ? override : DEFAULT_STOP_HOOK_BLOCK_CAP
+}
+
 /** Above 2^31-1 ms Node clamps a timer to 1ms, which would kill the hook instantly. */
 const MAX_TIMEOUT_S = 2_147_483
 
@@ -833,6 +859,9 @@ export default function hooksExtension(pi: ExtensionAPI) {
   let allowedHttpHookUrls: string[] | undefined
   let pendingSessionContext: string[] = []
   let stopHookActive = false
+  /** Consecutive Stop-hook blocks with no user progress between them. Reset on user input
+   * and on a non-blocking Stop; at the cap the continuation is suppressed and the turn ends. */
+  let stopHookBlockCount = 0
   let sessionCtx: ExtensionContext | undefined
   /** Claude's disableAllHooks escape hatch was set somewhere in the honored chain. */
   let hooksDisabled = false
@@ -856,7 +885,7 @@ export default function hooksExtension(pi: ExtensionAPI) {
       if (hook.type === 'prompt') return runPromptHook(hook, merged, ctx.model, ms)
       if (hook.type === 'agent') return runAgentHook(hook, merged, ms, (ctx.model as { id?: string } | undefined)?.id)
       if (hook.type === 'mcp_tool') return runMcpToolHook(hook, merged, ms)
-      return runHookCommand(hook.command, merged, ms, projectDir)
+      return runHookCommand(hook.command, merged, ms, projectDir, hook.args)
     }
   // Claude matchers name MCP tools mcp__<server>__<tool>; pi-code registers them as
   // <server>_<tool>. The mcp extension publishes the mapping on pi's shared bus.
@@ -996,6 +1025,9 @@ export default function hooksExtension(pi: ExtensionAPI) {
     // Only genuine user input; extension-injected messages (plan-mode, subagent) are not
     // prompts the user submitted.
     if (event.source === 'extension') return { action: 'continue' }
+    // Genuine user input is progress, so it breaks a Stop-hook continuation streak: the
+    // block cap counts only consecutive blocks with nothing from the user in between.
+    stopHookBlockCount = 0
     const decision = await runUserPromptSubmit(config, event.text, boundRunner(ctx), (message) => ctx.ui.notify(message, 'warning'))
     if (decision.block) {
       // pi's input result has no reason channel, so surface why before consuming it.
@@ -1048,8 +1080,25 @@ export default function hooksExtension(pi: ExtensionAPI) {
         return { block: false, reason: '' }
       })
       .find((verdict) => verdict.block)
-    stopHookActive = block !== undefined
-    if (block) pi.sendMessage({ customType: 'claude-stop-hook', content: block.reason, display: true }, { triggerTurn: true })
+    if (!block) {
+      // A non-blocking Stop breaks the streak: the next block starts a fresh count.
+      stopHookActive = false
+      stopHookBlockCount = 0
+      return
+    }
+    stopHookBlockCount += 1
+    const cap = stopHookBlockCap()
+    if (stopHookBlockCount >= cap) {
+      // Claude overrides a Stop hook that has blocked cap times in a row with no user
+      // progress: suppress the continuation, warn, and let the turn end so the loop cannot
+      // run forever. Reset the count so a later run (or user turn) starts clean.
+      stopHookActive = false
+      stopHookBlockCount = 0
+      ctx.ui.notify(`Stop hook block cap reached (${cap} consecutive blocks); ending the turn.`, 'warning')
+      return
+    }
+    stopHookActive = true
+    pi.sendMessage({ customType: 'claude-stop-hook', content: block.reason, display: true }, { triggerTurn: true })
   })
 
   pi.on('session_before_compact', async (event, ctx) => {

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -35,7 +35,16 @@ export interface ParsedCommand {
    * command's injected spans run (see spanExec). */
   shell?: string
   model?: string
+  /** `effort:` per-command thinking-level override, one of pi's ThinkingLevel values
+   * (off/minimal/low/medium/high/xhigh/max); undefined when absent or unrecognized. */
+  effort?: string
+  /** `when_to_use:` extra trigger text appended to the slash_command tool listing only,
+   * never to the user-facing command description. */
+  whenToUse?: string
   disableModelInvocation: boolean
+  /** `user-invocable:` false hides the command from the slash-command surface while
+   * keeping it callable by the model through the slash_command tool. Default true. */
+  userInvocable: boolean
   body: string
 }
 
@@ -236,6 +245,15 @@ const text = (value: unknown): string => {
 const YAML_TRUE = new Set(['true', 'yes', 'on', 'y', '1'])
 const isFlagEnabled = (value: unknown): boolean => value === true || YAML_TRUE.has(text(value).toLowerCase())
 
+/** YAML's negative boolean spellings, the mirror of YAML_TRUE. A flag that defaults to
+ * true (user-invocable) is turned off only by one of these; any other value, absent
+ * included, leaves it on, so an unrelated string never silently hides a command. */
+const YAML_FALSE = new Set(['false', 'no', 'off', 'n', '0'])
+const isFlagDisabled = (value: unknown): boolean => value === false || YAML_FALSE.has(text(value).toLowerCase())
+
+/** pi's ThinkingLevel union, the values a command's `effort:` override may name. */
+const THINKING_LEVELS = new Set(['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
+
 /** Claude writes `argument-hint: [pr]`, which YAML reads as a list; render it back. */
 const hint = (value: unknown): string => (Array.isArray(value) ? `[${value.join(', ')}]` : text(value))
 
@@ -265,6 +283,7 @@ export function parseCommandFile(content: string): ParsedCommand {
   const disable = frontmatter['disable-model-invocation']
   const grants = parseToolGrants(frontmatter['allowed-tools'])
   const shell = text(frontmatter.shell).toLowerCase()
+  const effort = text(frontmatter.effort).toLowerCase()
   return {
     description: text(frontmatter.description) || firstLine.slice(0, 60),
     argumentHint: hint(frontmatter['argument-hint']) || undefined,
@@ -276,7 +295,11 @@ export function parseCommandFile(content: string): ParsedCommand {
     disallowedTools: parseToolGrants(frontmatter['disallowed-tools'])?.tools,
     shell: SHELLS.has(shell) ? shell : undefined,
     model: text(frontmatter.model) || undefined,
+    // An unrecognized effort is dropped rather than passed to setThinkingLevel.
+    effort: THINKING_LEVELS.has(effort) ? effort : undefined,
+    whenToUse: text(frontmatter.when_to_use) || undefined,
     disableModelInvocation: isFlagEnabled(disable),
+    userInvocable: !isFlagDisabled(frontmatter['user-invocable']),
     body,
   }
 }
@@ -453,7 +476,9 @@ export function spanExec(shell: string | undefined, projectDir: string, script: 
   if (shell === 'powershell') {
     const binary = resolveBinary()
     if (binary !== undefined) {
-      const preamble = `$ErrorActionPreference='Continue'\n$env:CLAUDE_PROJECT_DIR='${powershellQuote(projectDir)}'`
+      // CLAUDECODE=1 marks every subprocess Claude spawns; pi.exec takes no env, so
+      // it is exported in the script alongside CLAUDE_PROJECT_DIR.
+      const preamble = `$ErrorActionPreference='Continue'\n$env:CLAUDE_PROJECT_DIR='${powershellQuote(projectDir)}'\n$env:CLAUDECODE='1'`
       // No in-script 2>&1: under pwsh 7 it does not merge a native command's
       // stderr on a script block, so mergeStreams has the caller append it. The
       // trailing exit forwards a failed native command's code, which pwsh
@@ -470,7 +495,7 @@ export function spanExec(shell: string | undefined, projectDir: string, script: 
   // comment-only span is a hard sh syntax error (exit 2) that aborted the whole
   // invocation, and `:` keeps such a span the harmless no-op it was on HEAD
   // while the group still merges stderr for real spans.
-  return { command: '/bin/sh', args: ['-c', `export CLAUDE_PROJECT_DIR='${quoted}'\n{ :\n${script}\n} 2>&1`] }
+  return { command: '/bin/sh', args: ['-c', `export CLAUDE_PROJECT_DIR='${quoted}'\nexport CLAUDECODE=1\n{ :\n${script}\n} 2>&1`] }
 }
 
 interface FenceBlock {

--- a/extensions/internal/config-dir.ts
+++ b/extensions/internal/config-dir.ts
@@ -1,0 +1,24 @@
+/**
+ * CLAUDE_CONFIG_DIR: Claude Code's override for the home configuration directory.
+ *
+ * Claude relocates the entire ~/.claude configuration tree (settings.json, commands,
+ * agents, skills, plugins, output-styles, CLAUDE.md) when CLAUDE_CONFIG_DIR is set,
+ * so a user can keep that config outside their home directory. This resolves the
+ * home-scope config root for every consumer; a project's own `.claude/` directory is
+ * a separate scope and is never affected. A leading `~` expands against `home`, and
+ * the result is resolved to an absolute path so a relative value cannot depend on the
+ * reader's working directory.
+ */
+
+import * as path from 'node:path'
+
+/** The home-scope Claude config directory: CLAUDE_CONFIG_DIR (expanded, absolute)
+ * when set to a non-empty value, otherwise `<home>/.claude`. */
+export function claudeConfigDir(home: string): string {
+  const override = process.env.CLAUDE_CONFIG_DIR
+  if (override && override.trim().length > 0) {
+    const expanded = override.startsWith('~') ? path.join(home, override.slice(1)) : override
+    return path.resolve(expanded)
+  }
+  return path.join(home, '.claude')
+}

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -15,6 +15,8 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 
+import { claudeConfigDir } from './config-dir.js'
+
 export interface InstalledPlugin {
   name: string
   /** The version directory: ${CLAUDE_PLUGIN_ROOT}. */
@@ -148,8 +150,8 @@ function pluginFingerprint(cacheDir: string, settingsFiles: string[]): string {
  * because any settings edit or cache-tree change invalidates it.
  */
 export function installedPlugins(home: string, extraSettingsFiles: string[] = []): InstalledPlugin[] {
-  const cacheDir = path.join(home, '.claude', 'plugins', 'cache')
-  const settingsFiles = [path.join(home, '.claude', 'settings.json'), ...extraSettingsFiles]
+  const cacheDir = path.join(claudeConfigDir(home), 'plugins', 'cache')
+  const settingsFiles = [path.join(claudeConfigDir(home), 'settings.json'), ...extraSettingsFiles]
   const key = [home, ...extraSettingsFiles].join('\n')
   const fingerprint = pluginFingerprint(cacheDir, settingsFiles)
   const cached = pluginCache.get(key)
@@ -180,7 +182,7 @@ function resolvePlugin(home: string, cacheDir: string, marketplace: string, plug
   const name = typeof manifest.name === 'string' && manifest.name.length > 0 ? manifest.name : pluginDir
   const id = qualified.replace(/[^A-Za-z0-9]+/g, '-')
   const userConfig = configs[qualified] ?? configs[pluginDir] ?? configs[name]
-  return { name, root, dataDir: path.join(home, '.claude', 'plugins', 'data', id), manifest, ...(userConfig ? { userConfig } : {}) }
+  return { name, root, dataDir: path.join(claudeConfigDir(home), 'plugins', 'data', id), manifest, ...(userConfig ? { userConfig } : {}) }
 }
 
 /** The two plugin path variables, textually substituted into plugin-shipped

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -1232,6 +1232,62 @@ export default async function mcpExtension(pi: ExtensionAPI) {
 
   let projectConnected = false
 
+  /** managed-mcp.json exclusive mode: a policy deployed mid-process must not leave
+   * already-connected user/project servers running alongside the managed set. Evict every
+   * connected client not in the managed set (delete it from the map first so the onclose
+   * handler's guard sees it gone and does not overwrite the status, then close it
+   * best-effort and mark it disabled), then connect only the managed servers. */
+  async function connectManagedExclusive(managed: Record<string, ServerConfig>, allowed: Set<string> | null, denied: Set<string>, authUi?: AuthUi): Promise<void> {
+    const managedServers = applyServerPolicy(managed, allowed, denied)
+    const managedNames = new Set(Object.keys(managedServers))
+    for (const [name, client] of Array.from(clients.entries())) {
+      if (managedNames.has(name)) continue
+      clients.delete(name)
+      await client.close().catch(() => {})
+      status.set(name, { state: 'disabled by managed policy', tools: 0 })
+    }
+    await connectServers(managedServers, authUi)
+  }
+
+  /** The normal user + plugin + project scopes, when no managed-mcp.json is present.
+   * Connecting spawns processes and opens sockets, so it belongs here rather than in the
+   * factory: pi runs the factory for invocations that never start a session. Names still
+   * connected are filtered out, so a later session start only retries servers that failed
+   * or whose transport dropped, without duplicate-name warnings. */
+  async function connectNormalScopes(ctx: ExtensionContext, allowed: Set<string> | null, denied: Set<string>, authUi?: AuthUi): Promise<void> {
+    // Plugin servers merge under the user scope (plugins are user-installed);
+    // the user's own entry wins a name clash with a plugin's.
+    const pluginServers = loadPluginServers(installedPlugins(os.homedir()))
+    const scoped = applyServerPolicy({ ...pluginServers, ...loadUserScope(os.homedir(), ctx.cwd) }, allowed, denied)
+    // Claude's precedence is project over user for a duplicate name. A project .mcp.json
+    // server only outranks the user's own when it will actually connect (the user already
+    // consented to it, or an approved project's), so a merely-present untrusted project
+    // entry cannot shadow a trusted user server by reusing its name. A gated project
+    // server still awaiting the approval prompt does not preempt the user server: that is
+    // a deliberate narrowing of Claude's rule to keep the safe default.
+    // The stored project decision, read without prompting: consent recorded inside
+    // the project only counts once the project itself has been approved.
+    const projectPolicy = projectServerPolicy(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
+    const { consented, gated } = splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), allowed, denied), projectPolicy)
+    const projectWinners = new Set(Object.keys(consented))
+    const userServers = Object.fromEntries(Object.entries(scoped).filter(([name]) => !clients.has(name) && !projectWinners.has(name)))
+    // The consented project servers carry no ordering dependency on the user scope:
+    // projectWinners already excludes their names from userServers, so the two batches
+    // are disjoint and connect concurrently, and startup pays the slower scope rather
+    // than the sum of both. Reconnect attempts after a refused confirm are safe:
+    // connectServers skips names that already connected.
+    const connects: Promise<void>[] = []
+    if (Object.keys(userServers).length > 0) connects.push(connectServers(userServers, authUi))
+    if (!projectConnected && Object.keys(consented).length > 0) connects.push(connectServers(consented, authUi))
+    await Promise.all(connects)
+    // A project .mcp.json can run arbitrary commands on connect, so only honor it once
+    // the project is trusted. Per-server settings refine that: disabled servers never
+    // connect, servers the user consented to individually connected above without the
+    // whole-project confirm, and the rest stay behind it, sequentially after both
+    // scopes so the confirm dialog never races a connect.
+    if (!projectConnected) projectConnected = await connectGatedProjectServers(ctx, gated, authUi)
+  }
+
   pi.on('session_start', async (_event, ctx) => {
     const authUi = authUiFor(ctx)
     // The managed allow/deny lists filter every scope, including a managed-mcp.json set.
@@ -1243,55 +1299,9 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // empty set (see loadManagedMcpServers).
     const managed = loadManagedMcpServers()
     if (managed !== null) {
-      const managedServers = applyServerPolicy(managed, allowed, denied)
-      const managedNames = new Set(Object.keys(managedServers))
-      // A policy deployed mid-process must not leave already-connected user/project servers
-      // running alongside the managed set. Evict every connected client not in the managed
-      // set: delete it from the map first so the onclose handler's guard sees it gone and
-      // does not overwrite the status, then close it best-effort and mark it disabled.
-      for (const [name, client] of [...clients.entries()]) {
-        if (managedNames.has(name)) continue
-        clients.delete(name)
-        await client.close().catch(() => {})
-        status.set(name, { state: 'disabled by managed policy', tools: 0 })
-      }
-      await connectServers(managedServers, authUi)
+      await connectManagedExclusive(managed, allowed, denied, authUi)
     } else {
-      // Connecting spawns processes and opens sockets, so it belongs here rather than in
-      // the factory: pi runs the factory for invocations that never start a session.
-      // Names still connected are filtered out, so a later session start only retries
-      // servers that failed or whose transport dropped, without duplicate-name warnings.
-      // Plugin servers merge under the user scope (plugins are user-installed);
-      // the user's own entry wins a name clash with a plugin's.
-      const pluginServers = loadPluginServers(installedPlugins(os.homedir()))
-      const scoped = applyServerPolicy({ ...pluginServers, ...loadUserScope(os.homedir(), ctx.cwd) }, allowed, denied)
-      // Claude's precedence is project over user for a duplicate name. A project .mcp.json
-      // server only outranks the user's own when it will actually connect (the user already
-      // consented to it, or an approved project's), so a merely-present untrusted project
-      // entry cannot shadow a trusted user server by reusing its name. A gated project
-      // server still awaiting the approval prompt does not preempt the user server: that is
-      // a deliberate narrowing of Claude's rule to keep the safe default.
-      // The stored project decision, read without prompting: consent recorded inside
-      // the project only counts once the project itself has been approved.
-      const projectPolicy = projectServerPolicy(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
-      const { consented, gated } = splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), allowed, denied), projectPolicy)
-      const projectWinners = new Set(Object.keys(consented))
-      const userServers = Object.fromEntries(Object.entries(scoped).filter(([name]) => !clients.has(name) && !projectWinners.has(name)))
-      // The consented project servers carry no ordering dependency on the user scope:
-      // projectWinners already excludes their names from userServers, so the two batches
-      // are disjoint and connect concurrently, and startup pays the slower scope rather
-      // than the sum of both. Reconnect attempts after a refused confirm are safe:
-      // connectServers skips names that already connected.
-      const connects: Promise<void>[] = []
-      if (Object.keys(userServers).length > 0) connects.push(connectServers(userServers, authUi))
-      if (!projectConnected && Object.keys(consented).length > 0) connects.push(connectServers(consented, authUi))
-      await Promise.all(connects)
-      // A project .mcp.json can run arbitrary commands on connect, so only honor it once
-      // the project is trusted. Per-server settings refine that: disabled servers never
-      // connect, servers the user consented to individually connected above without the
-      // whole-project confirm, and the rest stay behind it, sequentially after both
-      // scopes so the confirm dialog never races a connect.
-      if (!projectConnected) projectConnected = await connectGatedProjectServers(ctx, gated, authUi)
+      await connectNormalScopes(ctx, allowed, denied, authUi)
     }
 
     pi.events.emit(MCP_TOOLS_CHANNEL, [...aliases])

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -48,6 +48,7 @@ import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/webso
 import { PromptListChangedNotificationSchema, ResourceListChangedNotificationSchema, ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
 import { Type } from 'typebox'
 import { splitArgs } from './internal/command-file.js'
+import { claudeConfigDir } from './internal/config-dir.js'
 import { MCP_TOOLS_CHANNEL, type McpToolAlias } from './internal/mcp-alias.js'
 import { setMcpToolCaller } from './internal/mcp-call.js'
 import { FileOAuthProvider, openBrowser, startCallbackServer, waitForAuthCode } from './internal/mcp-oauth.js'
@@ -57,7 +58,14 @@ import { isProjectApproved, isProjectApprovedSilently } from './internal/project
 import { findNearestFile } from './internal/project-root.js'
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
-const DEFAULT_CALL_TIMEOUT_MS = 120_000
+// Claude's MCP_TOOL_TIMEOUT default is effectively hours: the per-call wall-clock budget
+// is only a ceiling, and the idle timeout below is the real guard. 4h matches that model,
+// so a legitimately slow-but-progressing tool is not killed at the old 2 minutes.
+const DEFAULT_CALL_TIMEOUT_MS = 14_400_000
+// The idle timeout: the longest a call may go with no response or progress before it is
+// abandoned. Claude uses a separate idle guard (minutes) rather than the hours-long
+// wall-clock budget; the SDK resets this window on every progress notification.
+const DEFAULT_CALL_IDLE_TIMEOUT_MS = 300_000
 
 /** A positive-integer env override, or the default when unset or unparseable. */
 function envTimeout(name: string, fallback: number): number {
@@ -70,6 +78,33 @@ function envTimeout(name: string, fallback: number): number {
 // Claude honors MCP_TIMEOUT (connect) and MCP_TOOL_TIMEOUT (per-call), both in ms.
 const connectTimeoutMs = (): number => envTimeout('MCP_TIMEOUT', DEFAULT_CONNECT_TIMEOUT_MS)
 const callTimeoutMs = (): number => envTimeout('MCP_TOOL_TIMEOUT', DEFAULT_CALL_TIMEOUT_MS)
+
+/** The idle timeout in ms: the longest a call may go with no response or progress before
+ * it is abandoned, overridable by CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT, with 0 disabling it
+ * (leaving only the wall-clock budget). Unlike envTimeout, an explicit 0 is honored as
+ * "disabled" rather than falling back to the default. */
+function idleTimeoutMs(): number {
+  const raw = process.env.CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT
+  if (raw === undefined) return DEFAULT_CALL_IDLE_TIMEOUT_MS
+  const value = Number.parseInt(raw, 10)
+  if (value === 0) return 0
+  return Number.isInteger(value) && value > 0 ? value : DEFAULT_CALL_IDLE_TIMEOUT_MS
+}
+
+/** The SDK RequestOptions for a call under pi's two-tier timeout: a wall-clock ceiling and,
+ * under it, an idle timeout the SDK resets on every progress notification. When the idle
+ * window is enabled and tighter than the wall budget, `timeout` is that per-quiet-period
+ * deadline (resetTimeoutOnProgress), maxTotalTimeout caps the wall clock, and an onprogress
+ * handler is required: it makes the server address progress to this request and lets the
+ * SDK reset the timer on it. When the idle timeout is disabled, or already looser than the
+ * wall budget, only the wall budget applies. The outer withTimeout race is a wall-clock
+ * backstop and must be raced against `wall`, never the idle window, so a legitimately
+ * progressing call is not cut off. */
+function callRequestOptions(wall: number): { timeout: number; resetTimeoutOnProgress?: boolean; maxTotalTimeout?: number; onprogress?: () => void } {
+  const idle = idleTimeoutMs()
+  if (idle === 0 || idle >= wall) return { timeout: wall }
+  return { timeout: idle, resetTimeoutOnProgress: true, maxTotalTimeout: wall, onprogress: () => {} }
+}
 // Tool names an MCP server must never take over. formatToolName always emits
 // `<server>_<tool>`, so only names containing an underscore are actually reachable:
 // pi's own built-ins (read, bash, edit, ...) cannot be produced and are not listed.
@@ -125,9 +160,19 @@ export function interpolateEnv(value: string, env: NodeJS.ProcessEnv = process.e
   })
 }
 
-/** User-scoped MCP config (the user's own; safe to load without project trust). */
+/** The user's ~/.claude.json (top-level mcpServers plus the per-project `projects` map).
+ * When CLAUDE_CONFIG_DIR is set, Claude relocates .claude.json inside that directory; by
+ * default it stays at the home root, since .claude.json does NOT live inside ~/.claude. A
+ * blank value is treated as unset, matching claudeConfigDir. */
+function claudeJsonPath(home: string): string {
+  const override = process.env.CLAUDE_CONFIG_DIR
+  return override && override.trim().length > 0 ? path.join(claudeConfigDir(home), '.claude.json') : path.join(home, '.claude.json')
+}
+
+/** User-scoped MCP config (the user's own; safe to load without project trust). The .pi
+ * tree is pi's own and is not relocated by CLAUDE_CONFIG_DIR. */
 export function userConfigPaths(home: string): string[] {
-  return [path.join(home, '.claude.json'), path.join(home, '.pi', 'agent', 'mcp.json')]
+  return [claudeJsonPath(home), path.join(home, '.pi', 'agent', 'mcp.json')]
 }
 
 /** Project-scoped MCP config, each file the nearest of its name at or above cwd
@@ -163,7 +208,7 @@ export function projectServerPolicy(cwd: string, home: string, projectApproved: 
     }
   }
   const names = (value: unknown): string[] => (Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [])
-  const userSettings = read(path.join(home, '.claude', 'settings.json'))
+  const userSettings = read(path.join(claudeConfigDir(home), 'settings.json'))
   const projectSettings = read(findNearestFile(cwd, path.join('.claude', 'settings.json')) ?? path.join(cwd, '.claude', 'settings.json'))
   const localSettings = read(findNearestFile(cwd, path.join('.claude', 'settings.local.json')) ?? path.join(cwd, '.claude', 'settings.local.json'))
   const disabled = new Set([...names(userSettings.disabledMcpjsonServers), ...names(projectSettings.disabledMcpjsonServers), ...names(localSettings.disabledMcpjsonServers)])
@@ -208,7 +253,7 @@ export function loadConfigFrom(files: string[]): Record<string, ServerConfig> {
 export function loadUserScope(home: string, cwd: string): Record<string, ServerConfig> {
   const servers = loadConfigFrom(userConfigPaths(home))
   try {
-    const claudeJson = JSON.parse(fs.readFileSync(path.join(home, '.claude.json'), 'utf-8'))
+    const claudeJson = JSON.parse(fs.readFileSync(claudeJsonPath(home), 'utf-8'))
     Object.assign(servers, claudeJson.projects?.[cwd]?.mcpServers ?? {})
   } catch {
     // missing or invalid ~/.claude.json: the top-level user servers already loaded
@@ -319,6 +364,47 @@ export function mcpAllowDeny(managedFile: string = managedSettingsFileOverride ?
     allowed: Array.isArray(settings.allowedMcpServers) ? new Set(names(settings.allowedMcpServers)) : null,
     denied: new Set(names(settings.deniedMcpServers)),
   }
+}
+
+/** The managed-mcp.json path: a sibling of managed-settings.json (same directory). Derived
+ * through the same test seam so a test can write both into one temp dir. */
+export function managedMcpPath(managedFile: string = managedSettingsFileOverride ?? managedSettingsPath()): string {
+  return path.join(path.dirname(managedFile), 'managed-mcp.json')
+}
+
+/** Claude's managed-mcp.json: when it exists beside managed-settings.json it takes
+ * exclusive control of MCP. Only its `mcpServers` load; user, project, and plugin servers
+ * are all suppressed (and the project-approval flow with them), and an empty map disables
+ * MCP entirely. Returns the managed server map (possibly empty) when the file exists and
+ * parses, or null only when the file is absent, in which case MCP loads from the usual
+ * scopes exactly as before. A file that parses but carries no `mcpServers` object is an
+ * empty managed set, so a deployed-but-bodyless policy locks down rather than silently
+ * reopening the other scopes. A file that is PRESENT but not valid JSON fails closed to
+ * the same empty set (deny-all) rather than reopening those scopes: the lockdown intent
+ * means a corrupt or truncated policy file must not become an allow-all. The allow/deny
+ * lists still filter the returned set. */
+export function loadManagedMcpServers(managedFile: string = managedSettingsFileOverride ?? managedSettingsPath()): Record<string, ServerConfig> | null {
+  const file = managedMcpPath(managedFile)
+  let raw: string
+  try {
+    raw = fs.readFileSync(file, 'utf-8')
+  } catch {
+    // Absent (or unreadable) managed-mcp.json: no managed MCP control, load normally.
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    // Present but corrupt: fail closed to an empty managed set, exactly like an empty map,
+    // rather than reopening the user/project/plugin scopes.
+    console.warn(`pi-code-mcp: managed-mcp.json is present but not valid JSON (${file}); failing closed to no MCP servers: ${error instanceof Error ? error.message : String(error)}`)
+    return {}
+  }
+  if (parsed === null || typeof parsed !== 'object') return {}
+  const servers = (parsed as { mcpServers?: unknown }).mcpServers
+  if (servers === null || typeof servers !== 'object' || Array.isArray(servers)) return {}
+  return servers as Record<string, ServerConfig>
 }
 
 /** Claude's managed allow/deny lists: `allowed` null means no allow list (keep all);
@@ -799,7 +885,7 @@ function resourceTemplateEntry(server: string, template: { uriTemplate: string; 
 async function collectResources(entries: Array<Record<string, unknown>>, name: string, client: Client, budget: number): Promise<void> {
   let cursor: string | undefined
   do {
-    const page = await withTimeout(client.listResources({ cursor }, { timeout: budget }), budget, `list resources ${name}`)
+    const page = await withTimeout(client.listResources({ cursor }, callRequestOptions(budget)), budget, `list resources ${name}`)
     for (const resource of page.resources) entries.push(resourceEntry(name, resource))
     cursor = page.nextCursor
   } while (cursor)
@@ -809,7 +895,7 @@ async function collectResources(entries: Array<Record<string, unknown>>, name: s
 async function collectResourceTemplates(entries: Array<Record<string, unknown>>, name: string, client: Client, budget: number): Promise<void> {
   let cursor: string | undefined
   do {
-    const page = await withTimeout(client.listResourceTemplates({ cursor }, { timeout: budget }), budget, `list resource templates ${name}`)
+    const page = await withTimeout(client.listResourceTemplates({ cursor }, callRequestOptions(budget)), budget, `list resource templates ${name}`)
     for (const template of page.resourceTemplates) entries.push(resourceTemplateEntry(name, template))
     cursor = page.nextCursor
   } while (cursor)
@@ -845,7 +931,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   setMcpToolCaller(async (server, tool, input) => {
     const client = clients.get(server)
     if (!client) throw new Error(`MCP server "${server}" is not connected`)
-    const result = await client.callTool({ name: tool, arguments: input }, undefined, { timeout: callTimeoutMs() })
+    const result = await client.callTool({ name: tool, arguments: input }, undefined, callRequestOptions(callTimeoutMs()))
     const text = mapContent(result.content as McpContentBlock[], result.structuredContent)
       .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
       .map((part) => part.text)
@@ -883,12 +969,15 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           // and this closure would otherwise keep calling the old, closed client.
           const current = clients.get(name)
           if (!current) throw new Error(`MCP server "${name}" is not connected`)
-          // Pass the timeout to the SDK too: its own default request timeout is 60s and
-          // would otherwise reject first, so the outer race at CALL_TIMEOUT_MS was dead.
-          // Claude's per-server timeout wins over MCP_TOOL_TIMEOUT, with a 1s floor.
+          // The per-server timeout (Claude's, 1s floor) or MCP_TOOL_TIMEOUT is the
+          // wall-clock ceiling; callRequestOptions layers the idle timeout under it, which
+          // the SDK enforces (resetting on progress). Pass the options to the SDK too: its
+          // own default request timeout is 60s and would otherwise reject first. The outer
+          // race uses the wall budget, never the idle window, so a progressing call is not
+          // cut off at the idle timeout.
           const declared = typeof config.timeout === 'number' && config.timeout >= 1000 ? config.timeout : undefined
-          const budget = declared ?? callTimeoutMs()
-          const result = await withTimeout(current.callTool({ name: tool.name, arguments: params as Record<string, unknown> }, undefined, { timeout: budget }), budget, toolName)
+          const wall = declared ?? callTimeoutMs()
+          const result = await withTimeout(current.callTool({ name: tool.name, arguments: params as Record<string, unknown> }, undefined, callRequestOptions(wall)), wall, toolName)
           const content = mapContent(result.content as McpContentBlock[], result.structuredContent)
           const details: { error?: string } = {}
           if (result.isError) {
@@ -940,8 +1029,8 @@ export default async function mcpExtension(pi: ExtensionAPI) {
             const promptArgs = mapPromptArguments(prompt.arguments, args)
             const params: { name: string; arguments?: Record<string, string> } = { name: prompt.name }
             if (Object.keys(promptArgs).length > 0) params.arguments = promptArgs
-            const budget = callTimeoutMs()
-            const result = await withTimeout(current.getPrompt(params, { timeout: budget }), budget, commandName)
+            const wall = callTimeoutMs()
+            const result = await withTimeout(current.getPrompt(params, callRequestOptions(wall)), wall, commandName)
             // The prompt drives a turn exactly the way a custom slash command does
             // (see commands.ts), carrying its image blocks through. A prompt that
             // yields no content is reported rather than sent as an empty turn.
@@ -1027,8 +1116,8 @@ export default async function mcpExtension(pi: ExtensionAPI) {
         const { server, uri } = params as { server: string; uri: string }
         const client = clients.get(server)
         if (!client) throw new Error(`MCP server "${server}" is not connected`)
-        const budget = callTimeoutMs()
-        const result = await withTimeout(client.readResource({ uri }, { timeout: budget }), budget, `read ${uri}`)
+        const wall = callTimeoutMs()
+        const result = await withTimeout(client.readResource({ uri }, callRequestOptions(wall)), wall, `read ${uri}`)
         const blocks = (result.contents as Array<{ uri: string; text?: string; blob?: string; mimeType?: string }>).map((entry): McpContentBlock => {
           if (typeof entry.text === 'string') return { type: 'resource', resource: { uri: entry.uri, text: entry.text } }
           if (entry.blob && entry.mimeType?.startsWith('image/')) return { type: 'image', data: entry.blob, mimeType: entry.mimeType }
@@ -1144,43 +1233,66 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   let projectConnected = false
 
   pi.on('session_start', async (_event, ctx) => {
-    // Connecting spawns processes and opens sockets, so it belongs here rather than in
-    // the factory: pi runs the factory for invocations that never start a session.
-    // Names still connected are filtered out, so a later session start only retries
-    // servers that failed or whose transport dropped, without duplicate-name warnings.
-    // Plugin servers merge under the user scope (plugins are user-installed);
-    // the user's own entry wins a name clash with a plugin's.
-    const pluginServers = loadPluginServers(installedPlugins(os.homedir()))
-    const { allowed, denied } = mcpAllowDeny()
-    const scoped = applyServerPolicy({ ...pluginServers, ...loadUserScope(os.homedir(), ctx.cwd) }, allowed, denied)
-    // Claude's precedence is project over user for a duplicate name. A project .mcp.json
-    // server only outranks the user's own when it will actually connect (the user already
-    // consented to it, or an approved project's), so a merely-present untrusted project
-    // entry cannot shadow a trusted user server by reusing its name. A gated project
-    // server still awaiting the approval prompt does not preempt the user server: that is
-    // a deliberate narrowing of Claude's rule to keep the safe default.
-    // The stored project decision, read without prompting: consent recorded inside
-    // the project only counts once the project itself has been approved.
-    const projectPolicy = projectServerPolicy(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
-    const { consented, gated } = splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), allowed, denied), projectPolicy)
-    const projectWinners = new Set(Object.keys(consented))
-    const userServers = Object.fromEntries(Object.entries(scoped).filter(([name]) => !clients.has(name) && !projectWinners.has(name)))
     const authUi = authUiFor(ctx)
-    // The consented project servers carry no ordering dependency on the user scope:
-    // projectWinners already excludes their names from userServers, so the two batches
-    // are disjoint and connect concurrently, and startup pays the slower scope rather
-    // than the sum of both. Reconnect attempts after a refused confirm are safe:
-    // connectServers skips names that already connected.
-    const connects: Promise<void>[] = []
-    if (Object.keys(userServers).length > 0) connects.push(connectServers(userServers, authUi))
-    if (!projectConnected && Object.keys(consented).length > 0) connects.push(connectServers(consented, authUi))
-    await Promise.all(connects)
-    // A project .mcp.json can run arbitrary commands on connect, so only honor it once
-    // the project is trusted. Per-server settings refine that: disabled servers never
-    // connect, servers the user consented to individually connected above without the
-    // whole-project confirm, and the rest stay behind it, sequentially after both
-    // scopes so the confirm dialog never races a connect.
-    if (!projectConnected) projectConnected = await connectGatedProjectServers(ctx, gated, authUi)
+    // The managed allow/deny lists filter every scope, including a managed-mcp.json set.
+    const { allowed, denied } = mcpAllowDeny()
+    // managed-mcp.json (beside managed-settings.json) takes exclusive control when present:
+    // only its servers load, and the user, project, and plugin scopes plus the whole
+    // project-approval flow below are skipped. An empty map disables MCP entirely. An absent
+    // file leaves the normal scopes untouched; a present but corrupt file fails closed to an
+    // empty set (see loadManagedMcpServers).
+    const managed = loadManagedMcpServers()
+    if (managed !== null) {
+      const managedServers = applyServerPolicy(managed, allowed, denied)
+      const managedNames = new Set(Object.keys(managedServers))
+      // A policy deployed mid-process must not leave already-connected user/project servers
+      // running alongside the managed set. Evict every connected client not in the managed
+      // set: delete it from the map first so the onclose handler's guard sees it gone and
+      // does not overwrite the status, then close it best-effort and mark it disabled.
+      for (const [name, client] of [...clients.entries()]) {
+        if (managedNames.has(name)) continue
+        clients.delete(name)
+        await client.close().catch(() => {})
+        status.set(name, { state: 'disabled by managed policy', tools: 0 })
+      }
+      await connectServers(managedServers, authUi)
+    } else {
+      // Connecting spawns processes and opens sockets, so it belongs here rather than in
+      // the factory: pi runs the factory for invocations that never start a session.
+      // Names still connected are filtered out, so a later session start only retries
+      // servers that failed or whose transport dropped, without duplicate-name warnings.
+      // Plugin servers merge under the user scope (plugins are user-installed);
+      // the user's own entry wins a name clash with a plugin's.
+      const pluginServers = loadPluginServers(installedPlugins(os.homedir()))
+      const scoped = applyServerPolicy({ ...pluginServers, ...loadUserScope(os.homedir(), ctx.cwd) }, allowed, denied)
+      // Claude's precedence is project over user for a duplicate name. A project .mcp.json
+      // server only outranks the user's own when it will actually connect (the user already
+      // consented to it, or an approved project's), so a merely-present untrusted project
+      // entry cannot shadow a trusted user server by reusing its name. A gated project
+      // server still awaiting the approval prompt does not preempt the user server: that is
+      // a deliberate narrowing of Claude's rule to keep the safe default.
+      // The stored project decision, read without prompting: consent recorded inside
+      // the project only counts once the project itself has been approved.
+      const projectPolicy = projectServerPolicy(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
+      const { consented, gated } = splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), allowed, denied), projectPolicy)
+      const projectWinners = new Set(Object.keys(consented))
+      const userServers = Object.fromEntries(Object.entries(scoped).filter(([name]) => !clients.has(name) && !projectWinners.has(name)))
+      // The consented project servers carry no ordering dependency on the user scope:
+      // projectWinners already excludes their names from userServers, so the two batches
+      // are disjoint and connect concurrently, and startup pays the slower scope rather
+      // than the sum of both. Reconnect attempts after a refused confirm are safe:
+      // connectServers skips names that already connected.
+      const connects: Promise<void>[] = []
+      if (Object.keys(userServers).length > 0) connects.push(connectServers(userServers, authUi))
+      if (!projectConnected && Object.keys(consented).length > 0) connects.push(connectServers(consented, authUi))
+      await Promise.all(connects)
+      // A project .mcp.json can run arbitrary commands on connect, so only honor it once
+      // the project is trusted. Per-server settings refine that: disabled servers never
+      // connect, servers the user consented to individually connected above without the
+      // whole-project confirm, and the rest stay behind it, sequentially after both
+      // scopes so the confirm dialog never races a connect.
+      if (!projectConnected) projectConnected = await connectGatedProjectServers(ctx, gated, authUi)
+    }
 
     pi.events.emit(MCP_TOOLS_CHANNEL, [...aliases])
 

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -14,11 +14,12 @@ import * as path from 'node:path'
 import { StringEnum } from '@earendil-works/pi-ai'
 import { type ExtensionAPI, withFileMutationQueue } from '@earendil-works/pi-coding-agent'
 import { Type } from 'typebox'
+import { claudeConfigDir } from './internal/config-dir.js'
 import { capForContext } from './internal/output-guard.js'
 import { isProjectApprovedSilently } from './internal/project-approval.js'
 import { findNearestFile, repoRoot } from './internal/project-root.js'
 
-const INDEX_FILE = 'MEMORY.md'
+export const INDEX_FILE = 'MEMORY.md'
 
 /** Claude loads the first 200 lines or 25KB of the memory index at startup. */
 export const INDEX_MAX_LINES = 200
@@ -282,7 +283,7 @@ function writeIndex(indexPath: string, content: string): void {
  * approved, since a project's `autoMemoryDirectory` is honored under the same trust
  * rule as hooks in settings files. Later files win. */
 export function memorySettingsFiles(cwd: string, home: string, approved: boolean): string[] {
-  const files = [path.join(home, '.claude', 'settings.json')]
+  const files = [path.join(claudeConfigDir(home), 'settings.json')]
   if (!approved) return files
   for (const name of ['settings.json', 'settings.local.json']) {
     files.push(findNearestFile(cwd, path.join('.claude', name)) ?? path.join(cwd, '.claude', name))
@@ -304,6 +305,40 @@ export function readMemorySettings(files: string[]): { autoMemoryEnabled?: unkno
     }
   }
   return merged
+}
+
+/** Write `autoMemoryEnabled` into the user settings file, preserving every other key
+ * and creating the file and its config directory when absent. Claude's /memory toggle
+ * writes to the user scope (relocated by CLAUDE_CONFIG_DIR); the value takes effect from
+ * the next session start, which is where autoMemoryEnabled is read.
+ *
+ * An absent file starts from an empty object so the toggle still lands. A file that is
+ * PRESENT but unparseable is refused, not overwritten: clobbering it would destroy the
+ * user's hooks, env and permissions config. The caller surfaces the returned failure. */
+export function setAutoMemoryEnabledSetting(home: string, value: boolean): { ok: true } | { ok: false; error: string } {
+  const dir = claudeConfigDir(home)
+  const file = path.join(dir, 'settings.json')
+  let current: Record<string, unknown> = {}
+  let raw: string | undefined
+  try {
+    raw = fs.readFileSync(file, 'utf-8')
+  } catch (error) {
+    // Only a missing file means start fresh; any other read failure propagates.
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+  if (raw !== undefined) {
+    try {
+      const parsed = JSON.parse(raw)
+      if (parsed !== null && typeof parsed === 'object') current = parsed as Record<string, unknown>
+    } catch {
+      // Present but unparseable: refuse rather than overwrite the user's config.
+      return { ok: false, error: 'settings.json is not valid JSON; not modified' }
+    }
+  }
+  current.autoMemoryEnabled = value
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(file, `${JSON.stringify(current, null, 2)}\n`)
+  return { ok: true }
 }
 
 export default function memoryExtension(pi: ExtensionAPI) {
@@ -407,6 +442,55 @@ export default function memoryExtension(pi: ExtensionAPI) {
 
       const index = readIndexQuietly(dir)
       return { content: [{ type: 'text' as const, text: index.trim() || 'No memories saved for this project yet.' }], details: {} }
+    },
+  })
+
+  // Claude's /memory lists the memory locations and toggles auto memory. pi has no
+  // editor seam, so the paths are printed rather than opened. The listing reads the
+  // settings chain live so it reflects a toggle written in the same session.
+  pi.registerCommand('memory', {
+    description: 'Show memory file locations and toggle auto memory (/memory [on|off])',
+    handler: async (args, ctx) => {
+      const home = os.homedir()
+      const arg = args.trim().toLowerCase()
+
+      if (arg === 'on' || arg === 'off') {
+        const next = arg === 'on'
+        let result: { ok: true } | { ok: false; error: string }
+        try {
+          result = setAutoMemoryEnabledSetting(home, next)
+        } catch (error) {
+          ctx.ui.notify(`Could not update auto memory: ${error instanceof Error ? error.message : String(error)}`, 'error')
+          return
+        }
+        if (!result.ok) {
+          ctx.ui.notify(result.error, 'error')
+          return
+        }
+        ctx.ui.notify(`Auto memory ${next ? 'enabled' : 'disabled'} in ${path.join(claudeConfigDir(home), 'settings.json')} (applies next session).`, 'info')
+        return
+      }
+
+      if (arg.length > 0) {
+        ctx.ui.notify('Usage: /memory [on|off]', 'error')
+        return
+      }
+
+      const approved = isProjectApprovedSilently(ctx)
+      const settings = readMemorySettings(memorySettingsFiles(ctx.cwd, home, approved))
+      const isEnabled = autoMemoryEnabled(settings.autoMemoryEnabled, process.env)
+      const override = typeof settings.autoMemoryDirectory === 'string' ? settings.autoMemoryDirectory : undefined
+      const store = resolveMemoryDir(ctx.cwd, override)
+      const lines = [
+        'Memory',
+        `  Auto memory: ${isEnabled ? 'on' : 'off'}`,
+        `  Store:       ${store}`,
+        `  Index:       ${path.join(store, INDEX_FILE)}`,
+        `  User memory (CLAUDE.md):    ${path.join(home, '.claude', 'CLAUDE.md')}`,
+        `  Project memory (CLAUDE.md): ${path.join(ctx.cwd, 'CLAUDE.md')}`,
+        'Toggle with /memory on or /memory off.',
+      ]
+      ctx.ui.notify(lines.join('\n'), 'info')
     },
   })
 }

--- a/extensions/notify.ts
+++ b/extensions/notify.ts
@@ -21,6 +21,8 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
+import { claudeConfigDir } from './internal/config-dir.js'
+
 /** How a finished turn is announced, from Claude's `preferredNotifChannel`. */
 export type NotifChannel = 'desktop' | 'bell' | 'both' | 'off'
 
@@ -55,7 +57,7 @@ export function isAway(lastInputAt: number | undefined, now: number, thresholdMs
  * or change your notifications. */
 function readPreferredNotifChannel(home: string): unknown {
   try {
-    const settings = JSON.parse(fs.readFileSync(path.join(home, '.claude', 'settings.json'), 'utf-8'))
+    const settings = JSON.parse(fs.readFileSync(path.join(claudeConfigDir(home), 'settings.json'), 'utf-8'))
     return settings?.preferredNotifChannel
   } catch {
     return undefined

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -24,6 +24,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
+import { claudeConfigDir } from './internal/config-dir.js'
 import { installedPlugins } from './internal/plugins.js'
 import { isProjectApproved } from './internal/project-approval.js'
 import { findNearestDir, findNearestFile } from './internal/project-root.js'
@@ -82,7 +83,7 @@ function isDirectory(target: string): boolean {
  * verbatim into the system prompt.
  */
 export function styleDirs(cwd: string, home: string, trusted: boolean): string[] {
-  const dirs = [path.join(home, '.claude', 'output-styles')]
+  const dirs = [path.join(claudeConfigDir(home), 'output-styles')]
   if (trusted) dirs.push(findNearestDir(cwd, path.join('.claude', 'output-styles')) ?? path.join(cwd, '.claude', 'output-styles'))
   return dirs.filter((dir) => isDirectory(dir))
 }
@@ -129,7 +130,7 @@ export function loadStyles(dirs: string[]): OutputStyle[] {
 /** Settings files that carry `outputStyle`. Project settings apply only when trusted,
  * each the nearest of its name at or above cwd, as the hooks settings chain reads. */
 export function settingsFiles(cwd: string, home: string, trusted: boolean): string[] {
-  const files = [path.join(home, '.claude', 'settings.json')]
+  const files = [path.join(claudeConfigDir(home), 'settings.json')]
   if (!trusted) return files
   for (const name of ['settings.json', 'settings.local.json']) {
     files.push(findNearestFile(cwd, path.join('.claude', name)) ?? path.join(cwd, '.claude', name))

--- a/extensions/skills.ts
+++ b/extensions/skills.ts
@@ -15,6 +15,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
+import { claudeConfigDir } from './internal/config-dir.js'
 import { installedPlugins } from './internal/plugins.js'
 import { isProjectApprovedSilently } from './internal/project-approval.js'
 import { findNearestDir } from './internal/project-root.js'
@@ -33,7 +34,7 @@ function isDirectory(target: string): boolean {
  * name and description to the model, so an untrusted repository would otherwise get
  * text into the prompt without the user ever agreeing to load its config. */
 export function skillDirs(cwd: string, home: string, trusted: boolean): string[] {
-  const candidates = [path.join(home, '.claude', 'skills')]
+  const candidates = [path.join(claudeConfigDir(home), 'skills')]
   // Enabled plugins contribute their skills directories. pi's loader names a
   // skill by its directory, so a plugin skill registers without Claude's
   // /plugin: prefix; a rename-free approximation, disclosed in the README.

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -11,6 +11,7 @@ import { getAgentDir, parseFrontmatter, stripFrontmatter } from '@earendil-works
 // Claude field, and `--tools` is an exact-name allowlist, so a name pi has no tool for
 // is not merely ignored, it narrows the child's registry.
 import { parseToolGrants } from '../internal/command-file.js'
+import { claudeConfigDir } from '../internal/config-dir.js'
 import { installedPlugins } from '../internal/plugins.js'
 import { findNearestDir } from '../internal/project-root.js'
 
@@ -291,7 +292,7 @@ function pluginAgentDirs(home: string): string[] {
 
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
   const userDir = path.join(getAgentDir(), 'agents')
-  const claudeUserDir = path.join(os.homedir(), '.claude', 'agents')
+  const claudeUserDir = path.join(claudeConfigDir(os.homedir()), 'agents')
   const projectPiDir = findNearestDir(cwd, path.join('.pi', 'agents'))
   const projectClaudeDir = findNearestDir(cwd, path.join('.claude', 'agents'))
 

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -24,6 +24,7 @@ import { type ExtensionAPI, type ExtensionContext, getMarkdownTheme, type Theme,
 import { Container, Markdown, Spacer, Text } from '@earendil-works/pi-tui'
 import { type Static, Type } from 'typebox'
 import { type AgentRunRequest, setAgentRunner } from '../internal/agent-run.js'
+import { claudeConfigDir } from '../internal/config-dir.js'
 import { capForContext } from '../internal/output-guard.js'
 import { isProjectApproved, isProjectApprovedSilently } from '../internal/project-approval.js'
 import { repoRoot } from '../internal/project-root.js'
@@ -697,7 +698,7 @@ export function agentMemoryDir(scope: AgentMemoryScope, name: string, cwd: strin
   const sanitized = name.replace(/[^\w.-]+/g, '_')
   // A name of only dots ('.', '..') survives the character filter but still traverses.
   const segment = /^\.+$/.test(sanitized) ? '_' : sanitized
-  if (scope === 'user') return path.join(home, '.claude', 'agent-memory', segment)
+  if (scope === 'user') return path.join(claudeConfigDir(home), 'agent-memory', segment)
   const root = repoRoot(cwd) ?? cwd
   return path.join(root, '.claude', scope === 'project' ? 'agent-memory' : 'agent-memory-local', segment)
 }

--- a/extensions/thinking.ts
+++ b/extensions/thinking.ts
@@ -19,7 +19,7 @@ const THINKING_ORDER: readonly ThinkingLevel[] = ['off', 'minimal', 'low', 'medi
 
 export function thinkingRank(level: ThinkingLevel): number {
   const i = THINKING_ORDER.indexOf(level)
-  return i < 0 ? 0 : i
+  return Math.max(i, 0)
 }
 
 /** The reasoning level a prompt requests through Claude's think keywords, or undefined

--- a/extensions/thinking.ts
+++ b/extensions/thinking.ts
@@ -1,0 +1,80 @@
+/**
+ * Thinking Keyword Escalation
+ *
+ * Claude Code raises reasoning effort for a single turn when the prompt carries a
+ * think keyword: `ultrathink` asks for the maximum, `think hard`/`think harder` for
+ * a high level, and a bare `think` for a medium one. The word stays in the prompt
+ * (the input is observed, never consumed or transformed), the escalation only ever
+ * raises the level, and the prior level is restored once the turn settles, mirroring
+ * how commands.ts restores a per-command model override on agent_settled.
+ */
+
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+
+// The pi ThinkingLevel union, taken from the setter's parameter so it tracks the SDK.
+type ThinkingLevel = Parameters<ExtensionAPI['setThinkingLevel']>[0]
+
+/** Lowest to highest, matching pi's ThinkingLevel union; rank is the index. */
+const THINKING_ORDER: readonly ThinkingLevel[] = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']
+
+export function thinkingRank(level: ThinkingLevel): number {
+  const i = THINKING_ORDER.indexOf(level)
+  return i < 0 ? 0 : i
+}
+
+/** The reasoning level a prompt requests through Claude's think keywords, or undefined
+ * when it names none. Checked most-specific first so `think harder` does not fall
+ * through to the bare-`think` branch, and on word boundaries so `rethink`/`thinking`
+ * and the whole word `ultrathink` never trip the bare match. */
+export function requestedThinkingLevel(text: string): ThinkingLevel | undefined {
+  if (/\bultrathink\b/i.test(text)) return 'max'
+  if (/\bthink harder\b/i.test(text) || /\bthink hard\b/i.test(text)) return 'high'
+  if (/\bthink\b/i.test(text)) return 'medium'
+  return undefined
+}
+
+export default function thinkingExtension(pi: ExtensionAPI) {
+  // The level to restore once the escalated turn settles, captured the first time a
+  // turn escalates so back-to-back keywords in one turn still restore the original.
+  // Cleared on agent_settled, the run's true end past any retry/compaction/Stop
+  // continuation, the same clearing point commands.ts uses for its model override.
+  let pendingRestore: ThinkingLevel | undefined
+  // The level this extension last escalated to. The restore is conditional on the level
+  // still being this target at settle: commands.ts also restores an `effort:` override
+  // on agent_settled, so both fire on the same event. Keying the restore on the target
+  // makes the outcome order-independent: if a command's restore (or a manual change)
+  // already moved the level, thinking stands down instead of clobbering it.
+  let pendingTarget: ThinkingLevel | undefined
+
+  pi.on('input', (event, ctx) => {
+    // Only genuine user input escalates. sendUserMessage emits an input event with
+    // source 'extension' (a subagent prompt, a command body replayed through it); a
+    // think keyword the user did not type must not escalate, mirroring hooks.ts's guard.
+    if (event.source === 'extension') return
+    const target = requestedThinkingLevel(event.text)
+    if (!target) return
+    const current = pi.getThinkingLevel?.() ?? ctx.thinkingLevel ?? 'off'
+    // A keyword only raises reasoning: leave a level already at or above the target.
+    if (thinkingRank(current) >= thinkingRank(target)) return
+    pendingRestore = pendingRestore ?? current
+    pendingTarget = target
+    pi.setThinkingLevel?.(target)
+    // Return nothing so the input is neither consumed nor transformed: Claude keeps
+    // the keyword in the prompt.
+  })
+
+  pi.on('agent_settled', () => {
+    if (pendingRestore === undefined) return
+    const restore = pendingRestore
+    const target = pendingTarget
+    pendingRestore = undefined
+    pendingTarget = undefined
+    // Restore only if nothing else moved the level since this extension set it. If a
+    // command's effort restore or the user's manual change already took over (current
+    // no longer equals our target), leave that value in place and stand down. When the
+    // level cannot be read, restore unconditionally, the prior best-effort behavior.
+    const current = pi.getThinkingLevel?.()
+    if (current !== undefined && current !== target) return
+    pi.setThinkingLevel?.(restore)
+  })
+}

--- a/tests/claude-rules.test.ts
+++ b/tests/claude-rules.test.ts
@@ -307,6 +307,23 @@ describe('extension wiring', () => {
     expect(prompt).toContain('Use parameterized queries.')
   })
 
+  it('resolves the global rules directory under CLAUDE_CONFIG_DIR', async () => {
+    // Global rules live under the relocated config dir when CLAUDE_CONFIG_DIR is set,
+    // not ~/.claude/rules.
+    const cfg = mkdtempSync(join(tmpdir(), 'rules-cfg-'))
+    const saved = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = cfg
+    try {
+      mkdirSync(join(cfg, 'rules'), { recursive: true })
+      writeFileSync(join(cfg, 'rules', 'style.md'), 'Prefer guard clauses.')
+      const prompt = await sessionPrompt(globalCtx())
+      expect(prompt).toContain('Prefer guard clauses.')
+    } finally {
+      if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR
+      else process.env.CLAUDE_CONFIG_DIR = saved
+    }
+  })
+
   it('keeps a path-scoped global rule as a scoped pointer instead of inlining it', async () => {
     // Claude Code attaches scoped rules only when matching files are touched; inlining
     // one unconditionally applied it everywhere and lost the scope entirely.

--- a/tests/command-parse.test.ts
+++ b/tests/command-parse.test.ts
@@ -26,6 +26,7 @@ describe('parseCommandFile', () => {
       allowedTools: ['bash', 'read', 'find'],
       model: 'sonnet',
       disableModelInvocation: true,
+      userInvocable: true,
       body: 'Do the thing with $1.',
     })
   })
@@ -178,6 +179,38 @@ describe('parseCommandFile', () => {
   it('reads a space-separated arguments declaration', () => {
     expect(parseCommandFile('---\narguments: issue branch\n---\nB.').argumentNames).toEqual(['issue', 'branch'])
   })
+
+  it('reads user-invocable and when_to_use, defaulting them when absent', () => {
+    const md = ['---', 'description: Generate', 'user-invocable: false', 'when_to_use: when the tests are red', '---', 'Body.'].join('\n')
+    const parsed = parseCommandFile(md)
+    expect(parsed.userInvocable).toBe(false)
+    expect(parsed.whenToUse).toBe('when the tests are red')
+    // Absent fields: user-invocable defaults true, when_to_use to undefined.
+    const bare = parseCommandFile('Body only.')
+    expect(bare.userInvocable).toBe(true)
+    expect(bare.whenToUse).toBeUndefined()
+  })
+
+  it('honors the YAML falsy spellings of user-invocable, the mirror of disable-model-invocation', () => {
+    // user-invocable defaults to true, so only an explicit false spelling turns it off;
+    // an unrelated value like `maybe` leaves the command user-invocable.
+    for (const value of ['false', 'False', 'no', 'NO', 'off', '0', 'n']) {
+      expect(parseCommandFile(`---\nuser-invocable: ${value}\n---\nx`).userInvocable).toBe(false)
+    }
+    for (const value of ['true', 'yes', 'on', '1', 'maybe']) {
+      expect(parseCommandFile(`---\nuser-invocable: ${value}\n---\nx`).userInvocable).toBe(true)
+    }
+  })
+
+  it('parses a valid effort thinking-level override, rejecting anything outside the union', () => {
+    for (const level of ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']) {
+      expect(parseCommandFile(`---\neffort: ${level}\n---\nx`).effort).toBe(level)
+    }
+    // Case-insensitive, and an unknown value is dropped rather than passed to setThinkingLevel.
+    expect(parseCommandFile('---\neffort: MAX\n---\nx').effort).toBe('max')
+    expect(parseCommandFile('---\neffort: turbo\n---\nx').effort).toBeUndefined()
+    expect(parseCommandFile('x').effort).toBeUndefined()
+  })
 })
 
 describe('substituteVars', () => {
@@ -247,6 +280,8 @@ describe('spanExec', () => {
     expect(run.command).toBe('/bin/sh')
     expect(run.args[0]).toBe('-c')
     expect(run.args[1]).toContain("export CLAUDE_PROJECT_DIR='/proj'")
+    // Claude marks every subprocess it spawns with CLAUDECODE=1.
+    expect(run.args[1]).toContain('export CLAUDECODE=1')
     expect(run.args[1]).toContain('git status')
     expect(run.args[1]).toContain('2>&1')
     // The sh script merges in-line; nothing asks the caller to merge again.
@@ -283,6 +318,7 @@ describe('spanExec', () => {
     const script = run.args[3]
     // PowerShell single-quote escaping doubles the quote, never sh's '\'' splice.
     expect(script).toContain("$env:CLAUDE_PROJECT_DIR='/it''s/proj'")
+    expect(script).toContain("$env:CLAUDECODE='1'")
     expect(script).toContain('Get-ChildItem')
     expect(script).toContain("$ErrorActionPreference='Continue'")
   })

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -65,6 +65,21 @@ describe('commandDirs', () => {
     mkdirSync(sub)
     expect(commandDirs(sub, hoisted.home, true)).toEqual([join(repo, '.claude', 'commands')])
   })
+
+  it('resolves the user commands directory under CLAUDE_CONFIG_DIR', () => {
+    // Claude keeps commands inside CLAUDE_CONFIG_DIR when set, not ~/.claude/commands.
+    const cfg = tempDir()
+    mkdirSync(join(cfg, 'commands'), { recursive: true })
+    writeFileSync(join(cfg, 'commands', 'x.md'), 'body')
+    const saved = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = cfg
+    try {
+      expect(commandDirs(tempDir(), hoisted.home, false)).toEqual([join(cfg, 'commands')])
+    } finally {
+      if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR
+      else process.env.CLAUDE_CONFIG_DIR = saved
+    }
+  })
 })
 
 describe('collectCommands', () => {
@@ -118,8 +133,12 @@ const setup = (cwd: string, trusted = true) => {
       modelSets.push(model.id)
       return true
     },
+    setThinkingLevel: (level: string) => {
+      thinkingSets.push(level)
+    },
   }
   const modelSets: string[] = []
+  const thinkingSets: string[] = []
   const available = [
     { id: 'gemma4', name: 'Gemma 4' },
     { id: 'claude-opus-5', name: 'Opus' },
@@ -154,6 +173,7 @@ const setup = (cwd: string, trusted = true) => {
     execCalls,
     ctx,
     modelSets,
+    thinkingSets,
     activeTools: () => active,
     setIdle: (value: boolean) => {
       idle = value
@@ -397,6 +417,103 @@ describe('command model frontmatter', () => {
     await s.handlers.get('session_start')?.({}, s.ctx)
     await s.commands.get('x')?.handler('', s.ctx)
     expect(s.modelSets).toEqual([])
+  })
+})
+
+describe('command effort frontmatter', () => {
+  it('escalates the thinking level for the run and restores it on agent_settled', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'deep.md', '---\neffort: max\n---\nThink hard.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('deep')?.handler('', s.ctx)
+    // The session level is 'high'; the command raises it for its run.
+    expect(s.thinkingSets).toEqual(['max'])
+    // A mid-run turn_end must not restore: a multi-step command keeps its level.
+    await s.handlers.get('turn_end')?.({}, s.ctx)
+    expect(s.thinkingSets).toEqual(['max'])
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
+    // Restored to the session level once the run settles.
+    expect(s.thinkingSets).toEqual(['max', 'high'])
+  })
+
+  it('does not touch the thinking level when effort matches the session or is absent, and restores nothing', async () => {
+    const cwd = tempDir()
+    // The session level is 'high'.
+    writeCommand(cwd, 'same.md', '---\neffort: high\n---\nx')
+    writeCommand(cwd, 'none.md', 'x')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('same')?.handler('', s.ctx)
+    await s.commands.get('none')?.handler('', s.ctx)
+    expect(s.thinkingSets).toEqual([])
+    // Nothing was changed, so agent_settled restores nothing either.
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
+    expect(s.thinkingSets).toEqual([])
+  })
+
+  it('ignores an effort value outside the thinking-level union', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'bad.md', '---\neffort: turbo\n---\nx')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('bad')?.handler('', s.ctx)
+    expect(s.thinkingSets).toEqual([])
+  })
+
+  it('restores the level from before the first command when two escalate in one turn', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'a.md', '---\neffort: max\n---\nA.')
+    writeCommand(cwd, 'b.md', '---\neffort: low\n---\nB.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('a')?.handler('', s.ctx)
+    await s.commands.get('b')?.handler('', s.ctx)
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
+    // First-restriction-wins: the restore target is the original session level.
+    expect(s.thinkingSets).toEqual(['max', 'low', 'high'])
+  })
+})
+
+describe('user-invocable frontmatter', () => {
+  it('hides a user-invocable:false command from the slash-command map but lists and runs it via the tool', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'gen.md', '---\ndescription: Generate code\nuser-invocable: false\n---\nGenerate $0.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    // Not registered as a user slash command...
+    expect(s.commands.has('gen')).toBe(false)
+    // ...but present in the slash_command tool description and callable by the model.
+    const tool = s.tools.get('slash_command')
+    expect(tool?.description).toContain('/gen - Generate code')
+    const result = await tool?.execute('t1', { command: '/gen staging' }, undefined, undefined, s.ctx)
+    expect(result?.content[0].text).toContain('Generate staging.')
+  })
+
+  it('registers only the user-invocable commands while keeping the hidden one model-callable', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'hidden.md', '---\nuser-invocable: false\n---\nHidden.')
+    writeCommand(cwd, 'shown.md', '---\ndescription: Visible\n---\nShown.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    expect([...s.commands.keys()]).toEqual(['shown'])
+    // The hidden command still resolves for the model.
+    const result = await s.tools.get('slash_command')?.execute('t1', { command: '/hidden' }, undefined, undefined, s.ctx)
+    expect(result?.content[0].text).toContain('Hidden.')
+  })
+})
+
+describe('when_to_use frontmatter', () => {
+  it('appends when_to_use to the tool listing but not the user-facing command description', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'deploy.md', '---\ndescription: Deploy it\nargument-hint: [env]\nwhen_to_use: use when shipping to prod\n---\nDeploy $0.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    // The user-facing command description omits when_to_use.
+    expect(s.commands.get('deploy')?.description).toBe('Deploy it [env]')
+    // The tool listing carries the trigger text.
+    expect(s.tools.get('slash_command')?.description).toContain('use when shipping to prod')
   })
 })
 
@@ -808,6 +925,11 @@ describe('slashCommandToolDescription', () => {
     expect(text).toContain('/lint - Lint the tree')
   })
 
+  it('appends when_to_use trigger text after the description, before the argument hint', () => {
+    const text = slashCommandToolDescription([{ name: 'deploy', description: 'Deploy it', whenToUse: 'use when shipping', argumentHint: '[env]' }], 15_000)
+    expect(text).toContain('/deploy - Deploy it use when shipping ([env])')
+  })
+
   it('caps one entry at 1536 characters', () => {
     const text = slashCommandToolDescription([{ name: 'big', description: 'x'.repeat(4000) }], 15_000)
     const entry = text.split('\n').find((line) => line.startsWith('/big')) ?? ''
@@ -992,6 +1114,21 @@ describe('disableSkillShellExecution', () => {
     writeFileSync(managed, JSON.stringify({ disableSkillShellExecution: true }))
     setManagedSettingsPath(managed)
     expect(shellExecutionDisabled(tempDir(), hoisted.home, false)).toBe(true)
+  })
+
+  it('reads the user settings.json from CLAUDE_CONFIG_DIR', () => {
+    // The user policy relocates with CLAUDE_CONFIG_DIR; ~/.claude/settings.json is no
+    // longer where Claude stores it.
+    const cfg = tempDir()
+    writeFileSync(join(cfg, 'settings.json'), JSON.stringify({ disableSkillShellExecution: true }))
+    const saved = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = cfg
+    try {
+      expect(shellExecutionDisabled(tempDir(), hoisted.home, false)).toBe(true)
+    } finally {
+      if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR
+      else process.env.CLAUDE_CONFIG_DIR = saved
+    }
   })
 
   it('replaces spans with the placeholder on the user path when set', async () => {

--- a/tests/config-dir.test.ts
+++ b/tests/config-dir.test.ts
@@ -1,0 +1,55 @@
+import * as path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { hookFiles } from '../extensions/hooks.ts'
+import { claudeConfigDir } from '../extensions/internal/config-dir.ts'
+
+const HOME = '/home/testuser'
+
+describe('claudeConfigDir', () => {
+  const saved = process.env.CLAUDE_CONFIG_DIR
+  afterEach(() => {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR
+    else process.env.CLAUDE_CONFIG_DIR = saved
+  })
+
+  it('defaults to ~/.claude when CLAUDE_CONFIG_DIR is unset', () => {
+    delete process.env.CLAUDE_CONFIG_DIR
+    expect(claudeConfigDir(HOME)).toBe(path.join(HOME, '.claude'))
+  })
+
+  it('honors an absolute CLAUDE_CONFIG_DIR', () => {
+    process.env.CLAUDE_CONFIG_DIR = '/opt/claude-config'
+    expect(claudeConfigDir(HOME)).toBe('/opt/claude-config')
+  })
+
+  it('expands a leading ~ against home', () => {
+    process.env.CLAUDE_CONFIG_DIR = '~/nested/cfg'
+    expect(claudeConfigDir(HOME)).toBe(path.join(HOME, 'nested', 'cfg'))
+  })
+
+  it('resolves a relative CLAUDE_CONFIG_DIR to an absolute path', () => {
+    process.env.CLAUDE_CONFIG_DIR = 'relative/cfg'
+    expect(claudeConfigDir(HOME)).toBe(path.resolve('relative/cfg'))
+  })
+
+  it('ignores a blank CLAUDE_CONFIG_DIR', () => {
+    process.env.CLAUDE_CONFIG_DIR = '   '
+    expect(claudeConfigDir(HOME)).toBe(path.join(HOME, '.claude'))
+  })
+})
+
+describe('config-dir sweep', () => {
+  const saved = process.env.CLAUDE_CONFIG_DIR
+  afterEach(() => {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR
+    else process.env.CLAUDE_CONFIG_DIR = saved
+  })
+
+  it('a swept consumer (hookFiles) resolves the user settings under CLAUDE_CONFIG_DIR', () => {
+    process.env.CLAUDE_CONFIG_DIR = '/opt/claude-config'
+    const [userSettings] = hookFiles('/some/proj', HOME, false)
+    expect(userSettings).toBe(path.join('/opt/claude-config', 'settings.json'))
+  })
+})

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -17,9 +17,11 @@ import contextImports, {
   MANAGED_CLAUDE_MD_PATH,
   MAX_IMPORT_BYTES,
   MAX_IMPORT_FILES,
+  managedClaudeMdPath,
   parseAdditionalDirs,
   readClaudeMdExcludes,
   rootsForImporter,
+  setManagedClaudeMdPath,
 } from '../extensions/context-imports.ts'
 import { INSTRUCTIONS_CHANNEL } from '../extensions/internal/instruction-events.ts'
 import { managedSettingsPath, readManagedSettings, setManagedSettingsPath } from '../extensions/internal/managed-settings.ts'
@@ -43,13 +45,28 @@ const importsFor = (file: string, home: string, cwd: string, content?: string) =
 // realpath so allowed-root prefix checks hold on macOS (/tmp -> /private/tmp)
 const tempDir = (): string => realpathSync(mkdtempSync(join(tmpdir(), 'ci-')))
 
+/** Assemble a prompt exactly as pi's buildSystemPrompt does (pinned by the wrapper
+ * regression tests above); shared by the ordering tests for the added blocks. */
+const assembledPrompt = (files: Array<{ path: string; content: string }>): string => {
+  let prompt = 'BASE PROMPT'
+  if (files.length === 0) return prompt
+  prompt += '\n\n<project_context>\n\nProject-specific instructions and guidelines:\n\n'
+  for (const { path: filePath, content } of files) prompt += `<project_instructions path="${filePath}">\n${content}\n</project_instructions>\n\n`
+  prompt += '</project_context>\n'
+  return prompt
+}
+
 beforeEach(() => {
   hoisted.home = tempDir()
   setManagedSettingsPath(join(hoisted.home, 'managed-settings.json'))
+  // The managed CLAUDE.md file sits alongside managed-settings.json; point it at the
+  // same throwaway dir (dirname of the overridden settings path) so tests can write it.
+  setManagedClaudeMdPath(join(hoisted.home, 'CLAUDE.md'))
 })
 afterEach(() => {
   hoisted.home = ''
   setManagedSettingsPath(undefined)
+  setManagedClaudeMdPath(undefined)
 })
 
 describe('expandHome', () => {
@@ -395,6 +412,25 @@ describe('user config is off limits to project context files', () => {
     expect(handler.map((f) => f.body)).toEqual(['user extra'])
   })
 
+  it('grants user-config roots to an importer under CLAUDE_CONFIG_DIR', () => {
+    // With CLAUDE_CONFIG_DIR set, the user config tree moves; a context file living there
+    // must still be able to import from that same relocated config dir.
+    const home = tempDir()
+    const cwd = tempDir()
+    const cfg = tempDir()
+    const saved = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = cfg
+    try {
+      writeFileSync(join(cfg, 'CLAUDE.md'), 'user context')
+      writeFileSync(join(cfg, 'extra.md'), 'user extra')
+      const handler = importsFor(join(cfg, 'CLAUDE.md'), home, cwd, '@extra.md')
+      expect(handler.map((f) => f.body)).toEqual(['user extra'])
+    } finally {
+      if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR
+      else process.env.CLAUDE_CONFIG_DIR = saved
+    }
+  })
+
   it('still lets a project file import within the project', () => {
     const { home, cwd } = scenario()
     writeFileSync(join(cwd, 'notes.md'), 'project notes')
@@ -478,6 +514,22 @@ describe('claudeMdExcludes settings chain', () => {
     const home = tempDir()
     expect(claudeMdExcludeFiles(cwd, home, false)).toEqual([join(home, '.claude', 'settings.json')])
     expect(claudeMdExcludeFiles(cwd, home, true)).toEqual([join(home, '.claude', 'settings.json'), join(cwd, '.claude', 'settings.json'), join(cwd, '.claude', 'settings.local.json')])
+  })
+
+  it('resolves the user settings.json under CLAUDE_CONFIG_DIR, leaving project scope alone', () => {
+    const cwd = tempDir()
+    const home = tempDir()
+    const cfg = tempDir()
+    const saved = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = cfg
+    try {
+      // The user entry relocates; the approval-gated project entries do not.
+      expect(claudeMdExcludeFiles(cwd, home, false)).toEqual([join(cfg, 'settings.json')])
+      expect(claudeMdExcludeFiles(cwd, home, true)).toEqual([join(cfg, 'settings.json'), join(cwd, '.claude', 'settings.json'), join(cwd, '.claude', 'settings.local.json')])
+    } finally {
+      if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR
+      else process.env.CLAUDE_CONFIG_DIR = saved
+    }
   })
 
   it('merges exclude globs across settings files and managed settings', () => {
@@ -1050,5 +1102,338 @@ describe('--add-dir additional directories', () => {
     await wired.fire(cwd)
 
     expect(wired.instructionEvents()).toEqual([{ file_path: join(cwd, 'CLAUDE.local.md'), memory_type: 'Local', load_reason: 'session_start' }])
+  })
+})
+
+/** Wire the extension with an instruction-event bus, session_start and per-turn fire.
+ * Shared by the user, project .claude/CLAUDE.md and managed-file describes below. */
+const wireWithBus = () => {
+  const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>()
+  const emitted: Array<{ channel: string; data: unknown }> = []
+  contextImports({
+    on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn),
+    events: { emit: (channel: string, data: unknown) => emitted.push({ channel, data }), on: () => () => {} },
+  } as never)
+  return {
+    instructionEvents: () => emitted.filter((entry) => entry.channel === INSTRUCTIONS_CHANNEL).map((entry) => entry.data),
+    start: (ctx: Record<string, unknown>) => handlers.get('session_start')?.({}, ctx),
+    fire: async (cwd: string, contextFiles: Array<{ path: string; content: string }> = [], systemPrompt = 'BASE') => {
+      const result = (await handlers.get('before_agent_start')?.({ systemPrompt, systemPromptOptions: { cwd, contextFiles } }, {})) as { systemPrompt: string } | undefined
+      return result?.systemPrompt ?? systemPrompt
+    },
+  }
+}
+
+/** A session_start ctx that approves the project (Claude-shaped config trusted). */
+const approvingCtx = (cwd: string) => ({ cwd, isProjectTrusted: () => true, hasUI: true, ui: { notify: () => {}, confirm: async () => true } })
+
+describe('user CLAUDE.md (~/.claude/CLAUDE.md)', () => {
+  let savedAgentDir: string | undefined
+  beforeEach(() => {
+    savedAgentDir = process.env.PI_CODING_AGENT_DIR
+    process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), 'ci-agent-'))
+  })
+  afterEach(() => {
+    if (savedAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR
+    else process.env.PI_CODING_AGENT_DIR = savedAgentDir
+  })
+
+  /** Write ~/.claude/CLAUDE.md under the mocked home and return its path. */
+  const writeUserClaudeMd = (content: string): string => {
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    const file = join(hoisted.home, '.claude', 'CLAUDE.md')
+    writeFileSync(file, content)
+    return file
+  }
+
+  it('loads ~/.claude/CLAUDE.md as a User memory block, announced once at session_start', async () => {
+    const file = writeUserClaudeMd('USER GLOBAL RULES')
+    const cwd = tempDir()
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    const prompt = await wired.fire(cwd)
+
+    expect(prompt).toContain('USER GLOBAL RULES')
+    expect(wired.instructionEvents()).toEqual([{ file_path: file, memory_type: 'User', load_reason: 'session_start' }])
+
+    // before_agent_start fires every turn; the User announce must not repeat.
+    await wired.fire(cwd)
+    expect(wired.instructionEvents()).toHaveLength(1)
+  })
+
+  it('places the user block after the managed block and before pi native project blocks', async () => {
+    // Claude's order: managed, then user, then project.
+    writeUserClaudeMd('USER RULES')
+    writeFileSync(join(hoisted.home, 'managed-settings.json'), JSON.stringify({ claudeMd: 'ORG POLICY' }))
+    const cwd = tempDir()
+    const native = { path: join(cwd, 'CLAUDE.md'), content: 'PROJECT NATIVE RULES' }
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    const prompt = await wired.fire(cwd, [native], assembledPrompt([native]))
+
+    expect(prompt.indexOf('ORG POLICY')).toBeLessThan(prompt.indexOf('USER RULES'))
+    expect(prompt.indexOf('USER RULES')).toBeLessThan(prompt.indexOf('PROJECT NATIVE RULES'))
+  })
+
+  it('resolves @imports in the user CLAUDE.md against user-scope roots', async () => {
+    // A user-config file may reach the rest of the user config; @extra.md sits in
+    // ~/.claude, which only the user-scope roots allow.
+    writeUserClaudeMd('USER RULES\n@extra.md')
+    writeFileSync(join(hoisted.home, '.claude', 'extra.md'), 'USER EXTRA CONTENT')
+    const cwd = tempDir()
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    const prompt = await wired.fire(cwd)
+
+    expect(prompt).toContain('USER RULES')
+    expect(prompt).toContain('USER EXTRA CONTENT')
+  })
+
+  it('excludes the user CLAUDE.md when claudeMdExcludes matches it', async () => {
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ claudeMdExcludes: ['~/.claude/CLAUDE.md'] }))
+    writeUserClaudeMd('USER RULES\n@extra.md')
+    writeFileSync(join(hoisted.home, '.claude', 'extra.md'), 'USER EXTRA CONTENT')
+    const cwd = tempDir()
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    const prompt = await wired.fire(cwd)
+
+    expect(prompt).not.toContain('USER RULES')
+    // An excluded file's imports must not be pulled in either.
+    expect(prompt).not.toContain('USER EXTRA CONTENT')
+    expect(wired.instructionEvents()).toEqual([])
+  })
+
+  it('strips block comments from the user CLAUDE.md body', async () => {
+    writeUserClaudeMd('USER KEEP\n<!-- user secret -->\nUSER TAIL')
+    const cwd = tempDir()
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    const prompt = await wired.fire(cwd)
+
+    expect(prompt).toContain('USER KEEP')
+    expect(prompt).toContain('USER TAIL')
+    expect(prompt).not.toContain('user secret')
+  })
+
+  it('does nothing when there is no ~/.claude/CLAUDE.md', async () => {
+    const cwd = tempDir()
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    expect(await wired.fire(cwd)).toBe('BASE')
+    expect(wired.instructionEvents()).toEqual([])
+  })
+})
+
+describe('project CLAUDE.md alternate location (./.claude/CLAUDE.md)', () => {
+  let savedAgentDir: string | undefined
+  beforeEach(() => {
+    savedAgentDir = process.env.PI_CODING_AGENT_DIR
+    process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), 'ci-agent-'))
+  })
+  afterEach(() => {
+    if (savedAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR
+    else process.env.PI_CODING_AGENT_DIR = savedAgentDir
+  })
+
+  /** Write ./.claude/CLAUDE.md under `dir` and return its path. */
+  const writeDotClaudeMd = (dir: string, content: string): string => {
+    mkdirSync(join(dir, '.claude'), { recursive: true })
+    const file = join(dir, '.claude', 'CLAUDE.md')
+    writeFileSync(file, content)
+    return file
+  }
+
+  const declining = (cwd: string) => ({ cwd, isProjectTrusted: () => false, hasUI: false, ui: { notify: () => {} } })
+
+  it('loads the nearest ./.claude/CLAUDE.md as a Project block when the project is approved', async () => {
+    const cwd = tempDir()
+    const file = writeDotClaudeMd(cwd, 'DOT CLAUDE RULES')
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    const prompt = await wired.fire(cwd)
+
+    expect(prompt).toContain(instructionsBlock(file, 'DOT CLAUDE RULES'))
+    expect(wired.instructionEvents()).toContainEqual({ file_path: file, memory_type: 'Project', load_reason: 'session_start' })
+  })
+
+  it('does not load ./.claude/CLAUDE.md when the project is not approved', async () => {
+    // A cloned repo can ship .claude/CLAUDE.md; without approval it must not reach the prompt.
+    const cwd = tempDir()
+    writeDotClaudeMd(cwd, 'DOT CLAUDE RULES')
+
+    const wired = wireWithBus()
+    await wired.start(declining(cwd))
+    const prompt = await wired.fire(cwd)
+
+    expect(prompt).not.toContain('DOT CLAUDE RULES')
+  })
+
+  it('finds ./.claude/CLAUDE.md at the repository root from a subdirectory session, imports included', async () => {
+    const repo = tempDir()
+    mkdirSync(join(repo, '.git'))
+    const file = writeDotClaudeMd(repo, 'ROOT DOT RULES\n@style.md')
+    writeFileSync(join(repo, '.claude', 'style.md'), 'DOT STYLE CONTENT')
+    const sub = join(repo, 'src')
+    mkdirSync(sub)
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(sub))
+    const prompt = await wired.fire(sub)
+
+    expect(prompt).toContain('ROOT DOT RULES')
+    expect(prompt).toContain('DOT STYLE CONTENT')
+    expect(wired.instructionEvents()).toContainEqual({ file_path: file, memory_type: 'Project', load_reason: 'session_start' })
+  })
+
+  it('resolves @imports of ./.claude/CLAUDE.md against project roots', async () => {
+    // The importer sits in .claude; @../notes.md climbs to the project root, which
+    // the project-scope roots (cwd, repo root) allow.
+    const cwd = tempDir()
+    writeDotClaudeMd(cwd, 'DOT RULES\n@../notes.md')
+    writeFileSync(join(cwd, 'notes.md'), 'PROJECT NOTES CONTENT')
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    const prompt = await wired.fire(cwd)
+
+    expect(prompt).toContain('PROJECT NOTES CONTENT')
+  })
+
+  it('dedupes against a native context file: no double block if pi already loaded it', async () => {
+    const cwd = tempDir()
+    const file = writeDotClaudeMd(cwd, 'DOT CLAUDE RULES')
+    const native = { path: file, content: 'DOT CLAUDE RULES' }
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    const prompt = await wired.fire(cwd, [native], assembledPrompt([native]))
+
+    expect(prompt.match(/DOT CLAUDE RULES/g)).toHaveLength(1)
+  })
+
+  it('excludes ./.claude/CLAUDE.md when claudeMdExcludes matches, imports and all', async () => {
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ claudeMdExcludes: ['**/.claude/CLAUDE.md'] }))
+    const cwd = tempDir()
+    writeDotClaudeMd(cwd, 'DOT CLAUDE RULES\n@notes.md')
+    writeFileSync(join(cwd, 'notes.md'), 'PROJECT NOTES CONTENT')
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    const prompt = await wired.fire(cwd)
+
+    expect(prompt).not.toContain('DOT CLAUDE RULES')
+    expect(prompt).not.toContain('PROJECT NOTES CONTENT')
+    expect(wired.instructionEvents()).toEqual([])
+  })
+
+  it('strips block comments from ./.claude/CLAUDE.md', async () => {
+    const cwd = tempDir()
+    writeDotClaudeMd(cwd, 'DOT KEEP\n<!-- dot secret -->\nDOT TAIL')
+
+    const wired = wireWithBus()
+    await wired.start(approvingCtx(cwd))
+    const prompt = await wired.fire(cwd)
+
+    expect(prompt).toContain('DOT KEEP')
+    expect(prompt).toContain('DOT TAIL')
+    expect(prompt).not.toContain('dot secret')
+  })
+})
+
+describe('managed CLAUDE.md file', () => {
+  /** Write the managed CLAUDE.md file (alongside managed-settings.json) and return its path. */
+  const writeManagedFile = (content: string): string => {
+    const file = managedClaudeMdPath()
+    writeFileSync(file, content)
+    return file
+  }
+
+  const writeManagedSettings = (settings: Record<string, unknown>): void => {
+    writeFileSync(join(hoisted.home, 'managed-settings.json'), JSON.stringify(settings))
+  }
+
+  const writeUserSettings = (settings: Record<string, unknown>): void => {
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify(settings))
+  }
+
+  it('loads the managed CLAUDE.md file as a Managed block, announced at session_start', async () => {
+    const file = writeManagedFile('ORG FILE POLICY')
+    const cwd = tempDir()
+
+    const wired = wireWithBus()
+    const prompt = await wired.fire(cwd)
+
+    expect(prompt).toContain(instructionsBlock(file, 'ORG FILE POLICY'))
+    expect(wired.instructionEvents()).toEqual([{ file_path: file, memory_type: 'Managed', load_reason: 'session_start' }])
+
+    // before_agent_start fires every turn; the Managed announce must not repeat.
+    await wired.fire(cwd)
+    expect(wired.instructionEvents()).toHaveLength(1)
+  })
+
+  it('loads the managed file before user and project context', async () => {
+    const file = writeManagedFile('ORG FILE POLICY')
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'CLAUDE.md'), 'USER RULES')
+    const cwd = tempDir()
+    const native = { path: join(cwd, 'CLAUDE.md'), content: 'PROJECT NATIVE RULES' }
+
+    const wired = wireWithBus()
+    await wired.start({ cwd, isProjectTrusted: () => true, hasUI: true, ui: { notify: () => {}, confirm: async () => true } })
+    const prompt = await wired.fire(cwd, [native], assembledPrompt([native]))
+
+    expect(prompt).toContain(instructionsBlock(file, 'ORG FILE POLICY'))
+    expect(prompt.indexOf('ORG FILE POLICY')).toBeLessThan(prompt.indexOf('USER RULES'))
+    expect(prompt.indexOf('USER RULES')).toBeLessThan(prompt.indexOf('PROJECT NATIVE RULES'))
+  })
+
+  it('merges the managed file before the managed settings-key when both exist', async () => {
+    // File content first, then the settings-key content, both managed policy.
+    const file = writeManagedFile('ORG FILE POLICY')
+    writeManagedSettings({ claudeMd: 'ORG KEY POLICY' })
+    const cwd = tempDir()
+
+    const prompt = await wireWithBus().fire(cwd)
+
+    expect(prompt).toContain(instructionsBlock(file, 'ORG FILE POLICY'))
+    expect(prompt).toContain(instructionsBlock(MANAGED_CLAUDE_MD_PATH, 'ORG KEY POLICY'))
+    expect(prompt.indexOf('ORG FILE POLICY')).toBeLessThan(prompt.indexOf('ORG KEY POLICY'))
+  })
+
+  it('never excludes the managed file, even with a catch-all claudeMdExcludes', async () => {
+    writeManagedFile('ORG FILE POLICY')
+    writeUserSettings({ claudeMdExcludes: ['**'] })
+    const cwd = tempDir()
+    const native = { path: join(cwd, 'CLAUDE.md'), content: 'PROJECT RULES' }
+
+    const prompt = await wireWithBus().fire(cwd, [native], assembledPrompt([native]))
+
+    expect(prompt).toContain('ORG FILE POLICY')
+    expect(prompt).not.toContain('PROJECT RULES')
+  })
+
+  it('strips block comments from the managed file body', async () => {
+    writeManagedFile('ORG KEEP\n<!-- managed note -->\nORG TAIL')
+    const cwd = tempDir()
+
+    const prompt = await wireWithBus().fire(cwd)
+
+    expect(prompt).toContain('ORG KEEP')
+    expect(prompt).toContain('ORG TAIL')
+    expect(prompt).not.toContain('managed note')
+  })
+
+  it('does nothing when there is no managed file and no managed key', async () => {
+    expect(await wireWithBus().fire(tempDir())).toBe('BASE')
   })
 })

--- a/tests/context-usage.test.ts
+++ b/tests/context-usage.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import contextUsageExtension, { formatContextUsage } from '../extensions/context-usage.ts'
+
+type CommandSpec = { description?: string; handler: (args: string, ctx: unknown) => Promise<void> }
+
+function wire() {
+  const commands = new Map<string, CommandSpec>()
+  contextUsageExtension({
+    on: () => {},
+    registerCommand: (name: string, spec: CommandSpec) => commands.set(name, spec),
+  } as never)
+  return commands
+}
+
+describe('formatContextUsage', () => {
+  it('renders a used/window/free breakdown with a percentage for populated usage', () => {
+    const text = formatContextUsage({ tokens: 45000, contextWindow: 200000, percent: 22.5 })
+    expect(text).toContain('45,000')
+    expect(text).toContain('200,000')
+    expect(text).toContain('22.5%')
+    expect(text).toContain('155,000') // window minus used
+  })
+
+  it('falls back to the model window and derives a percentage when usage omits them', () => {
+    // usage.contextWindow is 0 and percent is null, so the model window and a derived
+    // percentage carry the breakdown.
+    const text = formatContextUsage({ tokens: 50000, contextWindow: 0, percent: null }, 200000)
+    expect(text).toContain('200,000')
+    expect(text).toContain('25.0%')
+    expect(text).toContain('150,000')
+  })
+
+  it('reports a friendly message when usage is undefined', () => {
+    expect(formatContextUsage(undefined)).toMatch(/not available yet/i)
+  })
+
+  it('reports recalculating when tokens are unknown, still naming the window', () => {
+    const text = formatContextUsage({ tokens: null, contextWindow: 200000, percent: null })
+    expect(text).toMatch(/recalculat/i)
+    expect(text).toContain('200,000')
+  })
+})
+
+describe('context command', () => {
+  it('registers a single context command', () => {
+    expect([...wire().keys()]).toEqual(['context'])
+  })
+
+  it('notifies the populated breakdown as info', async () => {
+    const commands = wire()
+    const notify = vi.fn()
+    const ctx = {
+      getContextUsage: () => ({ tokens: 12345, contextWindow: 200000, percent: 6.2 }),
+      model: { contextWindow: 200000 },
+      ui: { notify },
+    }
+    await commands.get('context')?.handler('', ctx)
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(notify.mock.calls[0][0]).toContain('12,345')
+    expect(notify.mock.calls[0][0]).toContain('6.2%')
+    expect(notify.mock.calls[0][1]).toBe('info')
+  })
+
+  it('notifies the friendly message when there is no usage yet', async () => {
+    const commands = wire()
+    const notify = vi.fn()
+    const ctx = { getContextUsage: () => undefined, model: undefined, ui: { notify } }
+    await commands.get('context')?.handler('', ctx)
+    expect(notify.mock.calls[0][0]).toMatch(/not available yet/i)
+  })
+})

--- a/tests/env-settings.test.ts
+++ b/tests/env-settings.test.ts
@@ -1,0 +1,243 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import envSettingsExtension, { applyEnvSettings, envFromSettings, mergeEnvScopes } from '../extensions/env-settings.ts'
+import { setManagedSettingsPath } from '../extensions/internal/managed-settings.ts'
+
+const hoisted = vi.hoisted(() => ({ home: '', approved: false }))
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: () => hoisted.home }
+})
+
+// The project scope stays approval-gated (a project env var can redirect a provider),
+// so approval is stubbed to a per-test flag rather than exercising the trust store here.
+vi.mock('../extensions/internal/project-approval.js', () => ({
+  isProjectApprovedSilently: () => hoisted.approved,
+}))
+
+describe('envFromSettings', () => {
+  it('extracts string env values from a settings object', () => {
+    expect(envFromSettings({ env: { A: 'x', B: 'y' } })).toEqual({ A: 'x', B: 'y' })
+  })
+
+  it('coerces numbers and booleans to strings', () => {
+    expect(envFromSettings({ env: { N: 3, T: true, F: false } })).toEqual({ N: '3', T: 'true', F: 'false' })
+  })
+
+  it('skips non-scalar values (object, array, null)', () => {
+    expect(envFromSettings({ env: { O: {}, A: [], Z: null, S: 'keep' } })).toEqual({ S: 'keep' })
+  })
+
+  it('returns an empty object when there is no env object', () => {
+    expect(envFromSettings({})).toEqual({})
+    expect(envFromSettings(null)).toEqual({})
+    expect(envFromSettings({ env: 'nope' })).toEqual({})
+  })
+})
+
+describe('mergeEnvScopes', () => {
+  it('merges per key with precedence managed > user > project without wiping other scopes', () => {
+    const merged = mergeEnvScopes({ A: 'm', C: 'mc' }, { A: 'u', B: 'ub' }, { A: 'p', D: 'pd' })
+    expect(merged).toEqual({ A: 'm', B: 'ub', C: 'mc', D: 'pd' })
+  })
+})
+
+describe('applyEnvSettings', () => {
+  it('sets new keys and records them as owned', () => {
+    const env: NodeJS.ProcessEnv = {}
+    const owned = new Set<string>()
+    applyEnvSettings({ A: '1' }, env, owned)
+    expect(env.A).toBe('1')
+    expect(owned.has('A')).toBe(true)
+  })
+
+  it('never overwrites a variable already in the real environment it did not set', () => {
+    const env: NodeJS.ProcessEnv = { A: 'shell' }
+    const owned = new Set<string>()
+    applyEnvSettings({ A: 'settings' }, env, owned)
+    expect(env.A).toBe('shell')
+    expect(owned.has('A')).toBe(false)
+  })
+
+  it('updates a key it owns on a later refresh', () => {
+    const env: NodeJS.ProcessEnv = {}
+    const owned = new Set<string>()
+    applyEnvSettings({ A: '1' }, env, owned)
+    applyEnvSettings({ A: '2' }, env, owned)
+    expect(env.A).toBe('2')
+  })
+
+  it('unsets a key it owns once a later apply no longer defines it', () => {
+    // Cross-project leak guard: a key an approved project set must not persist into a
+    // later apply (session or project) that does not define it.
+    const env: NodeJS.ProcessEnv = {}
+    const owned = new Set<string>()
+    applyEnvSettings({ A: '1' }, env, owned)
+    applyEnvSettings({}, env, owned)
+    expect('A' in env).toBe(false)
+    expect(owned.has('A')).toBe(false)
+  })
+
+  it('leaves a key it never owned (a shell export) untouched on unset', () => {
+    // The unset guard only removes keys this module set, never a shell export it skipped.
+    const env: NodeJS.ProcessEnv = { A: 'shell' }
+    const owned = new Set<string>()
+    applyEnvSettings({ A: 'settings' }, env, owned) // skipped: shell outranks
+    applyEnvSettings({}, env, owned)
+    expect(env.A).toBe('shell')
+  })
+
+  it('lets a managed key overwrite a shell export, but a user key does not', () => {
+    // Managed policy outranks even an ambient shell export; user/project do not.
+    const managedEnv: NodeJS.ProcessEnv = { A: 'shell' }
+    const managedOwned = new Set<string>()
+    applyEnvSettings({ A: 'managed' }, managedEnv, managedOwned, new Set(['A']))
+    expect(managedEnv.A).toBe('managed')
+    expect(managedOwned.has('A')).toBe(true)
+
+    const userEnvVar: NodeJS.ProcessEnv = { A: 'shell' }
+    const userOwned = new Set<string>()
+    applyEnvSettings({ A: 'user' }, userEnvVar, userOwned, new Set())
+    expect(userEnvVar.A).toBe('shell')
+    expect(userOwned.has('A')).toBe(false)
+  })
+})
+
+describe('env-settings extension', () => {
+  const tempDirs: string[] = []
+  const tempDir = (prefix: string): string => {
+    const dir = mkdtempSync(join(tmpdir(), prefix))
+    tempDirs.push(dir)
+    return dir
+  }
+  const usedKeys = new Set<string>()
+  const setReal = (key: string, value: string): void => {
+    usedKeys.add(key)
+    process.env[key] = value
+  }
+  const writeSettings = (dir: string, name: string, env: unknown): void => {
+    mkdirSync(join(dir, '.claude'), { recursive: true })
+    writeFileSync(join(dir, '.claude', name), JSON.stringify({ env }))
+  }
+  const track = (...keys: string[]): void => {
+    for (const key of keys) usedKeys.add(key)
+  }
+
+  type Handler = (event: Record<string, unknown>, ctx?: Record<string, unknown>) => Promise<unknown>
+  const setup = (): { handlers: Map<string, Handler> } => {
+    const handlers = new Map<string, Handler>()
+    envSettingsExtension({ on: (name: string, fn: Handler) => handlers.set(name, fn) } as never)
+    return { handlers }
+  }
+
+  beforeEach(() => {
+    hoisted.home = tempDir('env-home-')
+    hoisted.approved = false
+    setManagedSettingsPath(join(hoisted.home, 'managed-settings.json'))
+  })
+
+  afterEach(() => {
+    for (const key of usedKeys) delete process.env[key]
+    usedKeys.clear()
+    setManagedSettingsPath(undefined)
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('applies user and managed env at factory time, but not project env', async () => {
+    track('ENVTEST_USER', 'ENVTEST_MANAGED', 'ENVTEST_PROJECT')
+    writeSettings(hoisted.home, 'settings.json', { ENVTEST_USER: 'uv' })
+    writeFileSync(join(hoisted.home, 'managed-settings.json'), JSON.stringify({ env: { ENVTEST_MANAGED: 'mv' } }))
+
+    setup()
+    expect(process.env.ENVTEST_USER).toBe('uv')
+    expect(process.env.ENVTEST_MANAGED).toBe('mv')
+    // Project scope needs the session ctx for approval, so it is untouched at factory time.
+    expect(process.env.ENVTEST_PROJECT).toBeUndefined()
+  })
+
+  it('adds approved project env at session_start', async () => {
+    track('ENVTEST_PROJECT')
+    const project = tempDir('env-proj-')
+    writeSettings(project, 'settings.json', { ENVTEST_PROJECT: 'pv' })
+    hoisted.approved = true
+
+    const { handlers } = setup()
+    await handlers.get('session_start')?.({ reason: 'startup' }, { cwd: project, isProjectTrusted: () => true })
+    expect(process.env.ENVTEST_PROJECT).toBe('pv')
+  })
+
+  it('merges settings.local.json over settings.json within the approved project scope', async () => {
+    track('ENVTEST_PROJECT')
+    const project = tempDir('env-proj-')
+    writeSettings(project, 'settings.json', { ENVTEST_PROJECT: 'base' })
+    writeSettings(project, 'settings.local.json', { ENVTEST_PROJECT: 'local' })
+    hoisted.approved = true
+
+    const { handlers } = setup()
+    await handlers.get('session_start')?.({ reason: 'startup' }, { cwd: project, isProjectTrusted: () => true })
+    expect(process.env.ENVTEST_PROJECT).toBe('local')
+  })
+
+  it('ignores project env when the project is not approved', async () => {
+    track('ENVTEST_PROJECT')
+    const project = tempDir('env-proj-')
+    writeSettings(project, 'settings.json', { ENVTEST_PROJECT: 'pv' })
+    hoisted.approved = false
+
+    const { handlers } = setup()
+    await handlers.get('session_start')?.({ reason: 'startup' }, { cwd: project, isProjectTrusted: () => true })
+    expect(process.env.ENVTEST_PROJECT).toBeUndefined()
+  })
+
+  it('does not overwrite a variable already in the real environment', async () => {
+    setReal('ENVTEST_REAL', 'from-shell')
+    writeSettings(hoisted.home, 'settings.json', { ENVTEST_REAL: 'from-settings' })
+
+    setup()
+    expect(process.env.ENVTEST_REAL).toBe('from-shell')
+  })
+
+  it('applies managed over user per key at factory time', async () => {
+    track('ENVTEST_SHARED', 'ENVTEST_USER_ONLY')
+    writeSettings(hoisted.home, 'settings.json', { ENVTEST_SHARED: 'user', ENVTEST_USER_ONLY: 'u' })
+    writeFileSync(join(hoisted.home, 'managed-settings.json'), JSON.stringify({ env: { ENVTEST_SHARED: 'managed' } }))
+
+    setup()
+    expect(process.env.ENVTEST_SHARED).toBe('managed')
+    expect(process.env.ENVTEST_USER_ONLY).toBe('u')
+  })
+
+  it('unsets an approved project key once a later session no longer defines it', async () => {
+    track('ENVTEST_PROJECT')
+    const project = tempDir('env-proj-')
+    writeSettings(project, 'settings.json', { ENVTEST_PROJECT: 'pv' })
+    hoisted.approved = true
+
+    const { handlers } = setup()
+    await handlers.get('session_start')?.({ reason: 'startup' }, { cwd: project, isProjectTrusted: () => true })
+    expect(process.env.ENVTEST_PROJECT).toBe('pv')
+
+    // A later session on a project that does not define the key must unset it, so an
+    // approved project's env cannot leak into a later one within the same process.
+    const other = tempDir('env-proj-')
+    await handlers.get('session_start')?.({ reason: 'startup' }, { cwd: other, isProjectTrusted: () => true })
+    expect(process.env.ENVTEST_PROJECT).toBeUndefined()
+  })
+
+  it('lets managed env override a preexisting shell export, but user env does not', async () => {
+    track('ENVTEST_MANAGED_OVR', 'ENVTEST_USER_OVR')
+    setReal('ENVTEST_MANAGED_OVR', 'from-shell')
+    setReal('ENVTEST_USER_OVR', 'from-shell')
+    writeFileSync(join(hoisted.home, 'managed-settings.json'), JSON.stringify({ env: { ENVTEST_MANAGED_OVR: 'from-managed' } }))
+    writeSettings(hoisted.home, 'settings.json', { ENVTEST_USER_OVR: 'from-user' })
+
+    setup()
+    expect(process.env.ENVTEST_MANAGED_OVR).toBe('from-managed') // managed outranks the shell
+    expect(process.env.ENVTEST_USER_OVR).toBe('from-shell') // user does not
+  })
+})

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -216,8 +216,24 @@ describe('runHookCommand process wiring', () => {
     expect(record.file).toBe('/bin/sh')
     expect(record.args).toEqual(['-c', 'guard.sh'])
     // `detached` is what makes the shell a process-group leader, so a timeout can kill
-    // the grandchildren a compound command forks.
-    expect(record.options).toEqual({ stdio: ['pipe', 'pipe', 'pipe'], detached: true, env: process.env })
+    // the grandchildren a compound command forks. Claude marks every subprocess it
+    // spawns with CLAUDECODE=1, so the child env inherits the parent's plus that flag.
+    expect(record.options).toEqual({ stdio: ['pipe', 'pipe', 'pipe'], detached: true, env: { ...process.env, CLAUDECODE: '1' } })
+  })
+
+  it('marks the hook child with CLAUDECODE=1 even when the parent env lacks it', async () => {
+    // Hermetic: pi-code itself may run under a parent that already set CLAUDECODE, so
+    // clear it to prove runHookCommand adds the flag rather than merely inheriting it.
+    const saved = process.env.CLAUDECODE
+    delete process.env.CLAUDECODE
+    try {
+      await runHookCommand('guard.sh', {}, 5000)
+      const options = recordFor('guard.sh').options as { env?: Record<string, string> }
+      expect(options.env?.CLAUDECODE).toBe('1')
+    } finally {
+      if (saved === undefined) delete process.env.CLAUDECODE
+      else process.env.CLAUDECODE = saved
+    }
   })
 
   it('writes the payload to stdin as JSON', async () => {
@@ -262,6 +278,46 @@ describe('runHookCommand process wiring', () => {
   it('swallows an EPIPE from a hook that exits without reading stdin', async () => {
     script('exit2', { stdinError: Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }), stderr: ['denied'], code: 2 })
     expect(await runHookCommand('exit2', {}, 5000)).toEqual({ code: 2, stdout: '', stderr: 'denied', timedOut: false })
+  })
+})
+
+describe('runHookCommand exec form', () => {
+  it('spawns the executable directly with its args and no /bin/sh wrapper', async () => {
+    await runHookCommand('/usr/bin/notify', {}, 5000, undefined, ['--message', 'hi; rm -rf /'])
+    const record = hoisted.calls.find((call) => call.file === '/usr/bin/notify')
+    expect(record).toBeDefined()
+    // No `/bin/sh -c`: the executable is spawned directly, so the metacharacters in the
+    // args are handed over literally rather than interpreted by a shell.
+    expect(record?.args).toEqual(['--message', 'hi; rm -rf /'])
+    expect(record?.options).toMatchObject({ detached: true, stdio: ['pipe', 'pipe', 'pipe'] })
+  })
+
+  it('delivers the payload as JSON on stdin, like the shell path', async () => {
+    await runHookCommand('/bin/tool', { tool_name: 'bash' }, 5000, undefined, ['run'])
+    const record = hoisted.calls.find((call) => call.file === '/bin/tool')
+    expect(JSON.parse(record?.stdin ?? '')).toEqual({ tool_name: 'bash' })
+  })
+
+  it('substitutes $ARGUMENTS per arg with a $$-safe replacer', async () => {
+    const payload = { tool_input: { command: 'echo $$ && x $&' } }
+    await runHookCommand('/bin/tool', payload, 5000, undefined, ['--json', '$ARGUMENTS', 'tail-$ARGUMENTS'])
+    const record = hoisted.calls.find((call) => call.file === '/bin/tool')
+    expect(record?.args[0]).toBe('--json')
+    // The whole event JSON replaces $ARGUMENTS; the $$ / $& inside it survive verbatim
+    // rather than being eaten as String.replace patterns.
+    expect(record?.args[1]).toBe(JSON.stringify(payload))
+    expect(record?.args[1]).toContain('echo $$ && x $&')
+    // Substitution applies to every arg, mid-string included.
+    expect(record?.args[2]).toBe(`tail-${JSON.stringify(payload)}`)
+  })
+
+  it('kills the exec-form child at the timeout, like the shell path', async () => {
+    vi.useFakeTimers()
+    script('holdopen', { hang: true })
+    void runHookCommand('/bin/tool', {}, 1000, undefined, ['run', 'holdopen'])
+    await vi.advanceTimersByTimeAsync(1000)
+    const record = hoisted.calls.find((call) => call.file === '/bin/tool')
+    expect(record?.killSignals).toEqual(['SIGKILL'])
   })
 })
 
@@ -649,6 +705,7 @@ describe('hooks extension session_start', () => {
 
     const options = recordFor('home-pre').options as { env?: Record<string, string> }
     expect(options.env?.CLAUDE_PROJECT_DIR).toBe(project)
+    expect(options.env?.CLAUDECODE).toBe('1')
     expect(options.env?.PATH).toBeDefined()
   })
 
@@ -1012,6 +1069,64 @@ describe('hooks extension notify-style events', () => {
     await ext.agentEnd()
     const third = hoisted.calls.filter((call) => call.command === 'keep-going')[2]
     expect(JSON.parse(third.stdin)).toEqual({ ...COMMON, hook_event_name: 'Stop', stop_hook_active: false })
+  })
+
+  describe('Stop hook consecutive-block cap', () => {
+    it('overrides the Stop hook after the default cap of consecutive blocks, ending the turn with a warning', async () => {
+      const ext = await withHooks({ Stop: [{ hooks: [{ command: 'keep-going' }] }] })
+      script('keep-going', { stderr: ['still red'], code: 2 })
+      // Blocks 1..7 each continue the conversation.
+      for (let i = 0; i < 7; i += 1) await ext.agentEnd()
+      expect(ext.sent).toHaveLength(7)
+      // The 8th consecutive block is suppressed: no continuation, a warning instead, and
+      // the turn is allowed to end.
+      await ext.agentEnd()
+      expect(ext.sent).toHaveLength(7)
+      expect(ext.notes.some((n) => n.level === 'warning' && /cap/i.test(n.msg))).toBe(true)
+    })
+
+    it('honors CLAUDE_CODE_STOP_HOOK_BLOCK_CAP as the consecutive-block cap', async () => {
+      const saved = process.env.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP
+      process.env.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP = '2'
+      try {
+        const ext = await withHooks({ Stop: [{ hooks: [{ command: 'keep-going' }] }] })
+        script('keep-going', { stderr: ['nope'], code: 2 })
+        await ext.agentEnd() // block 1 continues
+        expect(ext.sent).toHaveLength(1)
+        await ext.agentEnd() // block 2 hits the cap: suppressed
+        expect(ext.sent).toHaveLength(1)
+        expect(ext.notes.some((n) => /cap/i.test(n.msg))).toBe(true)
+      } finally {
+        if (saved === undefined) delete process.env.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP
+        else process.env.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP = saved
+      }
+    })
+
+    it('resets the streak on a non-blocking Stop result so a later block continues again', async () => {
+      const ext = await withHooks({ Stop: [{ hooks: [{ command: 'keep-going' }] }] })
+      script('keep-going', { stderr: ['red'], code: 2 })
+      for (let i = 0; i < 7; i += 1) await ext.agentEnd()
+      expect(ext.sent).toHaveLength(7)
+      // A clean stop breaks the streak...
+      script('keep-going', { code: 0, stderr: [] })
+      await ext.agentEnd()
+      expect(ext.sent).toHaveLength(7)
+      // ...so the next block continues rather than tripping the cap at the 8th call.
+      script('keep-going', { stderr: ['red again'], code: 2 })
+      await ext.agentEnd()
+      expect(ext.sent).toHaveLength(8)
+    })
+
+    it('resets the streak on genuine user input', async () => {
+      const ext = await withHooks({ Stop: [{ hooks: [{ command: 'keep-going' }] }] })
+      script('keep-going', { stderr: ['red'], code: 2 })
+      for (let i = 0; i < 7; i += 1) await ext.agentEnd()
+      expect(ext.sent).toHaveLength(7)
+      // User input breaks the streak, so the next block continues rather than capping.
+      await ext.input('keep working on it')
+      await ext.agentEnd()
+      expect(ext.sent).toHaveLength(8)
+    })
   })
 
   it('surfaces a systemMessage from any hook as a user warning', async () => {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -24,6 +24,7 @@ import {
   runMcpToolHook,
   runPreToolUse,
   runPromptHook,
+  stopHookBlockCap,
 } from '../extensions/hooks.ts'
 import { setAgentRunner } from '../extensions/internal/agent-run.ts'
 import { setMcpToolCaller } from '../extensions/internal/mcp-call.ts'
@@ -88,6 +89,33 @@ describe('runPromptHook', () => {
     })
     const result = await runPromptHook({ type: 'prompt', command: '', prompt: 'x' }, {}, fakeModel, 30)
     expect(result.timedOut).toBe(true)
+  })
+})
+
+describe('stopHookBlockCap', () => {
+  it('defaults to 8 and honors a positive integer CLAUDE_CODE_STOP_HOOK_BLOCK_CAP override', () => {
+    expect(stopHookBlockCap({})).toBe(8)
+    expect(stopHookBlockCap({ CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: '3' })).toBe(3)
+    // Non-positive or malformed values fall back to the default rather than capping at 0.
+    expect(stopHookBlockCap({ CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: '0' })).toBe(8)
+    expect(stopHookBlockCap({ CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: '-2' })).toBe(8)
+    expect(stopHookBlockCap({ CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: 'lots' })).toBe(8)
+  })
+})
+
+describe('runHookCommand exec form (real shell)', () => {
+  it('spawns the executable directly with no shell, so metacharacters in args stay literal', async () => {
+    // Through /bin/sh these would be command-substituted or split; exec-form passes
+    // each arg through untouched.
+    const result = await runHookCommand('/bin/echo', {}, 5000, undefined, ['$(whoami)', 'a;b', '$HOME'])
+    expect(result.code).toBe(0)
+    expect(result.stdout).toBe('$(whoami) a;b $HOME\n')
+  })
+
+  it('delivers the payload on stdin and substitutes $ARGUMENTS per arg from the payload', async () => {
+    const payload = { k: 'v' }
+    const result = await runHookCommand('/bin/echo', payload, 5000, undefined, ['$ARGUMENTS'])
+    expect(result.stdout).toBe(`${JSON.stringify(payload)}\n`)
   })
 })
 

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -974,8 +974,10 @@ describe('mcp tool execution', () => {
     vi.useFakeTimers()
 
     const pending = harness.tools[0].execute('call-1', {})
-    const assertion = expect(pending).rejects.toThrow('sonar_qube_search_issues timed out after 120000ms')
-    await vi.advanceTimersByTimeAsync(120_000)
+    // The outer race now uses the 4h wall budget (the idle timeout lives inside the SDK,
+    // which is stubbed here), so a fully hung call rejects at the wall.
+    const assertion = expect(pending).rejects.toThrow('sonar_qube_search_issues timed out after 14400000ms')
+    await vi.advanceTimersByTimeAsync(14_400_000)
     await assertion
   })
 
@@ -992,13 +994,89 @@ describe('mcp tool execution', () => {
     expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 5000 })
   })
 
-  it('passes the call timeout to the SDK so its shorter default cannot fire first', async () => {
+  it('passes the two-tier timeout to the SDK so its shorter default cannot fire first', async () => {
     hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
     const harness = await registerOne()
 
     await harness.tools[0].execute('call-1', {})
 
-    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 120_000 })
+    // The SDK gets the idle window as its per-quiet-period deadline (reset on progress),
+    // capped at the 4h wall; its own 60s default can no longer fire first.
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 300_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
+  })
+})
+
+describe('mcp tool-call idle timeout', () => {
+  const registerGo = async (config: Record<string, unknown> = { command: 'x' }): Promise<Harness> => {
+    withTools([{ name: 'go' }])
+    return setupStarted({ user: { srv: config } })
+  }
+
+  it('layers the default 300s idle window under the 4h wall budget, resetting on progress', async () => {
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
+    const harness = await registerGo()
+
+    await harness.tools[0].execute('c1', {})
+
+    // The idle window is the SDK's per-quiet-period deadline, reset on every progress
+    // notification; maxTotalTimeout caps the wall clock; onprogress is required so the
+    // server addresses progress here and the SDK resets the timer on it.
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 300_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
+  })
+
+  it('honors CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT for the idle window', async () => {
+    setEnv('CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT', '60000')
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
+    const harness = await registerGo()
+
+    await harness.tools[0].execute('c1', {})
+
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 60_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
+  })
+
+  it('disables the idle window for CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=0, leaving only the wall budget', async () => {
+    setEnv('CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT', '0')
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
+    const harness = await registerGo()
+
+    await harness.tools[0].execute('c1', {})
+
+    // A plain wall-clock timeout, no progress machinery.
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 14_400_000 })
+  })
+
+  it('keeps a per-server timeout as the wall-clock ceiling above the idle window', async () => {
+    // A 10 min per-server budget, wider than the 5 min idle window: the idle timeout still
+    // guards each quiet period, and the per-server value caps the wall clock.
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
+    const harness = await registerGo({ command: 'x', timeout: 600_000 })
+
+    await harness.tools[0].execute('c1', {})
+
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 300_000, resetTimeoutOnProgress: true, maxTotalTimeout: 600_000, onprogress: expect.any(Function) })
+  })
+
+  it('uses a plain wall timeout when a per-server budget is tighter than the idle window', async () => {
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
+    const harness = await registerGo({ command: 'x', timeout: 2000 })
+
+    await harness.tools[0].execute('c1', {})
+
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 2000 })
+  })
+
+  it('rejects a fully hung call at the wall budget, not the idle window', async () => {
+    // The stubbed SDK never enforces the idle timeout (that lives inside the real SDK), so
+    // the outer race is what fires: it must use the wall budget so a legitimately
+    // progressing call is never cut off at the idle window.
+    const harness = await registerGo({ command: 'x', timeout: 600_000 })
+    hoisted.control.callTool = () => new Promise<CallResult>(() => {})
+    vi.useFakeTimers()
+
+    const pending = harness.tools[0].execute('c1', {})
+    const assertion = expect(pending).rejects.toThrow('srv_go timed out after 600000ms')
+    await vi.advanceTimersByTimeAsync(600_000)
+    await assertion
   })
 })
 
@@ -1292,11 +1370,13 @@ describe('small MCP parity', () => {
     withTools([{ name: 'quick' }])
     const harness = await setupStarted({ user: { srv: { command: 'x', timeout: 1500 }, floored: { command: 'y', timeout: 10 } } })
     await harness.tools[0].execute('c1', {})
-    expect((hoisted.callOptions.at(-1) as { timeout: number }).timeout).toBe(1500)
+    // A per-server budget below the idle window is the plain wall-clock timeout.
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 1500 })
 
-    // Below Claude's documented 1s minimum the per-server value is ignored.
+    // Below Claude's documented 1s minimum the per-server value is ignored, so the call
+    // falls back to the global default, whose SDK deadline is the idle window under the 4h wall.
     await harness.tools[1].execute('c2', {})
-    expect((hoisted.callOptions.at(-1) as { timeout: number }).timeout).toBe(120_000)
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 300_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
   })
 
   it('expands environment variables in cwd', async () => {
@@ -1798,5 +1878,107 @@ describe('mcp resource tools', () => {
 
     expect(harness.toolNames()).not.toContain('read_mcp_resource')
     expect(harness.warnings.join('\n')).toContain('read_mcp_resource')
+  })
+})
+
+describe('managed-mcp.json exclusive control', () => {
+  // managed-mcp.json lives beside managed-settings.json; point the extension at a throwaway
+  // pair in a temp dir so managedMcpPath resolves the sibling from the managed settings path.
+  const withManagedMcp = (mcp: unknown, settings: unknown = {}): void => {
+    const dir = mkdtempSync(join(tmpdir(), 'mcp-managed-'))
+    tempDirs.push(dir)
+    writeFileSync(join(dir, 'managed-settings.json'), JSON.stringify(settings))
+    writeFileSync(join(dir, 'managed-mcp.json'), typeof mcp === 'string' ? mcp : JSON.stringify(mcp))
+    setManagedSettingsPath(join(dir, 'managed-settings.json'))
+  }
+  const withoutManagedMcp = (settings: unknown = {}): void => {
+    // Managed settings present, but no managed-mcp.json sibling: normal loading.
+    const dir = mkdtempSync(join(tmpdir(), 'mcp-managed-'))
+    tempDirs.push(dir)
+    writeFileSync(join(dir, 'managed-settings.json'), JSON.stringify(settings))
+    setManagedSettingsPath(join(dir, 'managed-settings.json'))
+  }
+  afterEach(() => setManagedSettingsPath(undefined))
+
+  it('loads only the managed servers, suppressing user and project scopes', async () => {
+    withTools([{ name: 'go' }])
+    withManagedMcp({ mcpServers: { managed: { command: 'm' } } })
+    const harness = await setup({ user: { fromUser: { command: 'u' } }, project: { fromProject: { command: 'p' } } })
+
+    await harness.sessionStart(true)
+
+    expect(harness.toolNames()).toEqual(['managed_go'])
+    expect(hoisted.transports.map((t) => t.options.command)).toEqual(['m'])
+  })
+
+  it('disables MCP entirely for an empty managed map', async () => {
+    withTools([{ name: 'go' }])
+    withManagedMcp({ mcpServers: {} })
+    const harness = await setup({ user: { fromUser: { command: 'u' } } })
+
+    await harness.sessionStart(true)
+
+    expect(harness.toolNames()).toEqual([])
+    expect(hoisted.transports).toEqual([])
+  })
+
+  it('still filters the managed set through the managed allow/deny lists', async () => {
+    withTools([{ name: 'go' }])
+    withManagedMcp({ mcpServers: { keep: { command: 'k' }, drop: { command: 'd' } } }, { deniedMcpServers: [{ serverName: 'drop' }] })
+    const harness = await setup()
+
+    await harness.sessionStart(true)
+
+    expect(harness.toolNames()).toEqual(['keep_go'])
+  })
+
+  it('leaves normal loading untouched when no managed-mcp.json is present', async () => {
+    withTools([{ name: 'go' }])
+    withoutManagedMcp()
+    const harness = await setup({ user: { fromUser: { command: 'u' } } })
+
+    await harness.sessionStart(true)
+
+    expect(harness.toolNames()).toEqual(['fromUser_go'])
+  })
+
+  it('fails closed (deny-all) when a present managed-mcp.json is invalid JSON', async () => {
+    // Deliberately the opposite of the old regression guard, which failed OPEN: a
+    // corrupt policy file used to reopen the user/project/plugin scopes. Under the
+    // lockdown intent a deployed-but-unparseable managed-mcp.json is a deny-all, exactly
+    // like an empty map, so a truncated write cannot silently allow every server.
+    withTools([{ name: 'go' }])
+    withManagedMcp('{not json')
+    const harness = await setup({ user: { fromUser: { command: 'u' } } })
+
+    await harness.sessionStart(true)
+
+    expect(harness.toolNames()).toEqual([])
+    expect(hoisted.transports).toEqual([])
+    expect(harness.warnings.join('\n')).toMatch(/managed-mcp\.json.*not valid JSON/)
+  })
+
+  it('evicts an already-connected non-managed server when a policy is deployed mid-process', async () => {
+    // A user server connects on the first session with no managed policy present. A later
+    // managed-mcp.json takes exclusive control, so re-firing session_start must close the
+    // surviving user client and leave only the managed set connected, not let it linger.
+    withTools([{ name: 'go' }])
+    const harness = await setup({ user: { fromUser: { command: 'u' } } })
+
+    withoutManagedMcp()
+    await harness.sessionStart(true)
+    const userClient = hoisted.clients.find((c) => c.transport?.options?.command === 'u')
+    expect(userClient).toBeDefined()
+    expect(hoisted.closed).not.toContain(userClient)
+
+    withManagedMcp({ mcpServers: { managed: { command: 'm' } } })
+    await harness.sessionStart(true)
+
+    // The user client was closed; only the managed server remains connected.
+    expect(hoisted.closed).toContain(userClient)
+    const lines = await statusLinesOf(harness)
+    expect(lines).toContain('fromUser: disabled by managed policy (0 tools)')
+    expect(lines.some((l) => l.startsWith('managed: connected'))).toBe(true)
+    expect(hoisted.transports.map((t) => t.options.command)).toEqual(['u', 'm'])
   })
 })

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -4,7 +4,24 @@ import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { applyServerPolicy, formatPromptCommandName, formatToolName, interpolateEnv, loadConfigFrom, loadUserScope, managedSettingsPath, mapContent, mapPromptArguments, mcpAllowDeny, normalizeSchema, parseHelperHeaders, projectConfigPaths, promptMessageContent, userConfigPaths } from '../extensions/mcp.ts'
+import {
+  applyServerPolicy,
+  formatPromptCommandName,
+  formatToolName,
+  interpolateEnv,
+  loadConfigFrom,
+  loadUserScope,
+  managedSettingsPath,
+  mapContent,
+  mapPromptArguments,
+  mcpAllowDeny,
+  normalizeSchema,
+  parseHelperHeaders,
+  projectConfigPaths,
+  projectServerPolicy,
+  promptMessageContent,
+  userConfigPaths,
+} from '../extensions/mcp.ts'
 
 describe('parseHelperHeaders', () => {
   it('keeps string-valued header entries and drops the rest', () => {
@@ -163,6 +180,27 @@ describe('mcp adapter helpers', () => {
   it('separates always-loaded user config from trust-gated project config', () => {
     expect(userConfigPaths('/home')).toEqual(['/home/.claude.json', '/home/.pi/agent/mcp.json'])
     expect(projectConfigPaths('/proj')).toEqual(['/proj/.mcp.json', '/proj/.pi/mcp.json'])
+  })
+
+  it('resolves HOME-scope config under CLAUDE_CONFIG_DIR while leaving project scope alone', () => {
+    // Claude relocates ~/.claude.json and ~/.claude/settings.json inside CLAUDE_CONFIG_DIR;
+    // the sweep must follow, or the user-scope MCP config splits across extensions.
+    const saved = process.env.CLAUDE_CONFIG_DIR
+    const cfg = mkdtempSync(join(tmpdir(), 'mcp-cfg-'))
+    process.env.CLAUDE_CONFIG_DIR = cfg
+    try {
+      // .claude.json now lives inside the config dir; .pi is pi's own tree, untouched.
+      expect(userConfigPaths('/home')).toEqual([join(cfg, '.claude.json'), join('/home', '.pi', 'agent', 'mcp.json')])
+      // The per-project local scope is read from the relocated .claude.json too.
+      writeFileSync(join(cfg, '.claude.json'), JSON.stringify({ projects: { '/work/p': { mcpServers: { local: { command: 'l' } } } } }))
+      expect(Object.keys(loadUserScope('/home', '/work/p'))).toEqual(['local'])
+      // projectServerPolicy reads the user settings.json from the config dir.
+      writeFileSync(join(cfg, 'settings.json'), JSON.stringify({ enableAllProjectMcpServers: true }))
+      expect(projectServerPolicy('/proj', '/home', false).consentAll).toBe(true)
+    } finally {
+      if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR
+      else process.env.CLAUDE_CONFIG_DIR = saved
+    }
   })
 
   it('finds project mcp config at the repository root from a subdirectory session', () => {

--- a/tests/memory-actions.test.ts
+++ b/tests/memory-actions.test.ts
@@ -28,6 +28,7 @@ describe('memory tool actions', () => {
       registerTool: (t: Tool) => {
         tool = t
       },
+      registerCommand: () => {},
     } as never)
     if (!tool) throw new Error('memory tool not registered')
     return { handlers, tool, cwd, dir: memoryDir(cwd) }
@@ -106,6 +107,7 @@ describe('memory index robustness', () => {
       registerTool: (t: Tool) => {
         tool = t
       },
+      registerCommand: () => {},
     } as never)
     if (!tool) throw new Error('memory tool not registered')
     return { handlers, tool, cwd, dir: memoryDir(cwd) }

--- a/tests/memory-command.test.ts
+++ b/tests/memory-command.test.ts
@@ -1,0 +1,141 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import memoryExtension, { INDEX_FILE, resolveMemoryDir } from '../extensions/memory.ts'
+
+type CommandSpec = { description?: string; handler: (args: string, ctx: unknown) => Promise<void> }
+
+// os.homedir() honors $HOME on POSIX, so point the settings write at a throwaway home.
+describe('memory command', () => {
+  let home: string
+  let savedHome: string | undefined
+  let savedDisable: string | undefined
+  let savedConfigDir: string | undefined
+
+  beforeEach(() => {
+    savedHome = process.env.HOME
+    home = mkdtempSync(join(tmpdir(), 'mem-home-'))
+    process.env.HOME = home
+    savedDisable = process.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY
+    delete process.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY
+    // Config-dir tests set this explicitly; clear it so the rest resolve to ~/.claude.
+    savedConfigDir = process.env.CLAUDE_CONFIG_DIR
+    delete process.env.CLAUDE_CONFIG_DIR
+  })
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME
+    else process.env.HOME = savedHome
+    if (savedDisable === undefined) delete process.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY
+    else process.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = savedDisable
+    if (savedConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR
+    else process.env.CLAUDE_CONFIG_DIR = savedConfigDir
+  })
+
+  function wire() {
+    const commands = new Map<string, CommandSpec>()
+    memoryExtension({
+      on: () => {},
+      registerTool: () => {},
+      registerCommand: (name: string, spec: CommandSpec) => commands.set(name, spec),
+    } as never)
+    return commands
+  }
+  const settingsFile = () => join(home, '.claude', 'settings.json')
+  const ctxFor = (cwd: string, notify = vi.fn()) => ({ cwd, isProjectTrusted: () => false, hasUI: false, ui: { notify } })
+  const run = async (args: string, cwd: string, notify = vi.fn()) => {
+    await wire().get('memory')?.handler(args, ctxFor(cwd, notify))
+    return notify
+  }
+
+  it('registers a single memory command', () => {
+    expect([...wire().keys()]).toEqual(['memory'])
+  })
+
+  it('lists the store, index, CLAUDE.md locations and the enabled state', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'mem-cwd-'))
+    const notify = await run('', cwd)
+    const text = notify.mock.calls[0][0] as string
+    expect(text).toContain(join(home, '.claude', 'CLAUDE.md'))
+    expect(text).toContain(join(cwd, 'CLAUDE.md'))
+    expect(text).toContain(join(resolveMemoryDir(cwd), INDEX_FILE))
+    expect(text).toMatch(/Auto memory:\s*on/i) // enabled by default
+  })
+
+  it('writes autoMemoryEnabled off/on while preserving other settings keys', async () => {
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    writeFileSync(settingsFile(), JSON.stringify({ theme: 'dark', autoMemoryDirectory: '~/mem' }))
+    const cwd = mkdtempSync(join(tmpdir(), 'mem-cwd-'))
+
+    const offNotify = await run('off', cwd)
+    const off = JSON.parse(readFileSync(settingsFile(), 'utf-8'))
+    expect(off.autoMemoryEnabled).toBe(false)
+    expect(off.theme).toBe('dark') // untouched
+    expect(off.autoMemoryDirectory).toBe('~/mem') // untouched
+    expect(offNotify.mock.calls[0][0]).toMatch(/disabled/i)
+
+    await run('on', cwd)
+    const on = JSON.parse(readFileSync(settingsFile(), 'utf-8'))
+    expect(on.autoMemoryEnabled).toBe(true)
+    expect(on.theme).toBe('dark')
+  })
+
+  it('creates the settings file and its directory when missing', async () => {
+    expect(existsSync(settingsFile())).toBe(false)
+    const cwd = mkdtempSync(join(tmpdir(), 'mem-cwd-'))
+    await run('on', cwd)
+    expect(existsSync(settingsFile())).toBe(true)
+    expect(JSON.parse(readFileSync(settingsFile(), 'utf-8')).autoMemoryEnabled).toBe(true)
+  })
+
+  it('reflects a just-written disabled state in the listing', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'mem-cwd-'))
+    await run('off', cwd)
+    const notify = await run('', cwd)
+    expect(notify.mock.calls[0][0]).toMatch(/Auto memory:\s*off/i)
+  })
+
+  it('notifies usage for an invalid argument', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'mem-cwd-'))
+    const notify = await run('bogus', cwd)
+    expect(notify.mock.calls[0][0]).toMatch(/usage/i)
+    expect(notify.mock.calls[0][1]).toBe('error')
+  })
+
+  it('does not clobber a present-but-unparseable settings.json and reports the error', async () => {
+    // A malformed settings.json must be left intact: overwriting it would destroy the
+    // user's hooks, env and permissions config.
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    const invalid = '{ this is not valid json'
+    writeFileSync(settingsFile(), invalid)
+    const cwd = mkdtempSync(join(tmpdir(), 'mem-cwd-'))
+
+    const notify = await run('on', cwd)
+    expect(readFileSync(settingsFile(), 'utf-8')).toBe(invalid) // unchanged
+    expect(notify.mock.calls[0][0]).toMatch(/not valid JSON/i)
+    expect(notify.mock.calls[0][1]).toBe('error')
+  })
+
+  it('reads and writes settings under CLAUDE_CONFIG_DIR when it is set', async () => {
+    const configDir = mkdtempSync(join(tmpdir(), 'mem-config-'))
+    const saved = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    try {
+      const cwd = mkdtempSync(join(tmpdir(), 'mem-cwd-'))
+      // The listing reads autoMemoryEnabled from the relocated config dir.
+      writeFileSync(join(configDir, 'settings.json'), JSON.stringify({ autoMemoryEnabled: false }))
+      const listing = await run('', cwd)
+      expect(listing.mock.calls[0][0]).toMatch(/Auto memory:\s*off/i)
+
+      // /memory on writes into the relocated config dir, not ~/.claude.
+      await run('on', cwd)
+      expect(JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf-8')).autoMemoryEnabled).toBe(true)
+      expect(existsSync(join(home, '.claude', 'settings.json'))).toBe(false)
+    } finally {
+      if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR
+      else process.env.CLAUDE_CONFIG_DIR = saved
+    }
+  })
+})

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -1502,6 +1502,21 @@ describe('agent memory', () => {
     expect(agentMemoryDir('project', 'scout', '/nowhere', '/home/u')).toBe(join('/nowhere', '.claude', 'agent-memory', 'scout'))
   })
 
+  it('resolves the user memory store under CLAUDE_CONFIG_DIR', () => {
+    // The user-scope store relocates with CLAUDE_CONFIG_DIR (consistent with the swept
+    // agents dir); the repo-controlled project/local stores never do.
+    const saved = process.env.CLAUDE_CONFIG_DIR
+    const cfg = fs.mkdtempSync(join(tmpdir(), 'sa-cfg-'))
+    process.env.CLAUDE_CONFIG_DIR = cfg
+    try {
+      expect(agentMemoryDir('user', 'scout', '/repo', '/home/u')).toBe(join(cfg, 'agent-memory', 'scout'))
+      expect(agentMemoryDir('project', 'scout', '/nowhere', '/home/u')).toBe(join('/nowhere', '.claude', 'agent-memory', 'scout'))
+    } finally {
+      if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR
+      else process.env.CLAUDE_CONFIG_DIR = saved
+    }
+  })
+
   it('sanitizes a repo-controlled agent name before it becomes a path segment', () => {
     expect(agentMemoryDir('user', '../../etc/passwd', '/repo', '/home/u')).toBe(join('/home/u', '.claude', 'agent-memory', '.._.._etc_passwd'))
     // A name of only dots survives the character filter but would still traverse.

--- a/tests/thinking.test.ts
+++ b/tests/thinking.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import thinkingExtension, { requestedThinkingLevel, thinkingRank } from '../extensions/thinking.ts'
+
+type Handler = (event: any, ctx: any) => unknown
+
+function wire(initial = 'off') {
+  const handlers = new Map<string, Handler>()
+  let level = initial
+  const setThinkingLevel = vi.fn((l: string) => {
+    level = l
+  })
+  const getThinkingLevel = vi.fn(() => level)
+  thinkingExtension({
+    on: (name: string, fn: Handler) => handlers.set(name, fn),
+    getThinkingLevel,
+    setThinkingLevel,
+  } as never)
+  return {
+    input: (text: string, ctx: any = {}, source = 'interactive') => handlers.get('input')?.({ text, source }, ctx),
+    settle: () => handlers.get('agent_settled')?.({}, {}),
+    setThinkingLevel,
+    getThinkingLevel,
+    level: () => level,
+  }
+}
+
+describe('thinkingRank', () => {
+  it('orders the pi thinking levels from off to max', () => {
+    expect(thinkingRank('off')).toBeLessThan(thinkingRank('medium'))
+    expect(thinkingRank('medium')).toBeLessThan(thinkingRank('high'))
+    expect(thinkingRank('high')).toBeLessThan(thinkingRank('max'))
+  })
+})
+
+describe('requestedThinkingLevel', () => {
+  it('maps ultrathink to max, think hard/harder to high, bare think to medium', () => {
+    expect(requestedThinkingLevel('please ultrathink this')).toBe('max')
+    expect(requestedThinkingLevel('ULTRATHINK')).toBe('max')
+    expect(requestedThinkingLevel('think hard about it')).toBe('high')
+    expect(requestedThinkingLevel('think harder here')).toBe('high')
+    expect(requestedThinkingLevel('think about the edge cases')).toBe('medium')
+  })
+
+  it('requires a word boundary so rethink/thinking do not trip the bare match', () => {
+    expect(requestedThinkingLevel('let me rethink this')).toBeUndefined()
+    expect(requestedThinkingLevel('it keeps thinking loudly')).toBeUndefined()
+    expect(requestedThinkingLevel('nothing to see here')).toBeUndefined()
+  })
+})
+
+describe('thinking extension', () => {
+  it('escalates to max on ultrathink and restores the prior level when the turn settles', () => {
+    const t = wire('low')
+    t.input('please ultrathink')
+    expect(t.setThinkingLevel).toHaveBeenLastCalledWith('max')
+    expect(t.level()).toBe('max')
+    t.settle()
+    expect(t.setThinkingLevel).toHaveBeenLastCalledWith('low')
+    expect(t.level()).toBe('low')
+  })
+
+  it('escalates think hard to high and bare think to medium', () => {
+    const hard = wire('off')
+    hard.input('think hard about this')
+    expect(hard.level()).toBe('high')
+
+    const bare = wire('off')
+    bare.input('think it over')
+    expect(bare.level()).toBe('medium')
+  })
+
+  it('does nothing when the input names no thinking keyword', () => {
+    const t = wire('off')
+    t.input('just do the thing')
+    expect(t.setThinkingLevel).not.toHaveBeenCalled()
+    t.settle()
+    expect(t.setThinkingLevel).not.toHaveBeenCalled()
+  })
+
+  it('never lowers the level when already at or above the target', () => {
+    const t = wire('max')
+    t.input('think about it') // target medium, current max: no change
+    expect(t.setThinkingLevel).not.toHaveBeenCalled()
+    t.settle()
+    expect(t.setThinkingLevel).not.toHaveBeenCalled() // nothing captured to restore
+  })
+
+  it('restores the original level once across back-to-back escalations in one turn', () => {
+    const t = wire('low')
+    t.input('think hard') // low -> high
+    expect(t.level()).toBe('high')
+    t.input('ultrathink now') // high -> max, pending stays low
+    expect(t.level()).toBe('max')
+    t.settle()
+    expect(t.level()).toBe('low')
+
+    // A second settle must not re-apply any restore.
+    t.setThinkingLevel.mockClear()
+    t.settle()
+    expect(t.setThinkingLevel).not.toHaveBeenCalled()
+  })
+
+  it('ignores extension-sourced input carrying a think keyword', () => {
+    // sendUserMessage emits an input event with source 'extension' (a subagent prompt,
+    // or a command body replayed through it). A think keyword the user did not type must
+    // not escalate.
+    const t = wire('low')
+    t.input('please ultrathink', {}, 'extension')
+    expect(t.setThinkingLevel).not.toHaveBeenCalled()
+    expect(t.level()).toBe('low')
+  })
+
+  it('stands down at settle when the level was moved after it escalated', () => {
+    // The fight scenario: commands.ts restores its own effort override on agent_settled
+    // too. thinking escalated, then something else (that restore, or a manual change)
+    // moved the level; thinking must not clobber it with its own restore, so the
+    // outcome is order-independent.
+    const t = wire('low')
+    t.input('please ultrathink')
+    expect(t.level()).toBe('max')
+    // Simulate a command's effort restore (or a manual change) moving the level away.
+    t.setThinkingLevel('high')
+    t.settle()
+    expect(t.level()).toBe('high') // external value kept, thinking stood down
+  })
+
+  it('restores the prior level when it still owns the escalation at settle', () => {
+    const t = wire('low')
+    t.input('please ultrathink')
+    expect(t.level()).toBe('max')
+    t.settle()
+    expect(t.level()).toBe('low')
+  })
+
+  it('reads the prior level from ctx.thinkingLevel when getThinkingLevel is absent', () => {
+    const handlers = new Map<string, Handler>()
+    const setThinkingLevel = vi.fn()
+    thinkingExtension({ on: (name: string, fn: Handler) => handlers.set(name, fn), setThinkingLevel } as never)
+    handlers.get('input')?.({ text: 'ultrathink' }, { thinkingLevel: 'medium' })
+    expect(setThinkingLevel).toHaveBeenLastCalledWith('max')
+    handlers.get('agent_settled')?.({}, {})
+    expect(setThinkingLevel).toHaveBeenLastCalledWith('medium')
+  })
+})


### PR DESCRIPTION
## Summary

Adds the highest-value Claude Code parity gaps the research fleet ranked, each test-driven; `npm run check` is green at 1663 tests, 96% statements and 91% branches. An adversarial review pass reshaped several pieces, noted below.

The CLAUDE.md scopes pi silently ignored now load: `~/.claude/CLAUDE.md` for the user (its imports resolving at user roots), the nearest `.claude/CLAUDE.md` for an approved project, and the managed per-OS CLAUDE.md file, which loads ahead of user and project context and cannot be excluded. All three ride the existing exclude, comment-strip, announce, and import-memo pipeline.

The settings `env` block injects into the session: managed and user scopes at load, an approved project's at session start, merged per key with managed over user over project. A shell export outranks user and project values but not managed ones, keys dropped from settings are unset, and a previously approved project's variables cannot leak into a later session. `CLAUDE_CONFIG_DIR` relocates the whole user config chain; the review caught that a partial sweep would have split the config between two locations, so every extension now resolves the user scope through one helper, including `~/.claude.json` for MCP.

MCP tool calls move to Claude's two-tier timeout: a four-hour wall clock with a five-minute idle guard that progress notifications reset, so slow tools survive while hung ones do not. A `managed-mcp.json` next to the managed settings takes exclusive control of which servers load; it fails closed on a corrupt file and evicts already-connected non-managed servers when deployed mid-process.

New `/context` and `/memory` commands cover the usage breakdown and memory management, `think`/`ultrathink` keywords escalate reasoning for the turn with a restore that stands down if anything else moved the level (the review caught it fighting the new per-command `effort` override), commands gain `user-invocable`, `effort`, and `when_to_use` frontmatter, Stop hooks get Claude's consecutive-block cap, command hooks accept the exec-form `args` array, and spawned subprocesses see `CLAUDECODE=1`.
