### PR TITLE
Surface rate limits, auto-title sessions, and harden the test suite

### DIFF
--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -3,7 +3,14 @@
  *
  * Runs Claude Code's `.claude/settings.json` hooks on pi's lifecycle events, so
  * a project's existing hooks work under pi:
- * - PreToolUse      -> pi `tool_call` (can block the tool or rewrite its input)
+ * - PreToolUse      -> pi `tool_call` (can block the tool or rewrite its input), plus
+ *                      pi `user_bash` for a `!`/`!!` command the user runs directly (the
+ *                      model never issues these, so a deny-list guard would otherwise miss
+ *                      them). No pi tool call exists there, so the payload reports the
+ *                      Claude name "Bash"; a deny hands pi a synthetic failed result so
+ *                      the command never runs. UserBashEvent carries no execution result
+ *                      and fires only before the command runs, so it has no PostToolUse
+ *                      counterpart (pi never delivers the output to observe).
  * - PostToolUse     -> pi `tool_result` (block reasons and additionalContext are
  *                      appended next to the tool result, as Claude documents)
  * - SessionStart    -> pi `session_start` (stdout/additionalContext is injected as
@@ -1019,6 +1026,31 @@ export default function hooksExtension(pi: ExtensionAPI) {
     const feedback = results.flatMap((result) => postToolFeedback(result, eventName, event.isError))
     if (feedback.length === 0) return
     return { content: [...event.content, ...feedback.map((text) => ({ type: 'text' as const, text }))] }
+  })
+
+  // Claude's PreToolUse for Bash, extended to a command the user runs directly with the
+  // `!`/`!!` prefix. pi fires user_bash before executing it, and the model never sees it,
+  // so without this a guard that blocks `git push -f` from the model would not stop the
+  // same command typed by hand. There is no pi tool call, so the matcher sees both pi's
+  // "bash" and the Claude name "Bash" (exactly as an MCP alias is bridged) and the payload
+  // reports "Bash", the tool_name a Claude-written PreToolUse Bash hook expects. The
+  // payload carries no tool_use_id (no model tool call produced it). UserBashEventResult
+  // exposes no block flag: a deny is enforced through `result` ("extension handled
+  // execution, use this result"), a synthetic failed BashResult that stands in for the
+  // command so it never runs and its deny reason shows as the output. The event delivers
+  // no execution result and fires only before the command runs, so there is deliberately
+  // no PostToolUse for it.
+  pi.on('user_bash', async (event, ctx) => {
+    const decision = await runPreToolUse(config, 'bash', { command: event.command }, boundRunner(ctx), 'Bash', (message) => ctx.ui.notify(message, 'warning'))
+    if (!decision.block) return undefined
+    // Claude's "ask": prompt before running and let the command through on approval; with
+    // no UI (headless) the block stands, the same safe default as the tool_call path.
+    if (decision.ask && ctx.hasUI) {
+      const approved = await ctx.ui.confirm('Allow this command?', decision.reason ?? 'A hook asks you to confirm this command.')
+      if (approved) return undefined
+    }
+    const reason = decision.reason ?? 'Command blocked by hook'
+    return { result: { output: `Blocked by hook: ${reason}`, exitCode: 1, cancelled: false, truncated: false } }
   })
 
   pi.on('input', async (event, ctx) => {

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -200,6 +200,13 @@ export default function outputStylesExtension(pi: ExtensionAPI) {
 
   pi.registerCommand('output-style', {
     description: 'Choose the active Claude output style (or /output-style <name>)',
+    // /output-style <name> takes a style name, so complete the discovered names by the
+    // typed prefix (case-insensitive, like the handler's own name lookup). An empty
+    // prefix offers every style.
+    getArgumentCompletions: (argumentPrefix) => {
+      const prefix = argumentPrefix.trim().toLowerCase()
+      return styles.filter((style) => style.name.toLowerCase().startsWith(prefix)).map((style) => ({ value: style.name, label: style.name, ...(style.description ? { description: style.description } : {}) }))
+    },
     handler: async (args, ctx) => {
       const requested = args.trim()
       if (requested) {

--- a/extensions/session-title.ts
+++ b/extensions/session-title.ts
@@ -1,0 +1,105 @@
+/**
+ * Session Auto-Title Extension
+ *
+ * Claude auto-names a new conversation from its first message; this does the same for
+ * pi. After the first run of an unnamed session settles, it asks the current model for
+ * a short title based on the first user message and applies it two ways: setSessionName
+ * (the name shown in the session selector) and the terminal window/tab title.
+ *
+ * It runs in every mode, not just the TUI: naming a session is cheap and harmless, and a
+ * headless run that persists its session still benefits from a readable name later. The
+ * window-title update is the only terminal-specific part, so it is optional-called rather
+ * than gated on hasUI. Titling is best-effort throughout: a session that already has a
+ * name, a run with no user text (a slash-command-only turn), a headless run with no model,
+ * or any provider error leaves the session untitled and never throws.
+ *
+ * Cost: one model call per session at most. The guard is claimed before the completion so
+ * repeated settles cannot each fire a call, and a failed attempt is not retried until a
+ * new session resets the guard.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
+
+import { completeText } from './internal/model-complete.js'
+
+const TITLE_SYSTEM = 'You name a coding session from its first user message. Reply with a terse 3 to 6 word title in Title Case that captures the task. No quotes, no surrounding punctuation, no trailing period. Output the title only, nothing else.'
+/** A title is a few words; a tight cap keeps the extra call cheap and stops a runaway reply. */
+const TITLE_MAX_TOKENS = 24
+/** The first message can be huge; only its opening is needed to name the session, and a
+ * bounded prompt keeps the input cost of the extra call small. */
+const MAX_PROMPT_CHARS = 1000
+
+/** Join the text of a message's content, mirroring git-checkpoint's extraction: content is
+ * either a plain string or an array of parts, of which only text parts carry a title's worth. */
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter((part) => part?.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text)
+    .join(' ')
+}
+
+/** Text of the first user message in the branch, or empty when the run carried no user text
+ * (for example a slash-command-only turn), in which case there is nothing to title from. */
+export function firstUserText(ctx: ExtensionContext): string {
+  for (const entry of ctx.sessionManager.getBranch()) {
+    if (entry?.type === 'message' && entry.message.role === 'user') {
+      return extractText(entry.message.content).trim()
+    }
+  }
+  return ''
+}
+
+/** Trim the model's reply to a bare title: collapse whitespace, then peel wrapping quotes
+ * and trailing punctuation until stable, so `"Fix The Parser."` and `Fix The Parser.` both
+ * land on the plain phrase. */
+export function cleanTitle(raw: string): string {
+  let title = raw.trim().replace(/\s+/g, ' ')
+  let prev: string
+  do {
+    prev = title
+    title = title
+      .replace(/^["'`“”‘’]+|["'`“”‘’]+$/g, '')
+      .replace(/[.,;:!?]+$/g, '')
+      .trim()
+  } while (title !== prev)
+  return title
+}
+
+export default function sessionTitleExtension(pi: ExtensionAPI) {
+  // One title per session, reset when a new session takes over so a resumed or forked
+  // session can still earn its own name.
+  let titled = false
+
+  pi.on('session_start', () => {
+    titled = false
+  })
+
+  pi.on('agent_settled', async (_event, ctx) => {
+    if (titled) return
+    // Never clobber an existing name: a user-chosen or resumed name wins.
+    if (pi.getSessionName?.()) return
+    const model = ctx.model
+    if (!model) return // headless with no model: nothing to name with, and the guard is left unspent
+    const prompt = firstUserText(ctx)
+    if (!prompt) return // no user text this run: leave the guard unspent for a later real message
+
+    // Claim the single attempt before the await, so overlapping or repeated settles cannot
+    // each fire a model call; a failed attempt below is not retried within this session.
+    titled = true
+    let title: string
+    try {
+      const { text } = await completeText(model, `First user message of a new coding session:\n\n${prompt.slice(0, MAX_PROMPT_CHARS)}`, {
+        system: TITLE_SYSTEM,
+        maxTokens: TITLE_MAX_TOKENS,
+      })
+      title = cleanTitle(text)
+    } catch {
+      return // no model, provider error: leave the session untitled (best-effort)
+    }
+    if (!title) return
+    pi.setSessionName(title)
+    ctx.ui.setTitle?.(title)
+  })
+}

--- a/extensions/session-title.ts
+++ b/extensions/session-title.ts
@@ -51,6 +51,30 @@ export function firstUserText(ctx: ExtensionContext): string {
   return ''
 }
 
+/** Wrapping quotes (straight, smart, and backtick) and trailing sentence punctuation that
+ * cleanTitle peels, held as plain strings so the trims below can test membership by index
+ * rather than with an anchored regex. */
+const WRAPPING_QUOTES = '"\'`“”‘’'
+const TRAILING_PUNCTUATION = '.,;:!?'
+
+/** Strip runs of `chars` from both ends of `value` in linear time. The equivalent
+ * /^[chars]+|[chars]+$/g backtracks super-linearly on a long run (S8786). */
+function trimBothEnds(value: string, chars: string): string {
+  let start = 0
+  let end = value.length
+  while (start < end && chars.includes(value[start])) start++
+  while (end > start && chars.includes(value[end - 1])) end--
+  return value.slice(start, end)
+}
+
+/** Strip a trailing run of `chars` from `value` in linear time. The equivalent
+ * /[chars]+$/g backtracks super-linearly on a long trailing run (S8786). */
+function trimTrailing(value: string, chars: string): string {
+  let end = value.length
+  while (end > 0 && chars.includes(value[end - 1])) end--
+  return value.slice(0, end)
+}
+
 /** Trim the model's reply to a bare title: collapse whitespace, then peel wrapping quotes
  * and trailing punctuation until stable, so `"Fix The Parser."` and `Fix The Parser.` both
  * land on the plain phrase. */
@@ -59,10 +83,7 @@ export function cleanTitle(raw: string): string {
   let prev: string
   do {
     prev = title
-    title = title
-      .replace(/^["'`“”‘’]+|["'`“”‘’]+$/g, '')
-      .replace(/[.,;:!?]+$/g, '')
-      .trim()
+    title = trimTrailing(trimBothEnds(title, WRAPPING_QUOTES), TRAILING_PUNCTUATION).trim()
   } while (title !== prev)
   return title
 }

--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -64,6 +64,66 @@ function formatCost(cost: number): string {
   return cost >= 0.01 ? `$${cost.toFixed(2)}` : `$${cost.toFixed(4)}`
 }
 
+interface RateLimitWindow {
+  used_percentage: number
+  resets_at?: string
+}
+interface RateLimitSnapshot {
+  five_hour?: RateLimitWindow
+  seven_day?: RateLimitWindow
+}
+
+/** Lowercase every header name (HTTP names are case-insensitive) and drop null
+ * values, so a single lookup shape works regardless of how the provider cased
+ * them. ProviderHeaders values are string | null. */
+function normalizeHeaders(raw: Record<string, string | null> | undefined): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw ?? {})) {
+    if (typeof value === 'string') out[key.toLowerCase()] = value
+  }
+  return out
+}
+
+function toNumber(value: string | undefined): number | undefined {
+  if (value === undefined || value.trim() === '') return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+/** One rate-limit window from the `anthropic-ratelimit-<prefix>-*` header family,
+ * taking a direct `-utilization` percentage when present, else computing it from
+ * `-limit` and `-remaining`. resets_at comes from `-reset` when the header is set.
+ * Header names vary, so only what is present is read and a bare number is enough. */
+function readRateLimitWindow(headers: Record<string, string>, prefix: string): RateLimitWindow | undefined {
+  const base = `anthropic-ratelimit-${prefix}`
+  let usedPercentage = toNumber(headers[`${base}-utilization`])
+  if (usedPercentage === undefined) {
+    const limit = toNumber(headers[`${base}-limit`])
+    const remaining = toNumber(headers[`${base}-remaining`])
+    if (limit !== undefined && limit > 0 && remaining !== undefined) {
+      usedPercentage = ((limit - remaining) / limit) * 100
+    }
+  }
+  if (usedPercentage === undefined) return undefined
+  const window: RateLimitWindow = { used_percentage: usedPercentage }
+  const resetsAt = headers[`${base}-reset`] ?? headers[`${base}-resets-at`]
+  if (resetsAt) window.resets_at = resetsAt
+  return window
+}
+
+/** The five-hour and seven-day utilization windows Claude's statusline reports,
+ * from the unified rate-limit response headers. Undefined when neither is present
+ * so a response without them never clobbers an earlier snapshot. */
+function parseRateLimits(headers: Record<string, string>): RateLimitSnapshot | undefined {
+  const fiveHour = readRateLimitWindow(headers, 'unified-5h')
+  const sevenDay = readRateLimitWindow(headers, 'unified-7d')
+  if (!fiveHour && !sevenDay) return undefined
+  const snapshot: RateLimitSnapshot = {}
+  if (fiveHour) snapshot.five_hour = fiveHour
+  if (sevenDay) snapshot.seven_day = sevenDay
+  return snapshot
+}
+
 export interface StatusLineConfig {
   command: string
   padding: number
@@ -120,6 +180,10 @@ export default function statusLine(pi: ExtensionAPI) {
   let apiDurationMs = 0
   let requestStartMs: number | undefined
   let lastUsage: { input: number; output: number; cacheRead: number; cacheWrite: number; totalTokens: number } | undefined
+  // The most recent rate-limit snapshot parsed from provider response headers, and
+  // a once-per-session guard so a 429 warns the user only the first time it lands.
+  let rateLimits: RateLimitSnapshot | undefined
+  let rateLimitWarned = false
   let refreshTimer: ReturnType<typeof setInterval> | undefined
   let debounceTimer: ReturnType<typeof setTimeout> | undefined
   let running = false
@@ -193,6 +257,9 @@ export default function statusLine(pi: ExtensionAPI) {
       payload.thinking = { enabled: ctx.thinkingLevel !== 'off' }
     }
     if (styleName) payload.output_style = { name: styleName }
+    // The current utilization of the account's rate-limit windows, when the
+    // provider reported them; omitted entirely until a response has carried them.
+    if (rateLimits) payload.rate_limits = rateLimits
     return payload
   }
 
@@ -260,9 +327,24 @@ export default function statusLine(pi: ExtensionAPI) {
   pi.on('before_provider_request', async () => {
     requestStartMs = Date.now()
   })
-  pi.on('after_provider_response', async () => {
+  pi.on('after_provider_response', async (event, ctx) => {
     if (requestStartMs !== undefined) apiDurationMs += Date.now() - requestStartMs
     requestStartMs = undefined
+    // Rate-limit windows and 429 handling ride on the same response event. Header
+    // names and presence vary, so parse only what is there and never throw.
+    const headers = normalizeHeaders(event.headers)
+    const snapshot = parseRateLimits(headers)
+    if (snapshot) rateLimits = snapshot
+    if (event.status === 429 && !rateLimitWarned) {
+      rateLimitWarned = true
+      const retryAfter = headers['retry-after']
+      const detail = retryAfter ? `; retry after ${retryAfter}s` : ''
+      try {
+        ctx.ui.notify(`Provider rate limit reached (429)${detail}`, 'warning')
+      } catch {
+        // The session may be gone by the time a late response lands; nothing to warn.
+      }
+    }
   })
   // The last message's token usage, for the breakdown getContextUsage() omits,
   // and the running cost total, so renders never re-walk the branch.
@@ -284,6 +366,8 @@ export default function statusLine(pi: ExtensionAPI) {
     apiDurationMs = 0
     requestStartMs = undefined
     lastUsage = undefined
+    rateLimits = undefined
+    rateLimitWarned = false
     clearInterval(refreshTimer)
     // Seed the running cost from the branch: a resumed or forked session starts
     // with history, and message_end only accumulates from here on.
@@ -324,6 +408,15 @@ export default function statusLine(pi: ExtensionAPI) {
 
   pi.on('agent_end', async (_event, ctx) => {
     show(ctx, segmentText(ctx, ctx.ui.theme.fg('success', '✓')))
+    scheduleRefresh()
+  })
+
+  // The model and effort segments of the payload go stale between turns; a switch
+  // fires these events, so refresh at once instead of waiting for the next tick.
+  pi.on('model_select', async () => {
+    scheduleRefresh()
+  })
+  pi.on('thinking_level_select', async () => {
     scheduleRefresh()
   })
 

--- a/scripts/e2e-full.sh
+++ b/scripts/e2e-full.sh
@@ -48,7 +48,8 @@ git -C "$FX" -c user.name=e2e -c user.email=e2e@local commit -q --allow-empty -m
 mkdir -p "$FX/.claude/rules" "$FX/.claude/commands" "$FX/.claude/skills/greet" "$FX/.claude/output-styles" "$FX/.claude/agents" "$FX/notes"
 printf -- '- Tests must be deterministic.\n' > "$FX/.claude/rules/testing.md"
 printf 'Reply with exactly the word HELLO_MARKER and nothing else.\n' > "$FX/.claude/commands/hello.md"
-printf -- '---\nname: greet\ndescription: Greets people for the e2e test\n---\nSay a friendly greeting.\n' > "$FX/.claude/skills/greet/SKILL.md"
+printf 'Reply with exactly the word SLASHTOOL_MARKER and nothing else.\n' > "$FX/.claude/commands/slashtool.md"
+printf -- '---\nname: greet\ndescription: Greets people for the e2e test\n---\nWhen this skill runs, reply with exactly the word GREET_SKILL_MARKER and nothing else.\n' > "$FX/.claude/skills/greet/SKILL.md"
 # A tone-only style that still codes keeps the coding instructions, per Claude's docs;
 # without the flag the new replace semantics would strip tool guidance mid-suite.
 printf -- '---\nname: Pirate\ndescription: e2e style\nkeep-coding-instructions: true\n---\nYou may speak like a pirate.\n' > "$FX/.claude/output-styles/pirate.md"
@@ -71,13 +72,29 @@ ln -s "$REPO/node_modules" "$FX/node_modules"
 cat > "$FX/mcp-server.mjs" <<'EOF'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { CallToolRequestSchema, GetPromptRequestSchema, ListPromptsRequestSchema, ListResourcesRequestSchema, ListToolsRequestSchema, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 
-const server = new Server({ name: 'e2e', version: '1.0.0' }, { capabilities: { tools: {} } })
+const server = new Server({ name: 'e2e', version: '1.0.0' }, { capabilities: { tools: {}, prompts: {}, resources: {} } })
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [{ name: 'ping', description: 'Health check; always replies with the marker E2EPONG', inputSchema: { type: 'object', properties: {} } }],
 }))
 server.setRequestHandler(CallToolRequestSchema, async () => ({ content: [{ type: 'text', text: 'E2EPONG' }] }))
+// prompts capability: the extension registers this prompt as the /mcp__e2e__greet slash
+// command; its returned message is sent as a user message, driving a marker turn.
+server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+  prompts: [{ name: 'greet', description: 'e2e greeting prompt that drives a marker turn' }],
+}))
+server.setRequestHandler(GetPromptRequestSchema, async () => ({
+  messages: [{ role: 'user', content: { type: 'text', text: 'Reply with exactly the word GREET_PROMPT_MARKER and nothing else.' } }],
+}))
+// resources capability: one text resource, reachable through the global
+// list_mcp_resources / read_mcp_resource tools the extension registers.
+server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+  resources: [{ uri: 'e2e://greeting', name: 'greeting', mimeType: 'text/plain', description: 'e2e text resource' }],
+}))
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => ({
+  contents: [{ uri: request.params.uri, mimeType: 'text/plain', text: 'MCP_RESOURCE_MARKER' }],
+}))
 await server.connect(new StdioServerTransport())
 EOF
 printf '{"mcpServers": {"e2e": {"command": "node", "args": ["mcp-server.mjs"]}}}\n' > "$FX/.mcp.json"
@@ -188,6 +205,12 @@ if capture | grep -q '⏸ plan'; then bad "plan-mode: badge stuck"; else ok "pla
 send "/rewind" Enter
 if wait_for 'No checkpoints recorded yet' 15; then ok "checkpoint: empty-session notice"; else bad "checkpoint: no empty notice"; fi
 
+# The /hooks viewer resolves the settings chain; the fixture's PreToolUse guard (its
+# command carries FORBIDDEN_MARKER) must show under the PreToolUse heading. This runs
+# before the FORBIDDEN_MARKER model turn below, so the match cannot be a stale echo.
+send "/hooks" Enter
+if wait_for 'PreToolUse:' 15 && capture | grep -q 'FORBIDDEN_MARKER'; then ok "hooks: /hooks viewer shows the PreToolUse guard"; else bad "hooks: /hooks viewer missing the guard"; fi
+
 # --- Model turns ----------------------------------------------------------------------
 type_prompt "/hello"
 if wait_for 'HELLO_MARKER' 200; then ok "commands: /hello template drove the turn"; else bad "commands: no HELLO_MARKER"; fi
@@ -265,6 +288,41 @@ else
 fi
 if wait_for 'SUBAGENT_OK' 280; then ok "subagent: child pi ran and reported back"; else bad "subagent: no SUBAGENT_OK"; fi
 
+# --- MCP prompts/resources, slash_command, skills, background tasks --------------------
+# The fixture MCP server also advertises the prompts and resources capabilities. The
+# extension exposes the greet prompt as /mcp__e2e__greet, whose returned message is sent
+# as a user message and drives the marker turn (the marker rides in on that message, so
+# it appears only when the prompt was actually fetched).
+type_prompt "/mcp__e2e__greet"
+if wait_for 'GREET_PROMPT_MARKER' 200; then ok "mcp-prompts: prompt command drove a turn"; else bad "mcp-prompts: no GREET_PROMPT_MARKER"; fi
+
+# The resources capability registers the global list_mcp_resources / read_mcp_resource
+# tools; the marker only surfaces if the model lists then reads the fixture resource.
+type_prompt "List MCP resources with the list_mcp_resources tool, then read the first one with the read_mcp_resource tool and quote its text verbatim."
+if wait_for 'MCP_RESOURCE_MARKER' 240; then ok "mcp-resources: model listed and read the resource"; else bad "mcp-resources: no MCP_RESOURCE_MARKER"; fi
+
+# The slash_command tool expands a discovered custom command into its own tool result;
+# /slashtool carries a marker distinct from /hello so an earlier turn cannot false-green.
+type_prompt "Use the slash_command tool to run /slashtool. Do nothing else."
+if wait_for 'SLASHTOOL_MARKER' 200; then ok "slash-command: slash_command tool expanded /slashtool"; else bad "slash-command: no SLASHTOOL_MARKER"; fi
+
+# The greet skill's body instructs the marker, so it appears only when the model actually
+# invokes the skill pi surfaced from .claude/skills.
+type_prompt "Use the greet skill now."
+if wait_for 'GREET_SKILL_MARKER' 200; then ok "skills: model invoked the greet skill"; else bad "skills: no GREET_SKILL_MARKER"; fi
+
+# A background subagent returns a run id immediately; /tasks then lists it without
+# interrupting. general-purpose is builtin, so no project-agent consent prompt fires.
+type_prompt "Use the subagent tool with background true, agent general-purpose, and task: print the exact word BGTASK_MARKER. Do nothing else."
+if wait_for 'Started background run' 200; then
+  ok "subagent: background run started"
+  sleep 2
+  send "/tasks" Enter
+  if wait_for 'general-purpose: (running|done)' 30; then ok "tasks: /tasks lists the background run"; else bad "tasks: no background run entry"; fi
+else
+  bad "subagent: background run did not start"
+fi
+
 send "/plan" Enter
 sleep 2
 type_prompt "Create a two step plan for adding an FAQ section to the README, then call the plan_mode_complete tool with the numbered plan."
@@ -280,9 +338,23 @@ send "/plan" Enter
 sleep 2
 
 # --- Second session: persistence checks -----------------------------------------------
+# A custom statusLine command replaces the built-in ready/turn segments the first session
+# asserts, so it is added only now, for the re-boot below. Editing the project settings
+# does not disturb the stored trust decision (keyed on the path, not the file contents).
+python3 - "$FX/.claude/settings.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+settings = json.load(open(path))
+settings["statusLine"] = {"type": "command", "command": "echo STATUS_E2E"}
+json.dump(settings, open(path, "w"))
+PY
+
 tmux kill-session -t "$SESSION" 2>/dev/null || true
 tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "$FX" "HOME=$FAKEHOME PI_E2E_WIRE=$WIRE pi"
 if wait_for '\[Extensions\]' 120; then ok "trust: stored decision honored on re-boot"; else bad "trust: re-boot failed"; fi
+# The statusLine command runs on the first status refresh after boot; its output replaces
+# the built-in segment, so STATUS_E2E in the pane proves the configured command drove it.
+if wait_for 'STATUS_E2E' 30; then ok "statusline: custom statusLine command output rendered"; else bad "statusline: no STATUS_E2E segment"; fi
 # Known pi TUI interaction: this banner renders standalone but not always in the full
 # extension load; the memory feature itself is asserted above via the on-disk file.
 if wait_for 'Memory: 1 memories loaded' 20; then ok "memory: index banner on next session"; else warn "memory: index banner not rendered (known pi TUI interaction)"; fi

--- a/tests/claude-rules.test.ts
+++ b/tests/claude-rules.test.ts
@@ -154,6 +154,19 @@ describe('extension wiring', () => {
     expect(failed).toBeUndefined()
   })
 
+  it('expands a brace glob in a scoped rule when matching a touched file', async () => {
+    const cwd = projectWithRule('---\npaths:\n  - "src/{a,b}/**"\n---\nMind the shared modules.')
+    const handlers = wire()
+    await handlers.get('session_start')?.({}, approvedCtx(cwd))
+
+    // `{a,b}` must expand: src/c is outside it, and the second alternative (src/b) matches.
+    const miss = await handlers.get('tool_result')?.(readResult('src/c/mod.ts'), { cwd })
+    expect(miss).toBeUndefined()
+
+    const hit = await handlers.get('tool_result')?.(readResult('src/b/mod.ts'), { cwd })
+    expect(injectedTexts(hit).join('\n')).toContain('Mind the shared modules.')
+  })
+
   it('attaches on edit and write, not only read', async () => {
     const cwd = projectWithRule('---\npaths:\n  - "db/**"\n---\nUse parameterized queries.')
     const handlers = wire()

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -821,6 +821,21 @@ describe('allowed-tools argument scopes', () => {
     expect(await s.handlers.get('tool_call')?.({ toolName: 'read', input: { path: 'src/secret.ts' } }, s.ctx)).toBeUndefined()
   })
 
+  it('expands a brace glob in an Edit path scope at the tool_call guard', async () => {
+    const cwd = tempDir()
+    writeCommand(cwd, 'edit.md', '---\nallowed-tools: Edit(src/{x,y}/**)\n---\nEdit x or y.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('edit')?.handler('', s.ctx)
+
+    // `{x,y}` must expand: edits under src/x and src/y (both alternatives) pass, src/z blocks.
+    expect(await s.handlers.get('tool_call')?.({ toolName: 'edit', input: { path: 'src/x/app.ts' } }, s.ctx)).toBeUndefined()
+    expect(await s.handlers.get('tool_call')?.({ toolName: 'edit', input: { path: 'src/y/util.ts' } }, s.ctx)).toBeUndefined()
+    const blocked = (await s.handlers.get('tool_call')?.({ toolName: 'edit', input: { path: 'src/z/other.ts' } }, s.ctx)) as { block?: boolean; reason?: string }
+    expect(blocked?.block).toBe(true)
+    expect(blocked?.reason).toContain('src/{x,y}/**')
+  })
+
   it('lifts the scope when a later command in the turn grants bash unscoped', async () => {
     const cwd = tempDir()
     writeCommand(cwd, 'a.md', '---\nallowed-tools: Bash(git add:*)\n---\nStage.')

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -684,6 +684,25 @@ describe('system prompt rewriting: managed claudeMd, excludes, comment strip', (
     expect(await fire([], tempDir())).toBeUndefined()
   })
 
+  it('excludes a .txt context file via a brace-glob claudeMdExcludes', async () => {
+    // `{md,txt}` must expand for the .txt block to drop; a literal-brace fallback would
+    // match neither and leave both in the prompt. `.log` is outside the group and survives.
+    userSettings({ claudeMdExcludes: ['**/*.{md,txt}'] })
+    const dir = tempDir()
+    const files = [
+      { path: join(dir, 'CLAUDE.md'), content: 'MD BODY' },
+      { path: join(dir, 'notes.txt'), content: 'TXT BODY' },
+      { path: join(dir, 'keep.log'), content: 'LOG BODY' },
+    ]
+
+    const result = await fire(files, dir)
+    const prompt = result?.systemPrompt ?? ''
+
+    expect(prompt).not.toContain('MD BODY')
+    expect(prompt).not.toContain('TXT BODY')
+    expect(prompt).toContain('LOG BODY')
+  })
+
   it('skips the imports of an excluded context file', async () => {
     userSettings({ claudeMdExcludes: ['**/CLAUDE.md'] })
     const dir = tempDir()

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -195,6 +195,7 @@ const setupExtension = () => {
     toolCall: (toolName: string, input: unknown, toolCallId = 't1', ctxOverride: Record<string, unknown> = {}) => handler('tool_call')({ toolName, input, toolCallId }, { ...defaultCtx, ...ctxOverride }),
     toolResult: (toolName: string, opts: { input?: unknown; content?: unknown[]; details?: unknown; isError?: boolean } = {}) =>
       handler('tool_result')({ type: 'tool_result', toolCallId: 't1', toolName, input: opts.input ?? {}, content: opts.content ?? [], details: opts.details, isError: opts.isError ?? false }, defaultCtx),
+    userBash: (command: string, ctxOverride: Record<string, unknown> = {}) => handler('user_bash')({ type: 'user_bash', command, excludeFromContext: false, cwd: '/proj' }, { ...defaultCtx, ...ctxOverride }),
     input: (text: string, source = 'interactive') => handler('input')({ text, source }, defaultCtx),
     agentEnd: (messages: unknown[] = []) => handler('agent_end')({ messages }, defaultCtx),
     agentSettled: () => handler('agent_settled')({}, defaultCtx),
@@ -616,7 +617,7 @@ describe('malformed hook config', () => {
 
 describe('hooks extension registration', () => {
   it('subscribes to the lifecycle events it bridges', () => {
-    expect(setupExtension().registered).toEqual(['session_start', 'before_agent_start', 'tool_call', 'tool_result', 'input', 'agent_end', 'session_before_compact', 'session_compact', 'session_shutdown'])
+    expect(setupExtension().registered).toEqual(['session_start', 'before_agent_start', 'tool_call', 'tool_result', 'user_bash', 'input', 'agent_end', 'session_before_compact', 'session_compact', 'session_shutdown'])
   })
 })
 
@@ -848,6 +849,64 @@ describe('hooks extension tool_call', () => {
   it('runs no hook and allows the tool before any session_start has loaded a config', async () => {
     writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'guard' }] }] })
     expect(await setupExtension().toolCall('bash', {})).toBeUndefined()
+    expect(commandsRun()).toEqual([])
+  })
+})
+
+describe('hooks extension user_bash (PreToolUse for direct ! commands)', () => {
+  const withPreHook = async (behavior: Behavior) => {
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'guard' }] }] })
+    script('guard', behavior)
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('runs the matching PreToolUse hook with the Bash tool payload and no tool_use_id', async () => {
+    const ext = await withPreHook({ code: 0 })
+    await ext.userBash('git status')
+    expect(commandsRun()).toEqual(['guard'])
+    // The Bash tool has no pi tool call here, so the payload reports the Claude name
+    // "Bash", the tool_name a Claude-written PreToolUse Bash hook expects; there is no
+    // tool_use_id because no model tool call produced this command.
+    expect(JSON.parse(recordFor('guard').stdin)).toEqual({ ...COMMON, hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'git status' } })
+  })
+
+  it('blocks the command with a synthetic failed result when the hook exits 2', async () => {
+    const ext = await withPreHook({ stderr: ['force push is not allowed'], code: 2 })
+    // UserBashEvent has no block flag; the honest block is UserBashEventResult.result
+    // ("extension handled execution, use this result"), so the command never runs and
+    // the deny reason stands in as its output.
+    expect(await ext.userBash('git push -f')).toEqual({ result: { output: 'Blocked by hook: force push is not allowed', exitCode: 1, cancelled: false, truncated: false } })
+  })
+
+  it('blocks with the deny reason from hookSpecificOutput', async () => {
+    const ext = await withPreHook({ stdout: [JSON.stringify({ hookSpecificOutput: { permissionDecision: 'deny', permissionDecisionReason: 'secrets file' } })], code: 0 })
+    expect(await ext.userBash('cat .env')).toEqual({ result: { output: 'Blocked by hook: secrets file', exitCode: 1, cancelled: false, truncated: false } })
+  })
+
+  it('returns undefined so the command runs when the hook allows it', async () => {
+    const ext = await withPreHook({ code: 0 })
+    expect(await ext.userBash('ls')).toBeUndefined()
+  })
+
+  it('prompts on permissionDecision ask, letting the command through when approved', async () => {
+    const ext = await withPreHook({ stdout: [JSON.stringify({ hookSpecificOutput: { permissionDecision: 'ask', permissionDecisionReason: 'confirm this' } })], code: 0 })
+    const ui = { notify: () => {}, confirm: async () => true }
+    expect(await ext.userBash('rm x', { hasUI: true, ui })).toBeUndefined()
+  })
+
+  it('blocks on permissionDecision ask when the user declines the prompt', async () => {
+    const ext = await withPreHook({ stdout: [JSON.stringify({ hookSpecificOutput: { permissionDecision: 'ask', permissionDecisionReason: 'confirm this' } })], code: 0 })
+    const ui = { notify: () => {}, confirm: async () => false }
+    expect(await ext.userBash('rm x', { hasUI: true, ui })).toEqual({ result: { output: 'Blocked by hook: confirm this', exitCode: 1, cancelled: false, truncated: false } })
+  })
+
+  it('does not interfere when no PreToolUse hooks are configured', async () => {
+    writeSettings(hoisted.home, 'settings.json', {})
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    expect(await ext.userBash('rm -rf /')).toBeUndefined()
     expect(commandsRun()).toEqual([])
   })
 })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import * as http from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -578,10 +578,33 @@ describe('runHookCommand timeout (real shell)', () => {
   })
 
   it('kills the shell descendants rather than leaving them running past the timeout', async () => {
-    const flag = join(tempDir(), 'grandchild-survived')
-    await runHookCommand(`(sleep 1; touch ${flag}) & sleep 30`, {}, 200)
-    await delay(2000)
+    const dir = tempDir()
+    const flag = join(dir, 'grandchild-survived')
+    const pidFile = join(dir, 'group.pid')
+    // The detached shell records its own pid (the process-group leader) so the test can
+    // watch the whole group, then backgrounds a grandchild that would touch the flag after
+    // 500ms. A 200ms timeout must SIGKILL the group before the grandchild's delay elapses.
+    await runHookCommand(`echo $$ > ${pidFile}; (sleep 0.5; touch ${flag}) & sleep 30`, {}, 200)
+    const pgid = Number(readFileSync(pidFile, 'utf8').trim())
+    expect(pgid).toBeGreaterThan(0)
 
+    // Bounded poll rather than a fixed sleep: watch for the group to disappear (kill -0
+    // throws ESRCH once every member is gone) while asserting the grandchild's flag never
+    // lands. Fast when the kill is prompt, flake-free in both directions.
+    const groupGone = (): boolean => {
+      try {
+        process.kill(-pgid, 0)
+        return false
+      } catch (error) {
+        return (error as NodeJS.ErrnoException).code === 'ESRCH'
+      }
+    }
+    const deadline = Date.now() + 2000
+    while (!groupGone()) {
+      expect(existsSync(flag)).toBe(false)
+      if (Date.now() > deadline) throw new Error('shell process group still alive 2s past the timeout')
+      await delay(50)
+    }
     expect(existsSync(flag)).toBe(false)
   })
 
@@ -602,6 +625,10 @@ describe('http hooks', () => {
   }
 
   const httpRunner: HookRunner = (hook, payload, ms) => runHttpHook(hook, payload, ms)
+
+  // Env stubs restore even if an assertion throws mid-test, so a failure cannot leak
+  // HOOK_TOKEN/HOOK_SECRET into sibling tests.
+  afterEach(() => vi.unstubAllEnvs())
 
   it('loads an http entry and blocks on a 2xx body carrying a deny decision', async () => {
     const srv = await serve((_req, res) => {
@@ -636,14 +663,12 @@ describe('http hooks', () => {
         res.end()
       })
     })
-    process.env.HOOK_TOKEN = 'tok123'
-    process.env.HOOK_SECRET = 'leakme'
+    vi.stubEnv('HOOK_TOKEN', 'tok123')
+    vi.stubEnv('HOOK_SECRET', 'leakme')
     const hook = { type: 'http', command: srv.url, url: srv.url, headers: { Authorization: 'Bearer $HOOK_TOKEN', 'X-Other': '${HOOK_SECRET}' }, allowedEnvVars: ['HOOK_TOKEN'] }
 
     const result = await runHttpHook(hook, { hook_event_name: 'PreToolUse', tool_name: 'bash' }, 5000)
     await srv.close()
-    delete process.env.HOOK_TOKEN
-    delete process.env.HOOK_SECRET
 
     expect(result).toMatchObject({ code: 0, timedOut: false })
     expect(seenAuth).toBe('Bearer tok123')

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -62,6 +62,8 @@ const hoisted = vi.hoisted(() => {
     clients: [] as ClientRecord[],
     callOptions: [] as Array<unknown>,
     closed: [] as ClientRecord[],
+    // Codes handed to a transport's finishAuth, so the interactive OAuth exchange is observable.
+    finishAuthCalls: [] as string[],
     notify: new Map<string, () => void | Promise<void>>(),
     control: {} as {
       connect: (transport: TransportRecord, client: ClientRecord) => Promise<void>
@@ -149,6 +151,11 @@ vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
       public options: Record<string, unknown>,
     ) {
       hoisted.transports.push(this)
+    }
+    // The SDK exchanges the authorization code here; recording it lets a test drive the
+    // interactive login and assert the code reached the transport.
+    async finishAuth(code: string): Promise<void> {
+      hoisted.finishAuthCalls.push(code)
     }
   },
 }))
@@ -301,6 +308,15 @@ const withTools = (tools: ToolDef[]): void => {
   hoisted.control.listTools = async () => ({ tools })
 }
 
+/** Poll a condition to a deadline; for interleaving a step into an in-flight connect flow. */
+const waitFor = async (predicate: () => boolean, timeoutMs = 3000): Promise<void> => {
+  const deadline = Date.now() + timeoutMs
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error('condition not met within timeout')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
 const defaultControl = (): typeof hoisted.control => ({
   connect: async () => {},
   listTools: async () => ({ tools: [] }),
@@ -337,6 +353,7 @@ beforeEach(() => {
   hoisted.clients.length = 0
   hoisted.callOptions.length = 0
   hoisted.closed.length = 0
+  hoisted.finishAuthCalls.length = 0
   hoisted.control = defaultControl()
   hoisted.notify.clear()
 })
@@ -786,6 +803,43 @@ describe('interactive OAuth serialization', () => {
     // The queued login proceeded once the first settled, and both servers connected.
     expect(confirmCount).toBe(2)
     expect(harness.toolNames().sort()).toEqual(['alpha_go', 'beta_go'])
+  })
+
+  it('exchanges the code through finishAuth and reconnects when the server 401s until authorized', async () => {
+    // The most real path: FileOAuthProvider, startCallbackServer and waitForAuthCode all run
+    // for real, so the loopback listener, the CSRF state echo and the code exchange are
+    // exercised end to end. Only the transport connect and the http client are stubbed, since
+    // the harness cannot reach a real OAuth server. Tradeoff: driving the real loopback means
+    // interleaving a fetch mid-flow (poll for the provider transport, then deliver the code),
+    // rather than stubbing waitForAuthCode, which would leave the callback plumbing untested.
+    withTools([{ name: 'go' }])
+    hoisted.control.connect = async (transport) => {
+      const authProvider = (transport.options as { authProvider?: unknown }).authProvider
+      // No provider is the silent first attempt; a provider before the exchange is the
+      // still-unauthorized retry. Both 401. Only a provider carrying the exchanged code connects.
+      if (!authProvider || hoisted.finishAuthCalls.length === 0) throw Object.assign(new Error('needs login'), { code: 401 })
+    }
+
+    const harness = await setup({ user: { remote: { url: 'https://example.com/mcp' } }, confirm: async () => true })
+    const started = harness.sessionStart()
+
+    // The interactive login builds a transport carrying the real provider; its redirect url
+    // reveals the loopback port the callback server actually bound.
+    const providerTransport = (): TransportRecord | undefined => hoisted.transports.find((t) => t.options.authProvider !== undefined)
+    await waitFor(() => providerTransport() !== undefined)
+    const provider = providerTransport()?.options.authProvider as { redirectUrl: string; state: () => string }
+
+    // Deliver the code to the real listener, echoing the provider's state so the CSRF check
+    // in waitForAuthCode passes; a wrong state would 400 and the login would hang.
+    const port = new URL(provider.redirectUrl).port
+    const redirect = await fetch(`http://127.0.0.1:${port}/callback?code=exchange-me&state=${provider.state()}`)
+    expect(redirect.status).toBe(200)
+
+    await started
+
+    expect(hoisted.finishAuthCalls).toEqual(['exchange-me'])
+    expect(harness.toolNames()).toEqual(['remote_go'])
+    expect(await statusLinesOf(harness)).toEqual(['remote: connected (1 tools)'])
   })
 })
 

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -2,9 +2,24 @@ import { mkdtempSync, readdirSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { FileOAuthProvider, startCallbackServer, waitForAuthCode } from '../extensions/internal/mcp-oauth.ts'
+// Record spawn so openBrowser's per-platform launch can be asserted without opening a browser.
+// importOriginal keeps the rest of child_process intact for any other consumer in the graph.
+const spawnMock = vi.hoisted(() => ({ calls: [] as Array<{ command: string; args: string[] }>, throwOnCall: false }))
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return {
+    ...actual,
+    spawn: (command: string, args: string[]) => {
+      spawnMock.calls.push({ command, args })
+      if (spawnMock.throwOnCall) throw new Error('spawn failed')
+      return { unref: () => {} }
+    },
+  }
+})
+
+const { FileOAuthProvider, openBrowser, startCallbackServer, waitForAuthCode } = await import('../extensions/internal/mcp-oauth.ts')
 
 let savedAgentDir: string | undefined
 beforeEach(() => {
@@ -72,6 +87,13 @@ describe('FileOAuthProvider', () => {
     expect(a.state()).toBe(a.state()) // stable within a single login
     expect(a.state()).not.toBe(b.state()) // a fresh token per attempt
   })
+
+  it('fails closed when the code verifier is read before one is saved', () => {
+    // The SDK asks for the PKCE verifier during the token exchange; a fresh provider has
+    // none, so it must throw rather than hand back an empty proof.
+    const provider = new FileOAuthProvider('no-verifier', () => {})
+    expect(() => provider.codeVerifier()).toThrow(/no code verifier saved/)
+  })
 })
 
 describe('callback server', () => {
@@ -131,5 +153,41 @@ describe('callback server', () => {
     await fetch(`http://127.0.0.1:${port}/callback?code=genuine&state=expected-state`)
     expect(await pending).toBe('genuine')
     server.close()
+  })
+})
+
+describe('openBrowser', () => {
+  const realPlatform = process.platform
+  const setPlatform = (value: NodeJS.Platform): void => {
+    Object.defineProperty(process, 'platform', { value, configurable: true })
+  }
+  afterEach(() => {
+    setPlatform(realPlatform)
+    spawnMock.calls.length = 0
+    spawnMock.throwOnCall = false
+  })
+
+  it('selects the launch command and args per platform', () => {
+    const url = 'https://auth.example/authorize?x=1'
+    const cases: Array<[NodeJS.Platform, string, string[]]> = [
+      ['darwin', 'open', [url]],
+      ['win32', 'cmd', ['/c', 'start', '', url]],
+      ['linux', 'xdg-open', [url]],
+    ]
+    for (const [platform, command, args] of cases) {
+      spawnMock.calls.length = 0
+      setPlatform(platform)
+      openBrowser(url)
+      expect(spawnMock.calls).toEqual([{ command, args }])
+    }
+  })
+
+  it('swallows a spawn failure so the notified url stays the only fallback', () => {
+    // A machine with no launcher throws on spawn; openBrowser must not surface it, since
+    // the caller already printed the URL for the user to open by hand.
+    setPlatform('linux')
+    spawnMock.throwOnCall = true
+    expect(() => openBrowser('https://auth.example/authorize')).not.toThrow()
+    expect(spawnMock.calls).toHaveLength(1)
   })
 })

--- a/tests/model-complete.test.ts
+++ b/tests/model-complete.test.ts
@@ -1,6 +1,32 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { assistantText, completeText, setCompleteBackend } from '../extensions/internal/model-complete.ts'
+// The real completion backend is ModelRuntime.create().completeSimple(...). Stub the runtime
+// with a recorder so a break in that production wiring is caught, rather than every test
+// overriding the backend and leaving realBackend() itself unexercised.
+const runtimeMock = vi.hoisted(() => ({
+  createCalls: 0,
+  completeCalls: [] as Array<{ model: unknown; context: { systemPrompt?: string; messages: Array<{ content: unknown }> }; options: { maxTokens?: number; signal?: AbortSignal } }>,
+  reply: { role: 'assistant', content: [{ type: 'text', text: 'real answer' }], api: 'x', provider: 'x', model: 'm', usage: { input: 3, output: 5, totalTokens: 8 }, stopReason: 'stop', timestamp: 0 },
+}))
+vi.mock('@earendil-works/pi-coding-agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@earendil-works/pi-coding-agent')>()
+  return {
+    ...actual,
+    ModelRuntime: {
+      create: async () => {
+        runtimeMock.createCalls += 1
+        return {
+          completeSimple: async (model: unknown, context: unknown, options: unknown) => {
+            runtimeMock.completeCalls.push({ model, context, options } as never)
+            return runtimeMock.reply
+          },
+        }
+      },
+    },
+  }
+})
+
+const { assistantText, completeText, setCompleteBackend } = await import('../extensions/internal/model-complete.ts')
 
 const msg = (parts: Array<{ type: string; text?: string }>, usage: unknown = {}) => ({ role: 'assistant', content: parts, api: 'x', provider: 'x', model: 'm', usage, stopReason: 'stop', timestamp: 0 }) as never
 
@@ -40,5 +66,36 @@ describe('completeText', () => {
       throw new Error('no credentials')
     })
     await expect(completeText({} as never, 'q')).rejects.toThrow(/no credentials/)
+  })
+})
+
+describe('completeText realBackend wiring', () => {
+  it('creates the ModelRuntime once, caches it, and forwards model, message and options', async () => {
+    runtimeMock.createCalls = 0
+    runtimeMock.completeCalls.length = 0
+    // Reset to the real backend so realBackend() actually runs ModelRuntime.create(); restore
+    // in finally so the cached mock runtime never leaks into a later test.
+    setCompleteBackend(null)
+    try {
+      const model = { id: 'test-model' } as never
+      const signal = new AbortController().signal
+      const first = await completeText(model, 'the question', { maxTokens: 321, signal })
+      const second = await completeText(model, 'again', { maxTokens: 50 })
+
+      // Created once and cached: both completions share the one runtime.
+      expect(runtimeMock.createCalls).toBe(1)
+      expect(runtimeMock.completeCalls).toHaveLength(2)
+      // {text, usage} flows back out of completeSimple.
+      expect(first).toEqual({ text: 'real answer', usage: runtimeMock.reply.usage })
+      expect(second.text).toBe('real answer')
+      // completeSimple received the model, the user message, and the resolved options.
+      const call = runtimeMock.completeCalls[0]
+      expect(call.model).toBe(model)
+      expect(call.context.messages[0]?.content).toBe('the question')
+      expect(call.options.maxTokens).toBe(321)
+      expect(call.options.signal).toBe(signal)
+    } finally {
+      setCompleteBackend(null)
+    }
   })
 })

--- a/tests/output-styles.test.ts
+++ b/tests/output-styles.test.ts
@@ -247,6 +247,33 @@ describe('extension wiring', () => {
     expect(notes.some((n) => n.includes('Unknown output style: no-such-style'))).toBe(true)
   })
 
+  it('completes /output-style names by prefix, returning every style for an empty prefix', async () => {
+    const cwd = tempDir()
+    mkdirSync(join(cwd, '.claude', 'output-styles'), { recursive: true })
+    writeFileSync(join(cwd, '.claude', 'output-styles', 'a.md'), '---\nname: QqzAlpha\ndescription: First\n---\nbody')
+    writeFileSync(join(cwd, '.claude', 'output-styles', 'b.md'), '---\nname: QqzBeta\n---\nbody')
+    const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>()
+    const commands = new Map<string, { getArgumentCompletions?: (prefix: string) => Promise<{ value: string; label: string; description?: string }[] | null> | { value: string; label: string; description?: string }[] | null }>()
+    outputStyles({
+      on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn),
+      registerCommand: (name: string, opts: { getArgumentCompletions?: (prefix: string) => unknown }) => commands.set(name, opts as never),
+    } as never)
+    const ctx = { cwd, hasUI: true, isProjectTrusted: () => true, ui: { notify: () => {}, confirm: async () => true, select: async () => undefined } }
+    await handlers.get('session_start')?.({}, ctx)
+    const complete = commands.get('output-style')?.getArgumentCompletions
+    if (!complete) throw new Error('output-style registered no getArgumentCompletions')
+
+    // Prefix match is case-insensitive; the Qqz prefix cannot collide with builtins.
+    expect((await complete('Qqz'))?.map((item) => item.value).sort()).toEqual(['QqzAlpha', 'QqzBeta'])
+    expect((await complete('qqza'))?.map((item) => item.value)).toEqual(['QqzAlpha'])
+    // The completion carries the style description when one exists.
+    expect((await complete('QqzAlpha'))?.[0]).toEqual({ value: 'QqzAlpha', label: 'QqzAlpha', description: 'First' })
+
+    // An empty prefix offers every discovered style, builtins included.
+    const expectedAll = loadStyles([BUILTIN_STYLES_DIR, join(cwd, '.claude', 'output-styles')]).map((style) => style.name)
+    expect((await complete(''))?.map((item) => item.value).sort()).toEqual([...expectedAll].sort())
+  })
+
   it('appends the active style body and the command persists a new choice', async () => {
     const cwd = projectWithStyle('Explain', 'Explain everything.')
 

--- a/tests/session-title.test.ts
+++ b/tests/session-title.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { setCompleteBackend } from '../extensions/internal/model-complete.ts'
+import sessionTitle, { cleanTitle, firstUserText } from '../extensions/session-title.ts'
+
+type Handler = (event: any, ctx: any) => Promise<unknown> | unknown
+
+/** A minimal assistant message the stubbed completion backend can return. */
+const assistantMsg = (text: string) => ({ role: 'assistant', content: [{ type: 'text', text }], api: 'x', provider: 'x', model: 'm', usage: {}, stopReason: 'stop', timestamp: 0 }) as never
+
+const userEntry = (content: any, id = 'u1') => ({ type: 'message', id, parentId: null, timestamp: '', message: { role: 'user', content } })
+const assistantEntry = (content: any, id = 'a1') => ({ type: 'message', id, parentId: null, timestamp: '', message: { role: 'assistant', content } })
+
+afterEach(() => setCompleteBackend(null))
+
+/** Fresh extension instance over a stub API. `initialName` seeds a pre-named session. */
+function setup(initialName?: string) {
+  const handlers = new Map<string, Handler>()
+  let name: string | undefined = initialName
+  const namesSet: string[] = []
+  const setTitles: string[] = []
+
+  sessionTitle({
+    on: (event: string, fn: Handler) => handlers.set(event, fn),
+    setSessionName: (n: string) => {
+      name = n
+      namesSet.push(n)
+    },
+    getSessionName: () => name,
+  } as any)
+
+  const makeCtx = (branch: any[], opts: { model?: unknown; setTitle?: boolean } = {}) => ({
+    model: 'model' in opts ? opts.model : {},
+    hasUI: true,
+    mode: 'tui' as const,
+    sessionManager: { getBranch: () => branch },
+    ui: opts.setTitle === false ? {} : { setTitle: (t: string) => setTitles.push(t) },
+  })
+
+  return {
+    settle: (branch: any[], opts?: { model?: unknown; setTitle?: boolean }) => handlers.get('agent_settled')?.({ type: 'agent_settled' }, makeCtx(branch, opts)),
+    start: (reason = 'new') => handlers.get('session_start')?.({ type: 'session_start', reason }, makeCtx([])),
+    namesSet,
+    setTitles,
+    getName: () => name,
+  }
+}
+
+describe('session auto-titling', () => {
+  it('names an unnamed session from its first user message on the first settle', async () => {
+    const t = setup()
+    setCompleteBackend(async () => assistantMsg('Refactor Config Loader'))
+    await t.settle([userEntry('refactor the config loader so it validates the schema up front')])
+    expect(t.namesSet).toEqual(['Refactor Config Loader'])
+    expect(t.setTitles).toEqual(['Refactor Config Loader'])
+    expect(t.getName()).toBe('Refactor Config Loader')
+  })
+
+  it('does not re-title on a later settle once the session is named', async () => {
+    const t = setup()
+    setCompleteBackend(async () => assistantMsg('First Title'))
+    await t.settle([userEntry('do the first thing')])
+    setCompleteBackend(async () => assistantMsg('Second Title'))
+    await t.settle([userEntry('do the first thing'), userEntry('do a second thing', 'u2')])
+    expect(t.namesSet).toEqual(['First Title'])
+    expect(t.setTitles).toEqual(['First Title'])
+  })
+
+  it('leaves a session that already has a name untouched, without calling the model', async () => {
+    const t = setup('User Chosen Name')
+    let called = false
+    setCompleteBackend(async () => {
+      called = true
+      return assistantMsg('Model Title')
+    })
+    await t.settle([userEntry('some message')])
+    expect(t.namesSet).toEqual([])
+    expect(t.setTitles).toEqual([])
+    expect(called).toBe(false)
+    expect(t.getName()).toBe('User Chosen Name')
+  })
+
+  it('skips titling and never throws when the completion fails', async () => {
+    const t = setup()
+    setCompleteBackend(async () => {
+      throw new Error('no credentials')
+    })
+    await expect(t.settle([userEntry('a message')])).resolves.toBeUndefined()
+    expect(t.namesSet).toEqual([])
+    expect(t.setTitles).toEqual([])
+    expect(t.getName()).toBeUndefined()
+  })
+
+  it('strips surrounding quotes and trailing punctuation from the model title', async () => {
+    const t = setup()
+    setCompleteBackend(async () => assistantMsg('"Fix The Parser."'))
+    await t.settle([userEntry('fix the parser bug')])
+    expect(t.namesSet).toEqual(['Fix The Parser'])
+  })
+
+  it('does not title a turn with no user text (slash-command-only)', async () => {
+    const t = setup()
+    let called = false
+    setCompleteBackend(async () => {
+      called = true
+      return assistantMsg('Nope')
+    })
+    await t.settle([assistantEntry([{ type: 'text', text: 'hello from the assistant' }])])
+    expect(t.namesSet).toEqual([])
+    expect(called).toBe(false)
+  })
+
+  it('does not title when no model is available (headless)', async () => {
+    const t = setup()
+    let called = false
+    setCompleteBackend(async () => {
+      called = true
+      return assistantMsg('Nope')
+    })
+    await t.settle([userEntry('hello')], { model: undefined })
+    expect(t.namesSet).toEqual([])
+    expect(called).toBe(false)
+  })
+
+  it('still names the session when the ui cannot set a window title', async () => {
+    const t = setup()
+    setCompleteBackend(async () => assistantMsg('Some Title'))
+    await t.settle([userEntry('do a thing')], { setTitle: false })
+    expect(t.namesSet).toEqual(['Some Title'])
+    expect(t.setTitles).toEqual([])
+  })
+
+  it('does not retry a failed attempt until a new session resets the guard', async () => {
+    const t = setup()
+    setCompleteBackend(async () => {
+      throw new Error('provider down')
+    })
+    await t.settle([userEntry('a message')])
+    // Same session, model now works: the single attempt was already spent, so no retry.
+    setCompleteBackend(async () => assistantMsg('Recovered Title'))
+    await t.settle([userEntry('a message'), userEntry('another', 'u2')])
+    expect(t.namesSet).toEqual([])
+    // A fresh session clears the guard, so titling can happen again.
+    await t.start('new')
+    await t.settle([userEntry('brand new session message')])
+    expect(t.namesSet).toEqual(['Recovered Title'])
+  })
+})
+
+describe('cleanTitle', () => {
+  it('strips wrapping quotes, trailing punctuation, and collapses whitespace', () => {
+    expect(cleanTitle('  "Refactor   the Loader."  ')).toBe('Refactor the Loader')
+    expect(cleanTitle("'Add Retry Logic'")).toBe('Add Retry Logic')
+    expect(cleanTitle('Plain Title')).toBe('Plain Title')
+    expect(cleanTitle('“Smart Quotes”')).toBe('Smart Quotes')
+    expect(cleanTitle('`Backtick Title`!')).toBe('Backtick Title')
+  })
+})
+
+describe('firstUserText', () => {
+  const ctxFor = (branch: any[]) => ({ sessionManager: { getBranch: () => branch } }) as any
+
+  it('returns the first user message text from string or text-part content', () => {
+    expect(firstUserText(ctxFor([userEntry('just a string')]))).toBe('just a string')
+    expect(
+      firstUserText(
+        ctxFor([
+          userEntry([
+            { type: 'text', text: 'part one' },
+            { type: 'text', text: 'part two' },
+          ]),
+        ]),
+      ),
+    ).toBe('part one part two')
+  })
+
+  it('skips assistant entries and returns empty when there is no user text', () => {
+    expect(firstUserText(ctxFor([assistantEntry('hi'), userEntry('the real one', 'u2')]))).toBe('the real one')
+    expect(firstUserText(ctxFor([assistantEntry([{ type: 'text', text: 'assistant only' }])]))).toBe('')
+    expect(firstUserText(ctxFor([]))).toBe('')
+  })
+})

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -2,9 +2,17 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import skillsExt, { skillDirs } from '../extensions/skills.ts'
+// Point os.homedir() at a hermetic temp home so the extension-wiring test never reads the
+// developer's real ~/.claude skills. The other suites pass home explicitly and are unaffected.
+const hoisted = vi.hoisted(() => ({ home: '' }))
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: () => hoisted.home }
+})
+
+const { default: skillsExt, skillDirs } = await import('../extensions/skills.ts')
 
 const tempDir = (prefix: string): string => mkdtempSync(join(tmpdir(), prefix))
 
@@ -72,19 +80,34 @@ describe('skillDirs', () => {
 })
 
 describe('extension wiring', () => {
+  // A mocked homedir plus a fresh agent dir make the discovery hermetic: the trust store
+  // and the home skills both live in temp dirs, never the developer's real config.
+  let savedAgentDir: string | undefined
+  beforeEach(() => {
+    hoisted.home = tempDir('cs-home-')
+    savedAgentDir = process.env.PI_CODING_AGENT_DIR
+    process.env.PI_CODING_AGENT_DIR = tempDir('cs-agent-')
+  })
+  afterEach(() => {
+    if (savedAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR
+    else process.env.PI_CODING_AGENT_DIR = savedAgentDir
+  })
+
   it('returns skillPaths from resources_discover when skills exist', async () => {
     const cwd = tempDir('cs-proj-')
     mkdirSync(join(cwd, '.claude', 'skills'), { recursive: true })
+    const homeSkills = join(hoisted.home, '.claude', 'skills')
+    mkdirSync(homeSkills, { recursive: true })
 
     const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>()
     skillsExt({ on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn) } as never)
-    // A .claude/skills directory is itself claude-shaped config, so a project pi
-    // trusts silently still has no stored decision and contributes nothing.
-    const ctx = { cwd, isProjectTrusted: () => true }
-    const result = (await handlers.get('resources_discover')?.({ reason: 'startup' }, ctx)) as { skillPaths: string[] } | undefined
-    expect(result?.skillPaths ?? []).not.toContain(join(cwd, '.claude', 'skills'))
+    // A .claude/skills directory is itself claude-shaped config, so a project pi trusts
+    // silently but has no stored decision for contributes nothing: only the hermetic home
+    // skills survive, and never the project's, trusted or not.
+    const trusted = (await handlers.get('resources_discover')?.({ reason: 'startup' }, { cwd, isProjectTrusted: () => true })) as { skillPaths: string[] } | undefined
+    expect(trusted).toEqual({ skillPaths: [homeSkills] })
 
     const untrusted = (await handlers.get('resources_discover')?.({ reason: 'startup' }, { cwd, isProjectTrusted: () => false })) as { skillPaths: string[] } | undefined
-    expect(untrusted?.skillPaths ?? []).not.toContain(join(cwd, '.claude', 'skills'))
+    expect(untrusted).toEqual({ skillPaths: [homeSkills] })
   })
 })

--- a/tests/status-line-command.test.ts
+++ b/tests/status-line-command.test.ts
@@ -339,6 +339,131 @@ describe('statusLine disableAllHooks', () => {
   })
 })
 
+describe('statusLine rate limits', () => {
+  it('surfaces the five-hour and seven-day windows from provider response headers', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'x', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    await handlers.get('after_provider_response')?.(
+      {
+        type: 'after_provider_response',
+        status: 200,
+        headers: {
+          'anthropic-ratelimit-unified-5h-utilization': '35.5',
+          'anthropic-ratelimit-unified-5h-reset': '2026-08-16T12:00:00Z',
+          'anthropic-ratelimit-unified-7d-utilization': '12',
+          'anthropic-ratelimit-unified-7d-reset': '2026-08-22T00:00:00Z',
+        },
+      },
+      ctx,
+    )
+    await handlers.get('turn_end')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+
+    const payload = hoisted.runs.at(-1)?.payload as Record<string, unknown>
+    expect(payload.rate_limits).toEqual({
+      five_hour: { used_percentage: 35.5, resets_at: '2026-08-16T12:00:00Z' },
+      seven_day: { used_percentage: 12, resets_at: '2026-08-22T00:00:00Z' },
+    })
+  })
+
+  it('computes utilization from limit and remaining when no utilization header is sent', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'x', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    // Header casing varies by provider, and a null value must be tolerated, not crash.
+    await handlers.get('after_provider_response')?.(
+      {
+        type: 'after_provider_response',
+        status: 200,
+        headers: {
+          'Anthropic-RateLimit-Unified-5h-Limit': '1000',
+          'Anthropic-RateLimit-Unified-5h-Remaining': '250',
+          'anthropic-ratelimit-unified-7d-utilization': null,
+        },
+      },
+      ctx,
+    )
+    await handlers.get('turn_end')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+
+    const payload = hoisted.runs.at(-1)?.payload as Record<string, unknown>
+    expect(payload.rate_limits).toEqual({ five_hour: { used_percentage: 75 } })
+  })
+
+  it('omits rate_limits when the response carries no rate-limit headers', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'x', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    await handlers.get('after_provider_response')?.({ type: 'after_provider_response', status: 200, headers: {} }, ctx)
+    await handlers.get('turn_end')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+
+    const payload = hoisted.runs.at(-1)?.payload as Record<string, unknown>
+    expect(payload.rate_limits).toBeUndefined()
+  })
+
+  it('warns once per session on a 429 with the retry-after delay', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'x', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    const notify = vi.fn()
+    ctx.ui.notify = notify
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    await handlers.get('after_provider_response')?.({ type: 'after_provider_response', status: 429, headers: { 'retry-after': '30' } }, ctx)
+    await handlers.get('after_provider_response')?.({ type: 'after_provider_response', status: 429, headers: {} }, ctx)
+
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(notify.mock.calls[0][1]).toBe('warning')
+    expect(String(notify.mock.calls[0][0])).toContain('30')
+  })
+})
+
+describe('statusLine instant refresh', () => {
+  it('refreshes immediately when the model changes', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'seg', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    const initial = hoisted.runs.length
+    await handlers.get('model_select')?.({ type: 'model_select', model: { id: 'other' }, previousModel: undefined, source: 'set' }, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(hoisted.runs.length).toBe(initial + 1)
+  })
+
+  it('refreshes immediately when the thinking level changes', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'seg', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    const initial = hoisted.runs.length
+    await handlers.get('thinking_level_select')?.({ type: 'thinking_level_select', level: 'low', previousLevel: 'high' }, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(hoisted.runs.length).toBe(initial + 1)
+  })
+})
+
 describe('statusLine model payload', () => {
   it('falls back to the model id when pi reports no display name', async () => {
     const cwd = tempDir()


### PR DESCRIPTION
## Summary

Closes out the audit backlog with the SDK-leverage wins and the test-quality fixes, test-driven; the suite lands at 1698 tests, 96.8% statements and 91.4% branches.

The statusline now parses the anthropic-ratelimit response headers it already receives into a rate_limits payload (five-hour and seven-day windows), warns once per session on a 429 with the retry-after, and refreshes immediately when the user switches model or thinking level instead of waiting for the next turn. Sessions auto-name themselves after the first run from the first prompt, through the same in-process completion seam the hooks use, best-effort and once per session. User-typed ! bash commands now run the PreToolUse Bash hooks: the user_bash event carries no block flag, so a deny is enforced honestly by handling the execution with a synthetic failed result, and the event delivers no output so there is deliberately no PostToolUse counterpart. /output-style completes style names.

The rest is test hardening from the audit: the interactive OAuth success path is now exercised against the real loopback listener with the CSRF state echoed and the code exchange asserted, the real completion-backend construction is pinned so its wiring cannot break silently, the skills suite is hermetic instead of reading the developer's real home, env mutations use stubEnv, the flaky kill-descendants test polls the process group instead of sleeping, the mcp-oauth fail-closed branches are covered, and brace globs are exercised at every consumer site. The live e2e script gains seven beats: MCP prompts as commands, the resource tools, the slash_command tool, /hooks, skills, a configured statusLine command, and a background subagent listed by /tasks.