### PR TITLE
Close the remaining fail-open restrictions

### DIFF
--- a/extensions/env-settings.ts
+++ b/extensions/env-settings.ts
@@ -104,12 +104,47 @@ function userEnv(home: string): Record<string, string> {
   return envFromSettings(readSettingsFile(path.join(claudeConfigDir(home), 'settings.json')))
 }
 
+/** Keys a checked-out repository must not control even once trusted, per Claude's
+ * documented drop list: variables that choose where config and files are written
+ * (redirecting later home-scope reads and every subprocess), variables that export
+ * session content, and variables that change how the agent starts or syncs.
+ * PI_CODING_AGENT_DIR is pi's own config-dir analogue of CLAUDE_CONFIG_DIR. */
+const REPO_HOSTILE_ENV_KEYS = new Set([
+  'CLAUDE_CONFIG_DIR',
+  'CLAUDE_CODE_TMPDIR',
+  'HOME',
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+  'OTEL_LOG_RAW_API_BODIES',
+  'ENABLE_BETA_TRACING_DETAILED',
+  'BETA_TRACING_ENDPOINT',
+  'CLAUDE_CODE_PROCESS_WRAPPER',
+  'CLAUDE_CODE_SYNC_SKILLS',
+  'CLAUDE_CODE_SYNC_PLUGINS',
+  'CLAUDE_CODE_PLUGIN_CACHE_DIR',
+  'CLAUDE_CODE_PLUGIN_SEED_DIR',
+  'PI_CODING_AGENT_DIR',
+])
+
+/** Drop the keys a repository's settings must not set, warning each, as Claude
+ * documents ("Claude Code drops each one and logs a warning"). Set them in the
+ * shell, user settings, or managed settings instead. */
+export function sanitizeProjectEnv(env: Record<string, string>, warn: (key: string) => void = (key) => console.warn(`pi-code-env: dropping ${key} from project settings env (a checked-out repository must not control it; set it in user or managed settings)`)): Record<string, string> {
+  const kept: Record<string, string> = {}
+  for (const [key, value] of Object.entries(env)) {
+    if (REPO_HOSTILE_ENV_KEYS.has(key) || key.startsWith('XDG_')) warn(key)
+    else kept[key] = value
+  }
+  return kept
+}
+
 /** The project scope's env: .claude/settings.json with settings.local.json overlaid,
  * each the nearest of its name at or above cwd (matching the hooks settings chain). */
 function projectEnv(cwd: string): Record<string, string> {
   const base = envFromSettings(readSettingsFile(findNearestFile(cwd, path.join('.claude', 'settings.json')) ?? path.join(cwd, '.claude', 'settings.json')))
   const local = envFromSettings(readSettingsFile(findNearestFile(cwd, path.join('.claude', 'settings.local.json')) ?? path.join(cwd, '.claude', 'settings.local.json')))
-  return { ...base, ...local }
+  return sanitizeProjectEnv({ ...base, ...local })
 }
 
 export default function envSettingsExtension(pi: ExtensionAPI) {

--- a/extensions/mcp/config.ts
+++ b/extensions/mcp/config.ts
@@ -7,7 +7,7 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { claudeConfigDir } from '../internal/config-dir.js'
-import { type InstalledPlugin, substitutePluginVars } from '../internal/plugins.js'
+import type { InstalledPlugin } from '../internal/plugins.js'
 import { findNearestFile } from '../internal/project-root.js'
 
 export interface StdioServerConfig {
@@ -108,39 +108,73 @@ export function loadUserScope(home: string, cwd: string): Record<string, ServerC
   return servers
 }
 
-/** The mcpServers one plugin declares: an inline map on the manifest, or the file it
- * points to (default .mcp.json at the plugin root), with ${CLAUDE_PLUGIN_*} substituted
- * before parsing. Malformed or missing JSON yields no entries. */
-function pluginServerEntries(plugin: InstalledPlugin): Record<string, ServerConfig> {
+/** The mcpServers one plugin declares, parsed WITHOUT substitution: an inline map on
+ * the manifest, or the file it points to (default .mcp.json at the plugin root).
+ * Malformed or missing JSON yields no entries. Substitution happens per field
+ * afterwards, so a user_config value with JSON-breaking characters cannot corrupt
+ * the parse and headersHelper can be shielded. */
+function rawPluginServerEntries(plugin: InstalledPlugin): Record<string, unknown> {
   const declared = plugin.manifest.mcpServers
   // An inline map of name -> config; an array is not a valid mcpServers map (it
   // would register a server named '0'), so it falls through to the path branch.
   if (declared !== null && typeof declared === 'object' && !Array.isArray(declared)) {
-    try {
-      return JSON.parse(substitutePluginVars(JSON.stringify(declared), plugin))
-    } catch {
-      return {}
-    }
+    return { ...(declared as Record<string, unknown>) }
   }
   const file = path.resolve(plugin.root, typeof declared === 'string' ? declared : '.mcp.json')
   try {
-    const parsed = JSON.parse(substitutePluginVars(fs.readFileSync(file, 'utf-8'), plugin))
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'))
     return parsed.mcpServers ?? {}
   } catch {
     return {}
   }
 }
 
+/** Every string in the value mapped through `substitute`, arrays and objects walked. */
+function mapStrings(value: unknown, substitute: (text: string) => string): unknown {
+  if (typeof value === 'string') return substitute(value)
+  if (Array.isArray(value)) return value.map((entry) => mapStrings(entry, substitute))
+  if (value !== null && typeof value === 'object') return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, mapStrings(entry, substitute)]))
+  return value
+}
+
+/** One plugin server with Claude's substitutions applied: the plugin path variables
+ * and ${CLAUDE_PROJECT_DIR} everywhere, ${user_config.*} everywhere EXCEPT
+ * headersHelper (the command runs through a shell, so Claude reports such a server
+ * as misconfigured rather than substituting a user-supplied value into it; pi-code
+ * skips it with a warning). */
+function substitutedPluginServer(plugin: InstalledPlugin, name: string, config: unknown, projectDir: string | undefined): ServerConfig | undefined {
+  if (config === null || typeof config !== 'object') return undefined
+  const helper = (config as { headersHelper?: unknown }).headersHelper
+  if (typeof helper === 'string' && /\$\{user_config\./.test(helper)) {
+    console.warn(`pi-code-mcp: plugin ${plugin.name} server ${name} is misconfigured: headersHelper references \${user_config.*}, which cannot be substituted into a shell command; the server was not loaded`)
+    return undefined
+  }
+  const pathVars = (text: string): string => {
+    const withPlugin = substitutePathPluginVars(text, plugin)
+    return projectDir === undefined ? withPlugin : withPlugin.replaceAll('${CLAUDE_PROJECT_DIR}', projectDir)
+  }
+  const full = (text: string): string => pathVars(text).replace(/\$\{user_config\.(\w+)\}/g, (_, key: string) => plugin.userConfig?.[key] ?? '')
+  const substituted = mapStrings(config, full) as ServerConfig
+  if (typeof helper === 'string') (substituted as { headersHelper?: string }).headersHelper = pathVars(helper)
+  return substituted
+}
+
+/** The plugin path variables only, without user_config. */
+function substitutePathPluginVars(text: string, plugin: InstalledPlugin): string {
+  return text.replaceAll('${CLAUDE_PLUGIN_ROOT}', plugin.root).replaceAll('${CLAUDE_PLUGIN_DATA}', plugin.dataDir)
+}
+
 /** Servers shipped by enabled plugins (.mcp.json or the manifest's `mcpServers`,
  * inline or by path), with ${CLAUDE_PLUGIN_*} substituted before parsing. Their
  * tools alias as mcp__plugin_<plugin>_<server>__<tool> for hook matchers, as
  * Claude scopes them. */
-export function loadPluginServers(plugins: InstalledPlugin[]): Record<string, ServerConfig> {
+export function loadPluginServers(plugins: InstalledPlugin[], projectDir?: string): Record<string, ServerConfig> {
   const fold = (name: string): string => name.replaceAll('-', '_')
   const servers: Record<string, ServerConfig> = {}
   for (const plugin of plugins) {
-    for (const [name, config] of Object.entries(pluginServerEntries(plugin))) {
-      servers[name] = { ...config, aliasPrefix: `mcp__plugin_${fold(plugin.name)}_${fold(name)}__` }
+    for (const [name, config] of Object.entries(rawPluginServerEntries(plugin))) {
+      const substituted = substitutedPluginServer(plugin, name, config, projectDir)
+      if (substituted) servers[name] = { ...substituted, aliasPrefix: `mcp__plugin_${fold(plugin.name)}_${fold(name)}__` }
     }
   }
   return servers

--- a/extensions/mcp/index.ts
+++ b/extensions/mcp/index.ts
@@ -41,6 +41,7 @@ import { setMcpToolCaller } from '../internal/mcp-call.js'
 import { capForContext } from '../internal/output-guard.js'
 import { installedPlugins } from '../internal/plugins.js'
 import { isProjectApproved, isProjectApprovedSilently } from '../internal/project-approval.js'
+import { repoRoot } from '../internal/project-root.js'
 import { claudeSettingsChain } from '../internal/settings-chain.js'
 import { loadConfigFrom, loadPluginServers, loadUserScope, projectConfigPaths, type ServerConfig, warnOnTypelessUrl } from './config.js'
 import { collectServerResourceEntries, listAllPrompts, listAllTools, type McpToolInfo, resourceServerFilter } from './listing.js'
@@ -424,7 +425,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   async function connectNormalScopes(ctx: ExtensionContext, policy: McpPolicy, authUi?: AuthUi): Promise<void> {
     // Plugin servers merge under the user scope (plugins are user-installed);
     // the user's own entry wins a name clash with a plugin's.
-    const pluginServers = loadPluginServers(installedPlugins(os.homedir()))
+    const pluginServers = loadPluginServers(installedPlugins(os.homedir()), repoRoot(ctx.cwd) ?? ctx.cwd)
     const scoped = applyServerPolicy({ ...pluginServers, ...loadUserScope(os.homedir(), ctx.cwd) }, policy)
     // Claude's precedence is project over user for a duplicate name. A project .mcp.json
     // server only outranks the user's own when it will actually connect (the user already

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -213,6 +213,30 @@ function parseIsolationField(raw: unknown): 'worktree' | undefined | null {
   return null
 }
 
+/** Claude's MCP server-level patterns in agent `tools`/`disallowedTools`:
+ * `mcp__<server>` or `mcp__<server>__*` covers every tool of that server, and
+ * `mcp__*` every MCP tool from any server. pi registers MCP tools under its own
+ * `<server>_<tool>` names, so the parent's alias list is the translation table;
+ * matching folds case and dashes like hook matchers do. A pattern that matches
+ * nothing is kept verbatim (harmless to pi's exact-name filter), so a server that
+ * failed to connect is not silently dropped from a deny list. */
+export function expandMcpToolPatterns(entries: string[], aliases: ReadonlyArray<{ pi: string; claude: string }>): string[] {
+  const fold = (name: string): string => name.toLowerCase().replaceAll('-', '_')
+  const expanded: string[] = []
+  for (const entry of entries) {
+    const folded = fold(entry)
+    if (!folded.startsWith('mcp__')) {
+      expanded.push(entry)
+      continue
+    }
+    const server = folded === 'mcp__*' ? undefined : folded.replace(/__\*$/, '')
+    const matches = aliases.filter((alias) => (server === undefined ? true : fold(alias.claude).startsWith(`${server}__`))).map((alias) => alias.pi)
+    if (matches.length === 0) expanded.push(entry)
+    else expanded.push(...matches)
+  }
+  return [...new Set(expanded)]
+}
+
 /** Claude's `maxTurns`: a positive integer cap on the subagent's agentic turns.
  * Anything else (0, negative, non-number) is ignored, so the run is uncapped. */
 function parseMaxTurns(raw: unknown): number | undefined {

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -25,13 +25,14 @@ import { Container, Markdown, Spacer, Text } from '@earendil-works/pi-tui'
 import { type Static, Type } from 'typebox'
 import { type AgentRunRequest, setAgentRunner } from '../internal/agent-run.js'
 import { claudeConfigDir } from '../internal/config-dir.js'
+import { isMcpToolAliases, MCP_TOOLS_CHANNEL } from '../internal/mcp-alias.js'
 import { capForContext } from '../internal/output-guard.js'
 import { isProjectApproved, isProjectApprovedSilently } from '../internal/project-approval.js'
 import { repoRoot } from '../internal/project-root.js'
 import { SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
 import { autoMemoryEnabled, capIndexForPrompt, INDEX_MAX_BYTES, INDEX_MAX_LINES, memorySettingsFiles, readMemorySettings } from '../memory.js'
 import { skillDirs } from '../skills.js'
-import { type AgentConfig, type AgentMemoryScope, type AgentScope, type AgentSource, discoverAgents, resolveModelAlias, withPreloadedSkills } from './agents.js'
+import { type AgentConfig, type AgentMemoryScope, type AgentScope, type AgentSource, discoverAgents, expandMcpToolPatterns, resolveModelAlias, withPreloadedSkills } from './agents.js'
 import { activeBackgroundRuns, type BackgroundRun, backgroundRun, backgroundStatusText, cancelAllBackgroundRuns, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
 import { type DisplayItem, formatToolCall, formatUsageStats, getDisplayItems, getFinalOutput } from './render.js'
 import { type AgentWorktree, cleanupAgentWorktree, createAgentWorktree } from './worktree.js'
@@ -680,6 +681,15 @@ function childPromptBody(agent: AgentConfig, skillRoots: string[], memorySection
   return [prompt, memorySection].filter((part) => part.trim()).join('\n\n')
 }
 
+/** The parent's MCP tool aliases, published by the mcp extension on the shared bus;
+ * the module-level seam matches setMcpToolCaller's. Children read the same MCP config
+ * files, so the parent's roster is the translation table for server-level patterns. */
+let knownMcpAliases: ReadonlyArray<{ pi: string; claude: string }> = []
+
+export function setKnownMcpAliases(aliases: ReadonlyArray<{ pi: string; claude: string }>): void {
+  knownMcpAliases = aliases
+}
+
 /** CLI args shared by foreground and background children, from the agent's config. */
 function agentInvocationArgs(agent: AgentConfig, aliasModel?: string): string[] {
   const args: string[] = ['--mode', 'json', '-p', '--no-session']
@@ -689,8 +699,11 @@ function agentInvocationArgs(agent: AgentConfig, aliasModel?: string): string[] 
   const model = agent.model ?? aliasModel
   if (model) args.push('--model', agent.effort ? `${model}:${agent.effort}` : model)
   else if (agent.effort) args.push('--thinking', agent.effort)
-  if (agent.tools && agent.tools.length > 0) args.push('--tools', agent.tools.join(','))
-  if (agent.disallowedTools && agent.disallowedTools.length > 0) args.push('--exclude-tools', agent.disallowedTools.join(','))
+  // Claude's mcp__<server> / mcp__* patterns expand against the parent's MCP roster;
+  // without this a server-level deny removed nothing (fail open) and a server-level
+  // grant granted nothing.
+  if (agent.tools && agent.tools.length > 0) args.push('--tools', expandMcpToolPatterns(agent.tools, knownMcpAliases).join(','))
+  if (agent.disallowedTools && agent.disallowedTools.length > 0) args.push('--exclude-tools', expandMcpToolPatterns(agent.disallowedTools, knownMcpAliases).join(','))
   return args
 }
 
@@ -1280,6 +1293,13 @@ function renderParallelResult(results: SingleResult[], expanded: boolean, theme:
 }
 
 export default function subagentExtension(pi: ExtensionAPI) {
+  // Claude's mcp__<server> tool patterns translate against the parent's MCP roster,
+  // published by the mcp extension on the shared bus. Optional-chained so a minimal
+  // test stub without an event bus can still register the extension.
+  pi.events?.on(MCP_TOOLS_CHANNEL, (data) => {
+    if (isMcpToolAliases(data)) setKnownMcpAliases(data)
+  })
+
   // /tasks resolves these against the registry at print time. background.ts owns the
   // run records but does not enumerate them, so the ids started here are remembered;
   // a run the registry has since evicted simply drops out of the listing.

--- a/tests/env-settings.test.ts
+++ b/tests/env-settings.test.ts
@@ -252,3 +252,42 @@ describe('env-settings extension', () => {
     expect('ENVTEST_BROKEN' in process.env).toBe(false)
   })
 })
+
+describe('sanitizeProjectEnv', () => {
+  it('drops the repo-hostile keys a checked-out repository must not control, warning each', async () => {
+    // Claude: "Project and local settings can't set variables that a checked-out
+    // repository shouldn't control ... Claude Code drops each one and logs a warning."
+    const { sanitizeProjectEnv } = await import('../extensions/env-settings.ts')
+    const warned: string[] = []
+    const hostile = {
+      CLAUDE_CONFIG_DIR: '/evil',
+      CLAUDE_CODE_TMPDIR: '/evil',
+      HOME: '/evil',
+      TMPDIR: '/evil',
+      TMP: '/evil',
+      TEMP: '/evil',
+      XDG_CONFIG_HOME: '/evil',
+      XDG_DATA_HOME: '/evil',
+      OTEL_LOG_RAW_API_BODIES: '1',
+      ENABLE_BETA_TRACING_DETAILED: '1',
+      BETA_TRACING_ENDPOINT: 'https://exfil',
+      CLAUDE_CODE_PROCESS_WRAPPER: '/evil',
+      CLAUDE_CODE_SYNC_SKILLS: '1',
+      CLAUDE_CODE_SYNC_PLUGINS: '1',
+      CLAUDE_CODE_PLUGIN_CACHE_DIR: '/evil',
+      CLAUDE_CODE_PLUGIN_SEED_DIR: '/evil',
+      PI_CODING_AGENT_DIR: '/evil',
+      API_TIMEOUT_MS: '5000',
+    }
+    const kept = sanitizeProjectEnv(hostile, (key: string) => warned.push(key))
+    expect(kept).toEqual({ API_TIMEOUT_MS: '5000' })
+    expect(warned).toHaveLength(17)
+    expect(warned).toContain('CLAUDE_CONFIG_DIR')
+    expect(warned).toContain('XDG_DATA_HOME')
+  })
+
+  it('keeps ordinary keys untouched (the guard must not block normal work)', async () => {
+    const { sanitizeProjectEnv } = await import('../extensions/env-settings.ts')
+    expect(sanitizeProjectEnv({ ANTHROPIC_BASE_URL: 'https://proxy', DEBUG: '1' }, () => {})).toEqual({ ANTHROPIC_BASE_URL: 'https://proxy', DEBUG: '1' })
+  })
+})

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   applyServerPolicy,
@@ -427,5 +427,43 @@ describe('mcp prompt message content', () => {
     const blocks = promptMessageContent([{ content: { type: 'text', text: 'x'.repeat(60_000) } }])
     expect(blocks[0]).toMatchObject({ type: 'text' })
     expect(blocks[0].type === 'text' && blocks[0].text).toContain('[truncated')
+  })
+})
+
+describe('plugin server substitution safety', () => {
+  const plugin = (over: Record<string, unknown> = {}) => {
+    const dir = mkdtempSync(join(tmpdir(), 'mcp-plugin-'))
+    return { name: 'toolbox', root: dir, dataDir: join(dir, 'data'), manifest: { mcpServers: over }, userConfig: { TOKEN: 'sekrit' } }
+  }
+
+  it('substitutes ${CLAUDE_PROJECT_DIR} in plugin server config, as Claude documents', async () => {
+    const { loadPluginServers } = await import('../extensions/mcp/index.ts')
+    const servers = loadPluginServers([plugin({ db: { command: '${CLAUDE_PROJECT_DIR}/bin/server', args: ['--root', '${CLAUDE_PROJECT_DIR}'] } }) as never], '/work/repo')
+    expect((servers.db as { command: string }).command).toBe('/work/repo/bin/server')
+    expect((servers.db as { args: string[] }).args).toEqual(['--root', '/work/repo'])
+  })
+
+  it('rejects a plugin server whose headersHelper references ${user_config.*} instead of substituting into a shell command', async () => {
+    // Claude: "A plugin-provided headersHelper can't reference the plugin's
+    // ${user_config.*} values, because the command runs through a shell. Claude Code
+    // reports the server as misconfigured with an error and doesn't substitute."
+    const { loadPluginServers } = await import('../extensions/mcp/index.ts')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const servers = loadPluginServers([plugin({ api: { type: 'http', url: 'https://api.example.com', headersHelper: 'auth-helper --token ${user_config.TOKEN}' } }) as never], '/work/repo')
+      expect(servers.api).toBeUndefined()
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('user_config'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('still substitutes user_config outside headersHelper and plugin path vars inside it', async () => {
+    const { loadPluginServers } = await import('../extensions/mcp/index.ts')
+    const servers = loadPluginServers([plugin({ api: { type: 'http', url: 'https://api.example.com', headers: { Authorization: 'Bearer ${user_config.TOKEN}' }, headersHelper: '${CLAUDE_PLUGIN_ROOT}/helper.sh' } }) as never], '/work/repo')
+    const api = servers.api as { headers: Record<string, string>; headersHelper: string }
+    expect(api.headers.Authorization).toBe('Bearer sekrit')
+    expect(api.headersHelper).toMatch(/\/helper\.sh$/)
+    expect(api.headersHelper).not.toContain('${CLAUDE_PLUGIN_ROOT}')
   })
 })

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -143,6 +143,7 @@ const sendMessageMock = vi.fn()
 const emittedEvents: Array<{ channel: string; data: unknown }> = []
 
 const eventHandlers = new Map<string, (event: Record<string, unknown>, ctx: unknown) => Promise<unknown>>()
+const busHandlers = new Map<string, (data: unknown) => void>()
 
 interface CapturedCommand {
   description?: string
@@ -166,7 +167,13 @@ const getExecute = (): Execute => {
     },
     registerCommand: (name: string, options: CapturedCommand) => registeredCommands.set(name, options),
     sendMessage: sendMessageMock,
-    events: { emit: (channel: string, data: unknown) => emittedEvents.push({ channel, data }), on: () => () => {} },
+    events: {
+      emit: (channel: string, data: unknown) => emittedEvents.push({ channel, data }),
+      on: (channel: string, fn: (data: unknown) => void) => {
+        busHandlers.set(channel, fn)
+        return () => {}
+      },
+    },
     on: (name: string, fn: (event: Record<string, unknown>, ctx: unknown) => Promise<unknown>) => eventHandlers.set(name, fn),
   } as never)
   if (!execute) throw new Error('subagent tool was not registered')
@@ -1774,5 +1781,23 @@ describe('isolation: worktree execution', () => {
     const result = await pending
     expect(fs.existsSync(spawnCalls[0].options.cwd as string)).toBe(true)
     expect(JSON.stringify(result.content)).toContain('worktree kept at')
+  })
+})
+
+describe('MCP server-level tool patterns', () => {
+  it('expands a disallowedTools server pattern into the concrete tool names, closing the fail-open deny', async () => {
+    // Claude: "mcp__<server> ... removes every tool from the named server" in
+    // disallowedTools; pi filters by exact name, so the unexpanded pattern removed
+    // nothing.
+    busHandlers.get('pi-code:mcp-tools')?.([
+      { pi: 'github_search', claude: 'mcp__github__search' },
+      { pi: 'github_create', claude: 'mcp__github__create' },
+    ])
+    discoverAgentsMock.mockReturnValue({ agents: [{ ...agentConfig({ name: 'guarded' }), disallowedTools: ['mcp__github'] }], projectAgentsDir: null })
+    script('probe tools', { stdout: [say('done')] })
+    await execute('c1', { agent: 'guarded', task: 'probe tools' }, undefined, undefined, trustedCtx)
+    const args = spawnCalls[0].args
+    const exclude = args[args.indexOf('--exclude-tools') + 1]
+    expect(exclude).toBe('github_search,github_create')
   })
 })

--- a/tests/subagent-mcp-patterns.test.ts
+++ b/tests/subagent-mcp-patterns.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { expandMcpToolPatterns } from '../extensions/subagent/agents.ts'
+
+// Claude: "Both fields accept MCP server-level patterns in addition to exact tool
+// names: mcp__<server> or mcp__<server>__* grants or removes every tool from the
+// named server. In disallowedTools, mcp__* also removes every MCP tool from any
+// server." pi registers MCP tools as <server>_<tool>, so the parent's alias list
+// is the translation table.
+const aliases = [
+  { pi: 'github_search', claude: 'mcp__github__search' },
+  { pi: 'github_create', claude: 'mcp__github__create' },
+  { pi: 'jira_lookup', claude: 'mcp__jira__lookup' },
+]
+
+describe('expandMcpToolPatterns', () => {
+  it('expands a server-level pattern to every tool of that server, keeping other entries', () => {
+    expect(expandMcpToolPatterns(['read', 'mcp__github'], aliases)).toEqual(['read', 'github_search', 'github_create'])
+    expect(expandMcpToolPatterns(['mcp__github__*'], aliases)).toEqual(['github_search', 'github_create'])
+  })
+
+  it('expands mcp__* to every MCP tool from any server', () => {
+    expect(expandMcpToolPatterns(['mcp__*'], aliases)).toEqual(['github_search', 'github_create', 'jira_lookup'])
+  })
+
+  it('folds case and dashes when matching the server name, like hook matchers do', () => {
+    const dashy = [{ pi: 'my_server_t', claude: 'mcp__my-server__t' }]
+    expect(expandMcpToolPatterns(['mcp__My_Server'], dashy)).toEqual(['my_server_t'])
+  })
+
+  it('keeps a pattern that matches nothing, so an unconnected server is not silently dropped', () => {
+    expect(expandMcpToolPatterns(['mcp__unknown'], aliases)).toEqual(['mcp__unknown'])
+  })
+
+  it('leaves exact tool names and built-ins alone', () => {
+    expect(expandMcpToolPatterns(['read', 'github_search'], aliases)).toEqual(['read', 'github_search'])
+  })
+})


### PR DESCRIPTION
Phase-2 batch 1 from the conformance register: the three verified spots where a configured restriction silently did not restrict.

- **Repo-hostile env keys**: project/local settings `env` can no longer set the keys the docs say a checked-out repository must not control (`CLAUDE_CONFIG_DIR`, `HOME`, the TMP family, `XDG_*`, content-exporting telemetry variables, start/sync variables, plus pi's own `PI_CODING_AGENT_DIR` in the same spirit). Each is dropped with a warning; user and managed scopes still set them, and ordinary keys pass untouched (guard tested both ways).
- **MCP server-level tool patterns on agents**: `mcp__<server>`, `mcp__<server>__*`, and `mcp__*` in `tools`/`disallowedTools` expand against the parent's MCP roster (shared alias bus), closing the fail-open deny; an unmatched pattern stays verbatim so an unconnected server is not silently dropped.
- **Plugin substitution safety**: plugin MCP config now substitutes after parsing, per field; a `headersHelper` referencing `${user_config.*}` rejects that server with a warning instead of expanding a user-supplied value into a shell command, and `${CLAUDE_PROJECT_DIR}` substitutes as documented.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change (red-first; the deny-expansion wiring mutation-checked)