### PR TITLE
Fix multi-session lifecycle gaps and track the 0.84 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ What a repository ships is treated as untrusted until you approve it: project MC
 
 ![pi-code demo](demos/hero.gif)
 
+## Requirements
+
+pi `>=0.79.1` (0.84.x recommended) and Node `>=22.19` for current pi.
+
 ## Install
 
 ```bash

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -466,6 +466,16 @@ export default function commandsExtension(pi: ExtensionAPI) {
   }
 
   pi.on('session_start', async (_event, ctx) => {
+    // One extension instance serves every session. A mid-turn /new fires session_start on
+    // the same instance while a command's per-run scoping is still pending (its agent_settled
+    // never came). Carrying that into the next session would restore an unrelated tool set,
+    // bash/path scope, model, or effort onto it, so drop the pending state here. Drop only:
+    // no setActiveTools/setModel/setThinkingLevel, since the new session owns its own state.
+    pendingRestore = undefined
+    pendingBashRules = undefined
+    pendingPathRules = undefined
+    pendingModelRestore = undefined
+    pendingEffortRestore = undefined
     const trusted = await isProjectApproved(ctx)
     projectApproved = trusted
     // A resume/fork/new session can switch projects in-process. pi cannot unregister a

--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -253,6 +253,13 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
   }
 
   pi.on('session_start', async (_event, ctx) => {
+    // One extension instance serves every session. A mid-turn /new fires session_start on
+    // the same instance after turn_start took the pre-run snapshot but before turn_end saved
+    // it; that pending ref belongs to the previous session and must not attach to the next
+    // session's first turn_end. Re-arm runNeedsSnapshot too, so the next run snapshots its
+    // own tree even though the prior run left it false.
+    pending = undefined
+    runNeedsSnapshot = true
     await ensureShadow(ctx)
     checkpoints.clear()
     for (const entry of ctx.sessionManager.getEntries()) {

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -67,7 +67,7 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import type { Api, Model } from '@earendil-works/pi-ai'
-import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
+import type { ExtensionAPI, ExtensionContext, ToolCallEventResult } from '@earendil-works/pi-coding-agent'
 import { runAgent } from './internal/agent-run.js'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { INSTRUCTIONS_CHANNEL, isInstructionLoadEvent } from './internal/instruction-events.js'
@@ -859,12 +859,10 @@ function postToolFeedback(result: HookRunResult, eventName: string, isError: boo
   return lines
 }
 
-/** A blocked tool_call verdict carrying pi 0.84.1's `terminate` flag (#7715): with it set on
+/** A blocked tool_call verdict carrying pi's `terminate` flag (#7715): with it set on
  * an all-terminating tool batch, pi skips the automatic follow-up model call that a plain
- * block would otherwise pay for. `terminate` is not on the installed 0.84.0
- * ToolCallEventResult type, so it is attached through this superset shape (rather than a cast
- * that would drop it at runtime); the wave's dep bump to ^0.84.2 lands the real declaration. */
-function blockedToolCall(reason: string | undefined): { block: true; reason?: string; terminate: true } {
+ * block would otherwise pay for. */
+function blockedToolCall(reason: string | undefined): ToolCallEventResult {
   return { block: true, reason, terminate: true }
 }
 

--- a/extensions/hooks.ts
+++ b/extensions/hooks.ts
@@ -859,6 +859,15 @@ function postToolFeedback(result: HookRunResult, eventName: string, isError: boo
   return lines
 }
 
+/** A blocked tool_call verdict carrying pi 0.84.1's `terminate` flag (#7715): with it set on
+ * an all-terminating tool batch, pi skips the automatic follow-up model call that a plain
+ * block would otherwise pay for. `terminate` is not on the installed 0.84.0
+ * ToolCallEventResult type, so it is attached through this superset shape (rather than a cast
+ * that would drop it at runtime); the wave's dep bump to ^0.84.2 lands the real declaration. */
+function blockedToolCall(reason: string | undefined): { block: true; reason?: string; terminate: true } {
+  return { block: true, reason, terminate: true }
+}
+
 export default function hooksExtension(pi: ExtensionAPI) {
   let config: HooksConfig = {}
   let projectDir = ''
@@ -951,6 +960,11 @@ export default function hooksExtension(pi: ExtensionAPI) {
 
   pi.on('session_start', async (event, ctx) => {
     sessionCtx = ctx
+    // One extension instance serves every session. A mid-turn /new fires session_start on
+    // the same instance while a Stop-hook continuation streak is in flight; it must not
+    // carry into the next session, so reset before any early return (disableAllHooks below).
+    stopHookActive = false
+    stopHookBlockCount = 0
     const trusted = await isProjectApproved(ctx)
     // Claude's CLAUDE_PROJECT_DIR is the project root, not the session cwd; a hook
     // referencing $CLAUDE_PROJECT_DIR/.claude/hooks/helper.sh must resolve from a
@@ -1002,9 +1016,9 @@ export default function hooksExtension(pi: ExtensionAPI) {
     // With no UI (headless) the block stands, which is the safe default.
     if (decision.ask && ctx.hasUI) {
       const approved = await ctx.ui.confirm(`Allow ${event.toolName}?`, decision.reason ?? 'A hook asks you to confirm this tool call.')
-      return approved ? undefined : { block: true, reason: decision.reason }
+      return approved ? undefined : blockedToolCall(decision.reason)
     }
-    return { block: true, reason: decision.reason }
+    return blockedToolCall(decision.reason)
   })
 
   // Claude's PostToolUse (success) and PostToolUseFailure (error) both feed their

--- a/extensions/mcp.ts
+++ b/extensions/mcp.ts
@@ -943,6 +943,12 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   // Original server/tool names per registered pi name, for Claude-style hook matchers.
   const aliases: McpToolAlias[] = []
 
+  /** How many tools a server actually has registered. Counted from `registered` (the
+   * durable owner map) rather than registerTools' return, so a reconnect on a second
+   * session, where every tool is already registered and registerTools adds 0, still
+   * reports the true count in /mcp and the startup banner instead of zero. */
+  const serverToolCount = (name: string): number => [...registered.values()].filter((owner) => owner === name).length
+
   /** Register every not-yet-registered tool of a server; returns how many were added. */
   function registerTools(name: string, config: ServerConfig, tools: McpToolInfo[]): number {
     let count = 0
@@ -1154,7 +1160,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           const added = registerTools(name, config, refreshed)
           if (added === 0) return
           const current = status.get(name)
-          status.set(name, { state: current?.state ?? 'connected', tools: (current?.tools ?? 0) + added })
+          status.set(name, { state: current?.state ?? 'connected', tools: serverToolCount(name) })
           pi.events.emit(MCP_TOOLS_CHANNEL, [...aliases])
         } catch (error) {
           console.warn(`pi-code-mcp: tool refresh failed for ${name}: ${error instanceof Error ? error.message : String(error)}`)
@@ -1187,7 +1193,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           const client = await connect(name, config, authUi)
           clients.set(name, client)
           const tools = await withTimeout(listAllTools(client), connectTimeoutMs(), `list tools ${name}`)
-          const count = registerTools(name, config, tools)
+          registerTools(name, config, tools)
           subscribeToToolChanges(name, config, client)
           // Prompts and resources are additive surfaces: their failures warn (inside
           // connectPrompts) rather than flipping a tool-serving server to failed.
@@ -1195,7 +1201,10 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           subscribeToPromptChanges(name, client)
           ensureResourceTools()
           subscribeToResourceChanges(client)
-          status.set(name, { state: 'connected', tools: count })
+          // Count from `registered`, not registerTools' return: a reconnect re-lists tools
+          // that are already registered (return 0) but still serves them, so the banner
+          // must reflect the true count.
+          status.set(name, { state: 'connected', tools: serverToolCount(name) })
           // A server that dies mid-session would otherwise stay "connected" in /mcp
           // while every call fails with the SDK's bare "Not connected"; flip the
           // status and free the name so a later session start can reconnect it.
@@ -1291,6 +1300,12 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   }
 
   pi.on('session_start', async (_event, ctx) => {
+    // Reset the status map so /mcp and the banner reflect only this session's config: a
+    // server present last session but not this one must not linger as "connected". The
+    // registered tools, aliases, and prompt commands stay: pi has no unregister (a
+    // withdrawn tool keeps its registration and surfaces the server's own error), which
+    // is why serverToolCount reads from `registered` to recover the true count here.
+    status.clear()
     const authUi = authUiFor(ctx)
     // The managed allow/deny lists filter every scope, including a managed-mcp.json set.
     const { allowed, denied } = mcpAllowDeny()
@@ -1320,6 +1335,13 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   pi.on('session_shutdown', async () => {
     // Close in parallel with a per-client timeout so one hung server can't stall pi's exit.
     await Promise.all([...clients.values()].map((client) => withTimeout(client.close(), 3000, 'close').catch(() => {})))
+    // Drop the closed clients and their status now rather than waiting on each client's
+    // onclose, which the SDK fires late: a same-process session switch (/new, /resume,
+    // /fork) runs the next session_start right after this, and a lingering dead client
+    // there would make connectServers skip reconnecting the name, stranding every tool
+    // closure on a closed client. session_start resets status too, so a switch rebuilds it.
+    clients.clear()
+    status.clear()
   })
 
   pi.registerCommand('mcp', {

--- a/extensions/session-title.ts
+++ b/extensions/session-title.ts
@@ -3,15 +3,15 @@
  *
  * Claude auto-names a new conversation from its first message; this does the same for
  * pi. After the first run of an unnamed session settles, it asks the current model for
- * a short title based on the first user message and applies it two ways: setSessionName
- * (the name shown in the session selector) and the terminal window/tab title.
+ * a short title based on the first user message and applies it with setSessionName, which
+ * names the session in the selector and refreshes the terminal window/tab title natively
+ * (pi changelog); a separate ctx.ui.setTitle call would only duplicate that, so there is none.
  *
  * It runs in every mode, not just the TUI: naming a session is cheap and harmless, and a
- * headless run that persists its session still benefits from a readable name later. The
- * window-title update is the only terminal-specific part, so it is optional-called rather
- * than gated on hasUI. Titling is best-effort throughout: a session that already has a
- * name, a run with no user text (a slash-command-only turn), a headless run with no model,
- * or any provider error leaves the session untitled and never throws.
+ * headless run that persists its session still benefits from a readable name later. Titling
+ * is best-effort throughout: a session that already has a name, a run with no user text (a
+ * slash-command-only turn), a headless run with no model, or any provider error leaves the
+ * session untitled and never throws.
  *
  * Cost: one model call per session at most. The guard is claimed before the completion so
  * repeated settles cannot each fire a call, and a failed attempt is not retried until a
@@ -132,8 +132,11 @@ export default function sessionTitleExtension(pi: ExtensionAPI) {
     // Post-await ctx getters throw once the session is disposed, and an escaping rejection
     // from this un-awaited settle can exit pi; apply the title best-effort.
     try {
+      // pi.setSessionName refreshes the terminal/tab title natively (pi changelog), so a
+      // separate ctx.ui.setTitle call would only duplicate that. The guard stays: a
+      // disposed session throws from setSessionName post-await, and an escaping rejection
+      // from this un-awaited settle can exit pi.
       pi.setSessionName(title)
-      ctx.ui.setTitle?.(title)
     } catch {
       // disposed session or a setter failure: leave the session untitled.
     }

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -1,8 +1,9 @@
 /**
  * Background subagent runs: fire-and-forget children whose completion wakes
  * the parent agent via a notification message. State lives in an in-memory
- * registry queried via {status: true}; it is lost on restart, and a child
- * still running when pi exits finishes on its own rather than being killed.
+ * registry queried via {status: true}; it is lost on restart. A child still
+ * running when pi quits is SIGTERMed (cancelAllBackgroundRuns); one still running
+ * across a same-process session switch keeps going under the new session.
  */
 
 import { spawn } from 'node:child_process'
@@ -139,6 +140,18 @@ export function cancelBackgroundRun(id: string): 'cancelled' | 'not-running' | '
   run.kill()
   run.kill = undefined
   return 'cancelled'
+}
+
+/** SIGTERM every live background child, killing each process group the way a single
+ * cancel does. Called on quit: a detached child would otherwise keep running (and
+ * spending tokens) after pi exits, its completion swallowed. Returns how many were
+ * signalled; each cancelled child still holds its slot until it actually dies. */
+export function cancelAllBackgroundRuns(): number {
+  let count = 0
+  for (const id of [...runs.keys()]) {
+    if (cancelBackgroundRun(id) === 'cancelled') count++
+  }
+  return count
 }
 
 export function backgroundStatusText(): string {

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -148,7 +148,7 @@ export function cancelBackgroundRun(id: string): 'cancelled' | 'not-running' | '
  * signalled; each cancelled child still holds its slot until it actually dies. */
 export function cancelAllBackgroundRuns(): number {
   let count = 0
-  for (const id of [...runs.keys()]) {
+  for (const id of Array.from(runs.keys())) {
     if (cancelBackgroundRun(id) === 'cancelled') count++
   }
   return count

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -32,7 +32,7 @@ import { SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
 import { autoMemoryEnabled, capIndexForPrompt, INDEX_MAX_BYTES, INDEX_MAX_LINES, memorySettingsFiles, readMemorySettings } from '../memory.js'
 import { skillDirs } from '../skills.js'
 import { type AgentConfig, type AgentMemoryScope, type AgentScope, type AgentSource, discoverAgents, resolveModelAlias, withPreloadedSkills } from './agents.js'
-import { activeBackgroundRuns, type BackgroundRun, backgroundRun, backgroundStatusText, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
+import { activeBackgroundRuns, type BackgroundRun, backgroundRun, backgroundStatusText, cancelAllBackgroundRuns, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
 
 const MAX_PARALLEL_TASKS = 8
 const MAX_CONCURRENCY = 4
@@ -1385,6 +1385,23 @@ export default function subagentExtension(pi: ExtensionAPI) {
       })
       return getFinalOutput(result.messages)
     })
+  })
+
+  pi.on('session_shutdown', (event, ctx) => {
+    // On quit pi is exiting, so a detached background child would keep running (and
+    // spending tokens) with its completion swallowed: SIGTERM every live run, killing the
+    // process group the way a cancel does. On a same-process session switch
+    // (new/resume/fork) the children keep running under the new session, so leave them be
+    // and warn once that they are still spending; /tasks inspects them. reload re-imports
+    // this module (losing the registry), so it neither kills nor warns.
+    if (event.reason === 'quit') {
+      cancelAllBackgroundRuns()
+      return
+    }
+    if (event.reason === 'new' || event.reason === 'resume' || event.reason === 'fork') {
+      const active = activeBackgroundRuns()
+      if (active > 0) ctx.ui?.notify(`${active} background run${active === 1 ? '' : 's'} still active; /tasks to inspect`, 'warning')
+    }
   })
 
   // Claude surfaces each agent's description so the model can pick one autonomously.

--- a/extensions/thinking.ts
+++ b/extensions/thinking.ts
@@ -46,6 +46,15 @@ export default function thinkingExtension(pi: ExtensionAPI) {
   // already moved the level, thinking stands down instead of clobbering it.
   let pendingTarget: ThinkingLevel | undefined
 
+  pi.on('session_start', () => {
+    // One extension instance serves every session. A mid-turn /new fires session_start on
+    // the same instance while an escalation is still pending (its agent_settled never came),
+    // and that stale restore must be dropped rather than fired into the next session, whose
+    // level the new session owns. Drop only: do NOT setThinkingLevel here.
+    pendingRestore = undefined
+    pendingTarget = undefined
+  })
+
   pi.on('input', (event, ctx) => {
     // Only genuine user input escalates. sendUserMessage emits an input event with
     // source 'extension' (a subagent prompt, a command body replayed through it); a

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "typebox": "^1.3.6"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.4",
-        "@earendil-works/pi-agent-core": "^0.84.0",
-        "@earendil-works/pi-ai": "^0.84.0",
-        "@earendil-works/pi-coding-agent": "^0.84.0",
-        "@earendil-works/pi-tui": "^0.84.0",
+        "@earendil-works/pi-agent-core": "^0.84.2",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-coding-agent": "^0.84.2",
+        "@earendil-works/pi-tui": "^0.84.2",
         "@types/node": "^26.1.1",
         "@vitest/coverage-v8": "^4.1.10",
         "typescript": "^7.0.2",
@@ -27,9 +27,9 @@
         "node": ">=22.19"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*",
-        "@earendil-works/pi-tui": "*"
+        "@earendil-works/pi-ai": ">=0.79.1",
+        "@earendil-works/pi-coding-agent": ">=0.79.1",
+        "@earendil-works/pi-tui": ">=0.79.1"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -133,14 +133,14 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
-      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
         "@aws/lambda-invoke-store": "^0.3.0",
         "@smithy/core": "^3.31.1",
         "@smithy/signature-v4": "^5.6.12",
@@ -153,14 +153,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
-      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -170,14 +170,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
-      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -189,14 +189,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
-      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -204,21 +204,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
-      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/credential-provider-env": "^3.972.67",
-        "@aws-sdk/credential-provider-http": "^3.972.69",
-        "@aws-sdk/credential-provider-login": "^3.972.74",
-        "@aws-sdk/credential-provider-process": "^3.972.67",
-        "@aws-sdk/credential-provider-sso": "^3.973.11",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -229,15 +229,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.74",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
-      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -247,19 +247,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.78",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
-      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.67",
-        "@aws-sdk/credential-provider-http": "^3.972.69",
-        "@aws-sdk/credential-provider-ini": "^3.973.12",
-        "@aws-sdk/credential-provider-process": "^3.972.67",
-        "@aws-sdk/credential-provider-sso": "^3.973.11",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -270,14 +270,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
-      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -287,16 +287,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
-      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/token-providers": "3.1103.0",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -306,15 +306,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1103.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
-      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -324,15 +324,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.73",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
-      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/nested-clients": "^3.997.41",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -342,13 +342,13 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
-      "integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.33.tgz",
+      "integrity": "sha512-1Dd5WyEE2Kb3HvY44u7Ob16ST2W6iutOqsQ8Y2hUmsL2mAH/STlGS1dS9h3IOE6L7Ld3AR2HzKJ6XeCMOw8Peg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -358,13 +358,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
-      "integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.28.tgz",
+      "integrity": "sha512-Z1EDXnS01P7H5jVrUx+/dBqV0m7dta7bSxLclkOuDuS93pNNQm0IcT4YLUbuvWKPYNxbI8aTG0p5Br30GSKDgA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -374,14 +374,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.49",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.49.tgz",
-      "integrity": "sha512-wGYJvu1/stdWuzGcNyh44u8aY7ArU8XFrMesBlzIYn70HWVCRBNEngQexDuPIMu0NEgsKGKmTc0uvnS/bF7KWw==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.51.tgz",
+      "integrity": "sha512-jdgP3jR5Q96j1jjZ98GGwpGg1CBNFIO2YE+vXg8cg8PvNY4NvgQNYJsqDaRX2PYv5gSUX/+C0D58Fhspj9ELMQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/signature-v4": "^5.6.12",
@@ -393,15 +393,15 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
-      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.6",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -413,14 +413,14 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
-      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -428,13 +428,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
-      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -462,9 +462,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
-      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
-      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -489,9 +489,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
-      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -533,13 +533,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -559,9 +559,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -583,9 +583,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.4.tgz",
-      "integrity": "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.9.tgz",
+      "integrity": "sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -599,20 +599,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.4",
-        "@biomejs/cli-darwin-x64": "2.5.4",
-        "@biomejs/cli-linux-arm64": "2.5.4",
-        "@biomejs/cli-linux-arm64-musl": "2.5.4",
-        "@biomejs/cli-linux-x64": "2.5.4",
-        "@biomejs/cli-linux-x64-musl": "2.5.4",
-        "@biomejs/cli-win32-arm64": "2.5.4",
-        "@biomejs/cli-win32-x64": "2.5.4"
+        "@biomejs/cli-darwin-arm64": "2.5.9",
+        "@biomejs/cli-darwin-x64": "2.5.9",
+        "@biomejs/cli-linux-arm64": "2.5.9",
+        "@biomejs/cli-linux-arm64-musl": "2.5.9",
+        "@biomejs/cli-linux-x64": "2.5.9",
+        "@biomejs/cli-linux-x64-musl": "2.5.9",
+        "@biomejs/cli-win32-arm64": "2.5.9",
+        "@biomejs/cli-win32-x64": "2.5.9"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.4.tgz",
-      "integrity": "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.9.tgz",
+      "integrity": "sha512-am22pX2aBqznqq1eMyIj/bZ++riF3Lk6ct7cbv+gQK0csFhr+d8O0RkOi2FF2qSgFgANbqNkIZ0/PxlnW2pLFg==",
       "cpu": [
         "arm64"
       ],
@@ -627,9 +627,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.4.tgz",
-      "integrity": "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.9.tgz",
+      "integrity": "sha512-l44KWDHLDvEnD0N/XcrVs7VXb3A18xL7QS3WB0eL93wbmk529ffIG55vleGCqaunpRUjLrdnjK05Qki1dsjylg==",
       "cpu": [
         "x64"
       ],
@@ -644,13 +644,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.4.tgz",
-      "integrity": "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.9.tgz",
+      "integrity": "sha512-ICaK+IYaVZvKbBxX2rwrPT0DdUDMnE9Vm3nQGe+mltQPmUg19pONzkPWGdY4FCsoreDETWDynvdt4ysCbF5gNQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -661,13 +664,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.4.tgz",
-      "integrity": "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.9.tgz",
+      "integrity": "sha512-7ImVPwBLCtkmpR5esd8RHhTqW94f0JLJQum6AneYcy94jRm18TaPPm7slaigGzFhfgt3QiD1Vj52LKmBAnKizA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -678,13 +684,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.4.tgz",
-      "integrity": "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.9.tgz",
+      "integrity": "sha512-z22Q/zFYSvbIJfW1CbfZPu4X8PddS6Qd2ORbc6h+aT6EcwAxUF3m6fA4HjNvA3TU4X0dTJRwNPB165ES3PJXzg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -695,13 +704,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.4.tgz",
-      "integrity": "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.9.tgz",
+      "integrity": "sha512-RXGaD0o1/pTTguYw1aeDJh9ad6Lfrui0fI7mBderTyGr7WuUJkBIttgLkR3XJyoxOkkgfBDspaUT8wXArTqLZw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -712,9 +724,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.4.tgz",
-      "integrity": "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.9.tgz",
+      "integrity": "sha512-nHK+/HHC+D0ogAHUxomgoSTdjImb6fmNNVTKmf0tyu4eDL1DqPKIHc+i+UL8+b0RnAu8224qo8F2tCVnaT0A3w==",
       "cpu": [
         "arm64"
       ],
@@ -729,9 +741,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.4.tgz",
-      "integrity": "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.9.tgz",
+      "integrity": "sha512-Yiq0H56LjXSSw/hd9YkXgSLQfzyDJzbzU2TezozxyNw+uKWAqOtqGVvBfzKRRDiaFF5avGAhHdWKx7LtDOShUw==",
       "cpu": [
         "x64"
       ],
@@ -746,14 +758,14 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.0.tgz",
-      "integrity": "sha512-L1lw0lwR5LXCzGEeHD9XNEruU2bg0H8clOA8ySdGMHvxutp8GC+yZL6MZp4tqQRnLKP3gHmY7TrWzQ3YnFdJYQ==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
+      "integrity": "sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.0",
-        "@earendil-works/pi-telemetry": "^0.84.0",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -763,23 +775,29 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/@earendil-works/pi-agent-core/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
-      "integrity": "sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.0",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -790,19 +808,26 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/@earendil-works/pi-ai/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.0.tgz",
-      "integrity": "sha512-oxEU7BT9xuVT6UKNwUNDzNP5dVGb+DZRGfaEyMyAab8dRlqTSxxyhSlMAxmYsu//YOeasj9E8n2+px1BzIai0g==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.2.tgz",
+      "integrity": "sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.84.0",
-        "@earendil-works/pi-ai": "^0.84.0",
-        "@earendil-works/pi-client": "^0.84.0",
-        "@earendil-works/pi-protocol": "^0.84.0",
-        "@earendil-works/pi-tui": "^0.84.0",
+        "@earendil-works/pi-agent-core": "^0.84.2",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-client": "^0.84.2",
+        "@earendil-works/pi-protocol": "^0.84.2",
+        "@earendil-works/pi-tui": "^0.84.2",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1293,13 +1318,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.0.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.0",
-        "@earendil-works/pi-telemetry": "^0.84.0",
+        "@earendil-works/pi-ai": "^0.84.2",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -1310,21 +1335,20 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.0",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -1336,20 +1360,20 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.0.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-protocol": "^0.84.0"
+        "@earendil-works/pi-protocol": "^0.84.2"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.0.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1360,8 +1384,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.0.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1369,8 +1393,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.0.tgz",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1596,27 +1620,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -1638,16 +1641,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
@@ -2434,14 +2427,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -2777,30 +2767,10 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.0.tgz",
-      "integrity": "sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2808,9 +2778,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.0.tgz",
-      "integrity": "sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
+      "integrity": "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2819,40 +2789,6 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@google/genai": {
@@ -2881,12 +2817,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2920,34 +2856,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -2981,25 +2896,6 @@
         }
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -3010,20 +2906,10 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3097,9 +2983,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
       "cpu": [
         "arm64"
       ],
@@ -3114,9 +3000,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
       "cpu": [
         "arm64"
       ],
@@ -3131,9 +3017,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
       "cpu": [
         "x64"
       ],
@@ -3148,9 +3034,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
       "cpu": [
         "x64"
       ],
@@ -3165,9 +3051,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
       "cpu": [
         "arm"
       ],
@@ -3182,13 +3068,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3199,13 +3088,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3216,13 +3108,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3233,13 +3128,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3250,13 +3148,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3267,13 +3168,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3284,9 +3188,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
       "cpu": [
         "arm64"
       ],
@@ -3300,29 +3204,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
       "cpu": [
         "arm64"
       ],
@@ -3337,9 +3222,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
       "cpu": [
         "x64"
       ],
@@ -3361,13 +3246,13 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
-      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
+      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3375,14 +3260,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
-      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3390,14 +3275,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.13",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
-      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3433,14 +3318,14 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
-      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
+      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3448,9 +3333,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
-      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3495,17 +3380,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -3532,9 +3406,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4166,9 +4040,9 @@
       }
     },
     "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4432,9 +4306,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4488,9 +4362,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -4550,9 +4424,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
-      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -4582,9 +4456,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -4716,9 +4590,9 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
-      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4870,9 +4744,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4966,9 +4840,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5035,9 +4909,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -5252,6 +5126,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5273,6 +5150,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5294,6 +5174,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5315,6 +5198,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5388,14 +5274,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.3",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "source-map-js": "^1.2.1"
       }
     },
@@ -5438,12 +5324,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -5490,9 +5380,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -5614,14 +5504,11 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -5721,9 +5608,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -5741,7 +5628,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5850,13 +5737,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.139.0",
+        "@oxc-project/types": "=0.144.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -5866,21 +5753,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.5",
-        "@rolldown/binding-darwin-arm64": "1.1.5",
-        "@rolldown/binding-darwin-x64": "1.1.5",
-        "@rolldown/binding-freebsd-x64": "1.1.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-        "@rolldown/binding-linux-arm64-musl": "1.1.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-musl": "1.1.5",
-        "@rolldown/binding-openharmony-arm64": "1.1.5",
-        "@rolldown/binding-wasm32-wasi": "1.1.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
       }
     },
     "node_modules/router": {
@@ -6144,9 +6030,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6171,9 +6057,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6222,9 +6108,9 @@
       }
     },
     "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6235,9 +6121,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
-      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "version": "1.3.15",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.15.tgz",
+      "integrity": "sha512-gOKAjLqUr+bFGbO5vxCEO5+nHh2wO+swzSIkiJJC0kJ4oLN6f65SrZn6tJYhsYO+qdnpf2NmlQwgsayYoi1NkQ==",
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -6301,16 +6187,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
+        "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.17",
-        "rolldown": "~1.1.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -6327,7 +6213,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -6517,9 +6403,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
-      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "todo"
   ],
   "license": "MIT",
+  "author": "ilovepixelart",
   "type": "module",
   "files": [
     "extensions"
@@ -51,20 +52,20 @@
     "provenance": true
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "typebox": "^1.3.6"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*"
+    "@earendil-works/pi-ai": ">=0.79.1",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
+    "@earendil-works/pi-tui": ">=0.79.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.4",
-    "@earendil-works/pi-agent-core": "^0.84.0",
-    "@earendil-works/pi-ai": "^0.84.0",
-    "@earendil-works/pi-coding-agent": "^0.84.0",
-    "@earendil-works/pi-tui": "^0.84.0",
+    "@earendil-works/pi-agent-core": "^0.84.2",
+    "@earendil-works/pi-ai": "^0.84.2",
+    "@earendil-works/pi-coding-agent": "^0.84.2",
+    "@earendil-works/pi-tui": "^0.84.2",
     "@types/node": "^26.1.1",
     "@vitest/coverage-v8": "^4.1.10",
     "typescript": "^7.0.2",

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -361,6 +361,33 @@ describe('commands extension', () => {
     expect(s.activeTools()).toEqual(['bash', 'read', 'edit', 'write'])
   })
 
+  it('drops pending command scoping on session_start so it never restores across a session switch', async () => {
+    // One extension instance serves every session. A mid-turn /new fires session_start on
+    // the same instance while a command's tool, model, and effort scoping is still pending;
+    // restoring that stale state into the next session would corrupt it, so session_start
+    // drops the pending state (without itself restoring anything).
+    const cwd = tempDir()
+    writeCommand(cwd, 'deep.md', '---\nallowed-tools: Read\nmodel: opus\neffort: max\n---\nLook only.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('deep')?.handler('', s.ctx)
+    expect(s.activeTools()).toEqual(['read'])
+    expect(s.modelSets).toEqual(['claude-opus-5'])
+    expect(s.thinkingSets).toEqual(['max'])
+
+    // A mid-turn /new reuses the instance: the pending restores must be dropped.
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    const toolSetsBefore = s.toolSets.length
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
+
+    // agent_settled fired no stale restore: tools, model, and effort are left where the
+    // command left them rather than reverted into the next session.
+    expect(s.toolSets.length).toBe(toolSetsBefore)
+    expect(s.activeTools()).toEqual(['read'])
+    expect(s.modelSets).toEqual(['claude-opus-5'])
+    expect(s.thinkingSets).toEqual(['max'])
+  })
+
   it('does not register project commands for an unapproved project', async () => {
     const cwd = tempDir()
     writeCommand(cwd, 'evil.md', 'do bad things')

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -232,6 +232,42 @@ describe('shadow-repo checkpoint lifecycle', () => {
 
     expect(t.notifications.some((n) => n.startsWith('[warning] Code restore failed'))).toBe(true)
   })
+
+  it('drops a pending snapshot on session_start so a mid-turn /new does not persist it into the next session', async () => {
+    // One extension instance serves every session. A mid-turn /new fires session_start
+    // after turn_start took the pre-run snapshot but before turn_end saved it; that
+    // pending ref belongs to the previous session and must not attach to the next
+    // session's first turn_end.
+    const t = setup()
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx([], [], []))
+    await t.handlers.get('agent_start')?.({}, t.makeCtx([], [], []))
+    await t.handlers.get('turn_start')?.({ turnIndex: 0 }, t.makeCtx([], [], []))
+
+    await t.handlers.get('session_start')?.({ reason: 'new' }, t.makeCtx([], [], []))
+    await t.handlers.get('turn_end')?.({ turnIndex: 0 }, t.makeCtx([], [userEntry], []))
+
+    expect(t.appended).toEqual([])
+  })
+
+  it('re-arms the pre-run snapshot on session_start so the next session still checkpoints', async () => {
+    // The prior run left runNeedsSnapshot false after its turn_start. session_start must
+    // re-arm it so the next session's first turn_start snapshots its own tree, even without
+    // an intervening agent_start.
+    const t = setup()
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx([], [], []))
+    await t.handlers.get('agent_start')?.({}, t.makeCtx([], [], []))
+    await t.handlers.get('turn_start')?.({ turnIndex: 0 }, t.makeCtx([], [], []))
+    await t.handlers.get('turn_end')?.({ turnIndex: 0 }, t.makeCtx([], [userEntry], []))
+    expect(t.appended).toHaveLength(1)
+
+    await t.handlers.get('session_start')?.({ reason: 'new' }, t.makeCtx([], [], []))
+    const secondPrompt = { ...userEntry, id: 'user0002', message: { role: 'user', content: 'a brand new task' } }
+    await t.handlers.get('turn_start')?.({ turnIndex: 1 }, t.makeCtx([], [secondPrompt], []))
+    await t.handlers.get('turn_end')?.({ turnIndex: 1 }, t.makeCtx([], [secondPrompt], []))
+
+    expect(t.appended).toHaveLength(2)
+    expect(t.appended[1].data.entryId).toBe('user0002')
+  })
 })
 
 describe('pruneCheckpointRepos', () => {

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -792,7 +792,7 @@ describe('hooks extension tool_call', () => {
 
   it('blocks the tool with the hook stderr as the reason when the hook exits 2', async () => {
     const ext = await withPreHook({ stderr: ['force push is not allowed'], code: 2 })
-    expect(await ext.toolCall('bash', { command: 'git push -f' })).toEqual({ block: true, reason: 'force push is not allowed' })
+    expect(await ext.toolCall('bash', { command: 'git push -f' })).toEqual({ block: true, reason: 'force push is not allowed', terminate: true })
   })
 
   it('runs a PreToolUse prompt hook through the model and blocks on its deny decision', async () => {
@@ -801,7 +801,7 @@ describe('hooks extension tool_call', () => {
     const ext = setupExtension()
     await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
     const decision = await ext.toolCall('bash', { command: 'rm -rf /' }, 't1', { model: {} })
-    expect(decision).toEqual({ block: true, reason: 'looks risky' })
+    expect(decision).toEqual({ block: true, reason: 'looks risky', terminate: true })
   })
 
   it('lets the tool through when a prompt hook allows and there is no command hook to run', async () => {
@@ -815,7 +815,7 @@ describe('hooks extension tool_call', () => {
 
   it('blocks the tool with the deny reason from hookSpecificOutput', async () => {
     const ext = await withPreHook({ stdout: [JSON.stringify({ hookSpecificOutput: { permissionDecision: 'deny', permissionDecisionReason: 'secrets file' } })], code: 0 })
-    expect(await ext.toolCall('bash', { command: 'cat .env' })).toEqual({ block: true, reason: 'secrets file' })
+    expect(await ext.toolCall('bash', { command: 'cat .env' })).toEqual({ block: true, reason: 'secrets file', terminate: true })
   })
 
   it('returns undefined so the tool proceeds when the hook allows it', async () => {
@@ -832,12 +832,12 @@ describe('hooks extension tool_call', () => {
   it('blocks on permissionDecision ask when the user declines the prompt', async () => {
     const ext = await withPreHook({ stdout: [JSON.stringify({ hookSpecificOutput: { permissionDecision: 'ask', permissionDecisionReason: 'confirm this' } })], code: 0 })
     const ui = { notify: () => {}, confirm: async () => false }
-    expect(await ext.toolCall('bash', { command: 'rm x' }, 't1', { hasUI: true, ui })).toEqual({ block: true, reason: 'confirm this' })
+    expect(await ext.toolCall('bash', { command: 'rm x' }, 't1', { hasUI: true, ui })).toEqual({ block: true, reason: 'confirm this', terminate: true })
   })
 
   it('blocks on permissionDecision ask with no UI to prompt (headless fallback)', async () => {
     const ext = await withPreHook({ stdout: [JSON.stringify({ hookSpecificOutput: { permissionDecision: 'ask', permissionDecisionReason: 'confirm this' } })], code: 0 })
-    expect(await ext.toolCall('bash', { command: 'rm x' })).toEqual({ block: true, reason: 'confirm this' })
+    expect(await ext.toolCall('bash', { command: 'rm x' })).toEqual({ block: true, reason: 'confirm this', terminate: true })
   })
 
   it('forwards the tool name and input to the hook payload', async () => {
@@ -1200,6 +1200,26 @@ describe('hooks extension notify-style events', () => {
       await ext.agentEnd()
       expect(ext.sent).toHaveLength(7)
       expect(ext.notes.some((n) => n.level === 'warning' && /cap/i.test(n.msg))).toBe(true)
+    })
+
+    it('resets the Stop-hook streak on session_start so a mid-turn /new starts fresh', async () => {
+      // One extension instance serves every session. A Stop-hook continuation streak
+      // (stop_hook_active plus the consecutive-block count) from the previous session must
+      // not carry into the next: a mid-turn /new fires session_start on the same instance,
+      // which resets both so the next Stop reports stop_hook_active false.
+      const ext = await withHooks({ Stop: [{ hooks: [{ command: 'keep-going' }] }] })
+      script('keep-going', { stderr: ['not done'], code: 2 })
+      await ext.agentEnd() // first block: continues and arms stop_hook_active for the next firing
+      expect(ext.sent).toHaveLength(1)
+
+      await ext.sessionStart('new', { cwd: tempDir('hooks-proj-') })
+
+      script('keep-going', { stderr: ['still red'], code: 2 })
+      await ext.agentEnd()
+      const calls = hoisted.calls.filter((call) => call.command === 'keep-going')
+      // The post-reset firing reports stop_hook_active false, not the true carried from before.
+      expect(JSON.parse(calls[calls.length - 1].stdin).stop_hook_active).toBe(false)
+      expect(ext.sent).toHaveLength(2) // the count reset too, so this block still continues
     })
   })
 
@@ -1674,7 +1694,7 @@ describe('allowedHttpHookUrls wiring', () => {
       allowedHttpHookUrls: ['https://hooks.example.com/*'],
       hooks: { PreToolUse: [{ hooks: [{ type: 'http', url: 'https://hooks.example.com/pre' }] }] },
     })
-    expect(await ext.toolCall('bash', { command: 'ls' })).toEqual({ block: true, reason: 'nope' })
+    expect(await ext.toolCall('bash', { command: 'ls' })).toEqual({ block: true, reason: 'nope', terminate: true })
     expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -1357,6 +1357,55 @@ describe('mcp session_shutdown', () => {
   })
 })
 
+describe('mcp second in-process session', () => {
+  it('reconnects the same server and reports its real tool count, not zero', async () => {
+    // session_start -> session_shutdown -> session_start with the same server. The
+    // shutdown must drop the closed client from the map (not rely on a deferred onclose),
+    // so the second session reconnects; the banner and /mcp must count the tools from the
+    // registered map (pi cannot unregister them) rather than registerTools' return, which
+    // is 0 on a reconnect because they are already registered.
+    withTools([{ name: 'go' }, { name: 'stop' }])
+    const harness = await setupStarted({ user: { srv: { command: 'x' } } })
+    const first = hoisted.clients.at(-1)
+    expect(harness.notifications).toEqual([{ message: 'MCP: 2 tools from 1 servers', level: 'info' }])
+
+    await harness.shutdown()
+    await harness.sessionStart()
+    const second = hoisted.clients.at(-1)
+    // The closed client was replaced, not skipped as a lingering duplicate.
+    expect(second).not.toBe(first)
+
+    // The second banner counts the real tools, not zero.
+    expect(harness.notifications.at(-1)).toEqual({ message: 'MCP: 2 tools from 1 servers', level: 'info' })
+    // /mcp shows the server connected with its true tool count.
+    expect(await statusLinesOf(harness)).toEqual(['srv: connected (2 tools)'])
+
+    // The still-registered tool executes against the SECOND client instance.
+    const calledOn: unknown[] = []
+    hoisted.control.callTool = async (_args, client) => {
+      calledOn.push(client)
+      return { content: [{ type: 'text', text: 'ok' }] }
+    }
+    await harness.tools[0].execute('call-1', {})
+    expect(calledOn).toEqual([second])
+  })
+
+  it('drops a server removed from the config from /mcp on the next session', async () => {
+    // A server present in the first session but not the second must not linger in /mcp:
+    // the status map is reset per session so it reflects only the current config.
+    withTools([{ name: 'go' }])
+    const harness = await setup({ user: { keep: { command: 'k' }, drop: { command: 'd' } } })
+    await harness.sessionStart()
+    expect((await statusLinesOf(harness)).sort()).toEqual(['drop: connected (1 tools)', 'keep: connected (1 tools)'])
+
+    await harness.shutdown()
+    writeServers(join(harness.home, '.claude.json'), { keep: { command: 'k' } })
+    await harness.sessionStart()
+
+    expect(await statusLinesOf(harness)).toEqual(['keep: connected (1 tools)'])
+  })
+})
+
 describe('MCP tool alias publication', () => {
   it('publishes pi-to-Claude tool name aliases on the shared bus with original names', async () => {
     withTools([{ name: 'web-search' }])

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -33,6 +33,7 @@ function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
   const tools = new Map<string, (id: string, params: Record<string, unknown>) => Promise<ToolResult>>()
   const shortcuts: Array<(ctx: unknown) => Promise<void>> = []
   const sent: SentMessage[] = []
+  const sentOptions: unknown[] = []
   const userMessages: string[] = []
   const userMessageOptions: unknown[] = []
   const appended: Array<{ type: string; data: unknown }> = []
@@ -53,7 +54,10 @@ function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
     registerTool: (tool: { name: string; execute: (id: string, params: Record<string, unknown>) => Promise<ToolResult> }) => tools.set(tool.name, tool.execute),
     registerShortcut: (_key: unknown, spec: { handler: (ctx: unknown) => Promise<void> }) => shortcuts.push(spec.handler),
     on: (name: string, fn: Handler) => handlers.set(name, fn),
-    sendMessage: (message: SentMessage) => sent.push(message),
+    sendMessage: (message: SentMessage, options?: unknown) => {
+      sent.push(message)
+      sentOptions.push(options)
+    },
     sendUserMessage: (text: string, options?: unknown) => {
       userMessages.push(text)
       userMessageOptions.push(options)
@@ -98,6 +102,13 @@ function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
     getActiveTools: () => activeTools,
     runCommand: (name: string, args = '', context: unknown = ctx) => commands.get(name)?.(args, context),
     callTool: (name: string, params: Record<string, unknown>) => tools.get(name)?.('call-1', params) as Promise<ToolResult>,
+    /** The { triggerTurn } options the last sendMessage of this customType carried. */
+    optionsFor: (customType: string) => {
+      for (let i = sent.length - 1; i >= 0; i--) {
+        if (sent[i].customType === customType) return sentOptions[i]
+      }
+      return undefined
+    },
   }
 }
 
@@ -633,5 +644,42 @@ describe('execution mode stall exit', () => {
     await s.emit('agent_end', { messages: [] })
 
     expect(await s.emit('before_agent_start')).toBeDefined()
+  })
+})
+
+describe('record-only sends (0.84.2 triggerTurn:false semantics)', () => {
+  // pi 0.84.2 (#8022) made sendMessage(..., { triggerTurn: false }) purely record-only:
+  // it no longer steers an active run, only appends a display message. plan mode has two
+  // such sites (the plan-todo-list review message and the plan-complete/stall summary);
+  // both intend record-only, and no surrounding logic depends on the old steer side effect.
+  it('records the plan-todo-list review message without triggering a turn', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    await s.emit('agent_end', { messages: [assistant('Plan:\n1. Read the config loader\n2. Add the new field')] })
+
+    expect(s.sent.find((m) => m.customType === 'plan-todo-list')).toBeDefined()
+    expect(s.optionsFor('plan-todo-list')).toEqual({ triggerTurn: false })
+  })
+
+  it('records the plan-complete summary without triggering a turn', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    await s.callTool('plan_mode_complete', { plan: '1. First step\n2. Second step' })
+    await s.emit('agent_end', { messages: [] }) // default choice executes the plan
+    await s.emit('turn_end', { message: assistant('[DONE:1] [DONE:2]') })
+    await s.emit('agent_end', { messages: [] }) // every step done -> endExecution sends plan-complete
+
+    expect(s.sent.find((m) => m.customType === 'plan-complete')).toBeDefined()
+    expect(s.optionsFor('plan-complete')).toEqual({ triggerTurn: false })
+  })
+
+  it('still drives a turn for the execute message (triggerTurn:true), unlike the record-only sends', async () => {
+    const s = setup()
+    await s.runCommand('plan')
+    await s.emit('agent_end', { messages: [assistant('Plan:\n1. Read the config loader')] })
+
+    // The one send that must still steer a run is plan-mode-execute; the record-only sites
+    // are deliberately triggerTurn:false alongside it.
+    expect(s.optionsFor('plan-mode-execute')).toEqual({ triggerTurn: true })
   })
 })

--- a/tests/session-title.test.ts
+++ b/tests/session-title.test.ts
@@ -13,45 +13,37 @@ const assistantEntry = (content: any, id = 'a1') => ({ type: 'message', id, pare
 
 afterEach(() => setCompleteBackend(null))
 
-/** Fresh extension instance over a stub API. `initialName` seeds a pre-named session. */
-function setup(initialName?: string) {
+/** Fresh extension instance over a stub API. `initialName` seeds a pre-named session;
+ * `throwOnSetName` models a session disposed while the title call was in flight. */
+function setup(initialName?: string, opts: { throwOnSetName?: boolean } = {}) {
   const handlers = new Map<string, Handler>()
   let name: string | undefined = initialName
   const namesSet: string[] = []
-  const setTitles: string[] = []
 
   sessionTitle({
     on: (event: string, fn: Handler) => handlers.set(event, fn),
     setSessionName: (n: string) => {
+      // pi.setSessionName refreshes the terminal/tab title natively, so it is the only title
+      // sink; a session disposed mid-call throws from it post-await, which the guard swallows.
+      if (opts.throwOnSetName) throw new Error('session disposed')
       name = n
       namesSet.push(n)
     },
     getSessionName: () => name,
   } as any)
 
-  const makeCtx = (branch: any[], opts: { model?: unknown; setTitle?: boolean; throwUi?: boolean } = {}) => {
-    const base = {
-      model: 'model' in opts ? opts.model : {},
-      hasUI: true,
-      mode: 'tui' as const,
-      sessionManager: { getBranch: () => branch },
-    }
-    // A ctx whose ui getter throws models a session disposed while a title call was in flight.
-    if (opts.throwUi) {
-      return Object.defineProperty(base, 'ui', {
-        get: () => {
-          throw new Error('session disposed')
-        },
-      })
-    }
-    return { ...base, ui: opts.setTitle === false ? {} : { setTitle: (t: string) => setTitles.push(t) } }
-  }
+  const makeCtx = (branch: any[], ctxOpts: { model?: unknown } = {}) => ({
+    model: 'model' in ctxOpts ? ctxOpts.model : {},
+    hasUI: true,
+    mode: 'tui' as const,
+    sessionManager: { getBranch: () => branch },
+    ui: {},
+  })
 
   return {
-    settle: (branch: any[], opts?: { model?: unknown; setTitle?: boolean; throwUi?: boolean }) => handlers.get('agent_settled')?.({ type: 'agent_settled' }, makeCtx(branch, opts)),
+    settle: (branch: any[], ctxOpts?: { model?: unknown }) => handlers.get('agent_settled')?.({ type: 'agent_settled' }, makeCtx(branch, ctxOpts)),
     start: (reason = 'new') => handlers.get('session_start')?.({ type: 'session_start', reason }, makeCtx([])),
     namesSet,
-    setTitles,
     getName: () => name,
   }
 }
@@ -62,7 +54,6 @@ describe('session auto-titling', () => {
     setCompleteBackend(async () => assistantMsg('Refactor Config Loader'))
     await t.settle([userEntry('refactor the config loader so it validates the schema up front')])
     expect(t.namesSet).toEqual(['Refactor Config Loader'])
-    expect(t.setTitles).toEqual(['Refactor Config Loader'])
     expect(t.getName()).toBe('Refactor Config Loader')
   })
 
@@ -73,7 +64,6 @@ describe('session auto-titling', () => {
     setCompleteBackend(async () => assistantMsg('Second Title'))
     await t.settle([userEntry('do the first thing'), userEntry('do a second thing', 'u2')])
     expect(t.namesSet).toEqual(['First Title'])
-    expect(t.setTitles).toEqual(['First Title'])
   })
 
   it('leaves a session that already has a name untouched, without calling the model', async () => {
@@ -85,7 +75,6 @@ describe('session auto-titling', () => {
     })
     await t.settle([userEntry('some message')])
     expect(t.namesSet).toEqual([])
-    expect(t.setTitles).toEqual([])
     expect(called).toBe(false)
     expect(t.getName()).toBe('User Chosen Name')
   })
@@ -97,7 +86,6 @@ describe('session auto-titling', () => {
     })
     await expect(t.settle([userEntry('a message')])).resolves.toBeUndefined()
     expect(t.namesSet).toEqual([])
-    expect(t.setTitles).toEqual([])
     expect(t.getName()).toBeUndefined()
   })
 
@@ -130,14 +118,6 @@ describe('session auto-titling', () => {
     await t.settle([userEntry('hello')], { model: undefined })
     expect(t.namesSet).toEqual([])
     expect(called).toBe(false)
-  })
-
-  it('still names the session when the ui cannot set a window title', async () => {
-    const t = setup()
-    setCompleteBackend(async () => assistantMsg('Some Title'))
-    await t.settle([userEntry('do a thing')], { setTitle: false })
-    expect(t.namesSet).toEqual(['Some Title'])
-    expect(t.setTitles).toEqual([])
   })
 
   it('does not retry a failed attempt until a new session resets the guard', async () => {
@@ -174,15 +154,16 @@ describe('session auto-titling', () => {
     await settling
     // The late title belonged to the prior session; it must not rename the new one.
     expect(t.namesSet).toEqual([])
-    expect(t.setTitles).toEqual([])
   })
 
-  it('does not reject when the ctx is disposed after the model call resolves', async () => {
-    const t = setup()
+  it('does not reject when setSessionName throws on a disposed session after the model call', async () => {
+    const t = setup(undefined, { throwOnSetName: true })
     setCompleteBackend(async () => assistantMsg('Some Title'))
-    // A ctx whose ui getter throws post-await models a session disposed while the call
-    // was in flight; an escaping rejection from this un-awaited settle can exit pi.
-    await expect(t.settle([userEntry('do a thing')], { throwUi: true })).resolves.toBeUndefined()
+    // setSessionName is the only post-await title sink; a session disposed while the call
+    // was in flight throws from it, and an escaping rejection from this un-awaited settle
+    // can exit pi, so the guard must swallow it.
+    await expect(t.settle([userEntry('do a thing')])).resolves.toBeUndefined()
+    expect(t.namesSet).toEqual([])
   })
 })
 

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -504,6 +504,58 @@ describe('cancelBackgroundRun', () => {
   })
 })
 
+describe('cancelAllBackgroundRuns', () => {
+  const invocation = { command: 'pi', args: ['--mode', 'json'], cwd: '/work/dir' }
+
+  it('signals every live child, marks them cancelled, and reports the count', async () => {
+    const { startBackgroundRun, cancelAllBackgroundRuns, activeBackgroundRuns, backgroundStatusText } = await loadBackground()
+    const completed: Array<{ state: string }> = []
+    startBackgroundRun('scout', 'one', invocation, (run) => completed.push(run))
+    startBackgroundRun('scout', 'two', invocation, (run) => completed.push(run))
+    expect(activeBackgroundRuns()).toBe(2)
+
+    expect(cancelAllBackgroundRuns()).toBe(2)
+    for (const child of spawned.children) expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(backgroundStatusText()).not.toContain('running')
+
+    // A cancelled child still holds its slot until it actually dies (SIGTERM may be ignored).
+    expect(activeBackgroundRuns()).toBe(2)
+    for (const child of spawned.children) child.emit('close', 143)
+    expect(activeBackgroundRuns()).toBe(0)
+    expect(completed.map((run) => run.state)).toEqual(['cancelled', 'cancelled'])
+  })
+
+  it('skips already-finished runs and counts only the ones it signalled', async () => {
+    const { startBackgroundRun, cancelAllBackgroundRuns } = await loadBackground()
+    startBackgroundRun('scout', 'done-run', invocation, () => {})
+    spawned.children[0].emit('close', 0) // finished before the shutdown
+    startBackgroundRun('scout', 'live-run', invocation, () => {})
+
+    expect(cancelAllBackgroundRuns()).toBe(1)
+    expect(spawned.children[1].kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('signals the process group, not just the direct child', async () => {
+    // A cancel kills -pid so any grandchild the agent spawned dies too; the fake child's
+    // pid stands in for the group. Spying process.kill lets the group signal succeed and
+    // be observed rather than throwing ESRCH and falling back to the direct child.
+    const { startBackgroundRun, cancelAllBackgroundRuns } = await loadBackground()
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    try {
+      startBackgroundRun('scout', 'grp', invocation, () => {})
+      cancelAllBackgroundRuns()
+      expect(killSpy).toHaveBeenCalledWith(-4242, 'SIGTERM')
+    } finally {
+      killSpy.mockRestore()
+    }
+  })
+
+  it('returns zero when there are no runs to cancel', async () => {
+    const { cancelAllBackgroundRuns } = await loadBackground()
+    expect(cancelAllBackgroundRuns()).toBe(0)
+  })
+})
+
 describe('startBackgroundRun', () => {
   const invocation = { command: 'pi', args: ['--mode', 'json'], cwd: '/work/dir' }
 

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -21,6 +21,7 @@ const discoverAgentsMock = vi.hoisted(() => vi.fn())
 const startBackgroundRunMock = vi.hoisted(() => vi.fn((_agent: string, _task: string, _invocation: { command: string; args: string[]; cwd: string }, _onComplete: (run: unknown) => void): string | null => 'bg-deadbeef'))
 const backgroundStatusTextMock = vi.hoisted(() => vi.fn(() => 'No background runs in this session.'))
 const cancelBackgroundRunMock = vi.hoisted(() => vi.fn())
+const cancelAllBackgroundRunsMock = vi.hoisted(() => vi.fn(() => 0))
 const resumeBackgroundRunMock = vi.hoisted(() => vi.fn())
 const activeBackgroundRunsMock = vi.hoisted(() => vi.fn(() => 0))
 const backgroundRunMock = vi.hoisted(() => vi.fn())
@@ -33,6 +34,7 @@ vi.mock('../extensions/subagent/agents.js', async (importOriginal) => ({
 vi.mock('../extensions/subagent/background.js', () => ({
   backgroundStatusText: backgroundStatusTextMock,
   cancelBackgroundRun: cancelBackgroundRunMock,
+  cancelAllBackgroundRuns: cancelAllBackgroundRunsMock,
   resumeBackgroundRun: resumeBackgroundRunMock,
   startBackgroundRun: startBackgroundRunMock,
   activeBackgroundRuns: activeBackgroundRunsMock,
@@ -224,6 +226,8 @@ beforeEach(() => {
   startBackgroundRunMock.mockReturnValue('bg-deadbeef')
   backgroundStatusTextMock.mockClear()
   cancelBackgroundRunMock.mockReset()
+  cancelAllBackgroundRunsMock.mockClear()
+  cancelAllBackgroundRunsMock.mockReturnValue(0)
   resumeBackgroundRunMock.mockReset()
   activeBackgroundRunsMock.mockReturnValue(0)
   backgroundRunMock.mockReset()
@@ -970,6 +974,45 @@ describe('agentsListText', () => {
     expect(out).toContain('user:')
     expect(out).not.toContain('builtin:')
     expect(out).not.toContain('project:')
+  })
+})
+
+describe('session_shutdown background runs', () => {
+  const shutdown = (reason: string, ctx: unknown) => eventHandlers.get('session_shutdown')?.({ reason }, ctx)
+
+  it('SIGTERMs every live background run on quit without warning', async () => {
+    activeBackgroundRunsMock.mockReturnValue(2)
+
+    await shutdown('quit', commandCtx())
+
+    expect(cancelAllBackgroundRunsMock).toHaveBeenCalledTimes(1)
+    expect(notifyMock).not.toHaveBeenCalled()
+  })
+
+  it.each(['new', 'resume', 'fork'])('warns about still-active runs on a %s switch without killing them', async (reason) => {
+    activeBackgroundRunsMock.mockReturnValue(3)
+
+    await shutdown(reason, commandCtx())
+
+    expect(cancelAllBackgroundRunsMock).not.toHaveBeenCalled()
+    expect(notifyMock).toHaveBeenCalledWith('3 background runs still active; /tasks to inspect', 'warning')
+  })
+
+  it('warns in the singular for a single active run', async () => {
+    activeBackgroundRunsMock.mockReturnValue(1)
+
+    await shutdown('resume', commandCtx())
+
+    expect(notifyMock).toHaveBeenCalledWith('1 background run still active; /tasks to inspect', 'warning')
+  })
+
+  it('stays silent on a switch when no runs are active', async () => {
+    activeBackgroundRunsMock.mockReturnValue(0)
+
+    await shutdown('new', commandCtx())
+
+    expect(cancelAllBackgroundRunsMock).not.toHaveBeenCalled()
+    expect(notifyMock).not.toHaveBeenCalled()
   })
 })
 

--- a/tests/thinking.test.ts
+++ b/tests/thinking.test.ts
@@ -19,6 +19,7 @@ function wire(initial = 'off') {
   return {
     input: (text: string, ctx: any = {}, source = 'interactive') => handlers.get('input')?.({ text, source }, ctx),
     settle: () => handlers.get('agent_settled')?.({}, {}),
+    start: () => handlers.get('session_start')?.({}, {}),
     setThinkingLevel,
     getThinkingLevel,
     level: () => level,
@@ -147,6 +148,21 @@ describe('thinking extension', () => {
     t.setThinkingLevel.mockClear()
     t.settle()
     expect(t.setThinkingLevel).not.toHaveBeenCalled()
+  })
+
+  it('drops a pending escalation on session_start so it never restores into the next session', () => {
+    // One extension instance serves every session. A mid-turn /new fires session_start on
+    // the same instance while an escalation is still pending; that stale restore must be
+    // dropped, not fired into the next session (whose level the new session owns), and
+    // session_start itself must not call setThinkingLevel.
+    const t = wire('low')
+    t.input('please ultrathink') // low -> max
+    expect(t.level()).toBe('max')
+    t.setThinkingLevel.mockClear()
+    t.start()
+    expect(t.setThinkingLevel).not.toHaveBeenCalled() // the reset does not fire a restore
+    t.settle()
+    expect(t.setThinkingLevel).not.toHaveBeenCalled() // the pending escalation was dropped
   })
 
   it('reads the prior level from ctx.thinkingLevel when getThinkingLevel is absent', () => {


### PR DESCRIPTION
## Summary

Fixes the multi-session lifecycle gaps and upstream drift a four-analyst codebase review surfaced, and tightens the packaging posture; the suite is green at 1734 tests with a clean npm audit.

Quitting pi now terminates live background subagent runs instead of letting detached children keep spending tokens unattended, and a session switch warns that runs are still active. The MCP maps reset per session, so the second in-process session's banner and /mcp report real tool counts instead of zero, and a closed client can no longer be skipped as a lingering duplicate on reconnect. Per-turn state that survived a mid-turn /new (thinking escalations, command scoping and model/effort restores, the Stop-hook streak, a pending checkpoint snapshot) resets on session start.

Tracking the 0.84 runtime: blocked tool calls set the 0.84.1 terminate flag so pi skips the pointless follow-up model call after an all-blocked batch; plan mode's record-only sends are pinned against the 0.84.2 triggerTurn semantics change; and the redundant window-title call is gone now that pi refreshes it natively. Dependencies move to ^0.84.2 so types and tests validate against what users actually run, the MCP SDK floor matches what the code imports (clearing four stale transitive advisories), the pi peers declare the 0.79.1 floor the runtime guard enforces, and the README states the supported runtimes.