### PR TITLE
Release 1.0.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-code",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-code",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-code",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, and subagents",
   "keywords": [
     "pi",


### PR DESCRIPTION
Version bump to 1.0.16. Docs-conformance batch: allowed-tools space parsing, typed MCP allow/deny policy with scope merge, STOP_HOOK_BLOCK_CAP=0, divergence-note corrections.