### PR TITLE
Release 1.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-code",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-code",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-code",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, and subagents",
   "keywords": [
     "pi",


### PR DESCRIPTION
Version bump to 1.0.13. Multi-session lifecycle fixes, 0.84 runtime tracking, and dependency hygiene.