### PR TITLE
Follow Claude's env precedence and let settings replace shell exports

### DIFF
--- a/docs/settings-env.md
+++ b/docs/settings-env.md
@@ -2,7 +2,6 @@
 
 Exports `env` blocks from settings into the session. Source: [`extensions/env-settings.ts`](../extensions/env-settings.ts).
 
-- Reads `managed-settings.json`, `~/.claude/settings.json`, and the project `.claude/settings.json`/`settings.local.json`, per-key `managed > user > project`.
-- The project scope is approval-gated (a repo's env can redirect providers).
-- A shell `export` outranks user and project values, but a managed key overrides even that.
-- A key an approved project set is unset once a later session no longer defines it.
+- Reads `managed-settings.json`, `~/.claude/settings.json`, and the project `.claude/settings.json`/`settings.local.json`, per-key with Claude's settings precedence: managed > project (with `settings.local.json` overlaying `settings.json`) > user.
+- A settings value replaces a value inherited from the shell, as Claude documents, and an empty string is the documented override for an export that cannot be unset; when a later session no longer defines a key, the shell's original value is restored.
+- The project scope is approval-gated (a repo's env can redirect providers), and the keys a checked-out repository must not control (`CLAUDE_CONFIG_DIR`, `HOME`, the TMP family, `XDG_*`, content-exporting telemetry variables, start/sync variables, and pi's own `PI_CODING_AGENT_DIR`) are dropped from project and local settings with a warning; set those in the shell, user settings, or managed settings instead.

--- a/extensions/env-settings.ts
+++ b/extensions/env-settings.ts
@@ -13,19 +13,21 @@
  * approval-gated on purpose: a checked-out repository's env can redirect providers
  * (ANTHROPIC_BASE_URL and friends), so an untrusted repo must not reach process.env.
  *
- * Precedence is per key, managed > user > project, matching Claude's merge: a scope
- * only supplies keys it names and never wipes another scope's keys. Values must be
- * strings; a number or boolean is coerced via String, anything else is skipped.
+ * Precedence is per key, managed > project (settings.local.json overlaying
+ * settings.json inside the project scope) > user, matching Claude's settings
+ * precedence: a scope only supplies keys it names and never wipes another scope's
+ * keys. Values must be strings; a number or boolean is coerced via String,
+ * anything else is skipped.
  *
- * A variable already present in the real environment that this module did not set is
- * left untouched for the user and project scopes: a shell `export` outranks them. The
- * managed scope is the exception: an org policy env must win over an ambient export, so
- * a managed key overwrites a preexisting shell value. The keys this module sets are
- * recorded so a later refresh can update them without clobbering unrelated env, and a
- * key an earlier apply set that the current merge no longer defines is unset (deleted
- * from process.env), so an approved project's env cannot leak into a later session or
- * project that does not define it. A managed overwrite of a shell var is owned like any
- * other set key; its original shell value cannot be restored, so on unset it is deleted.
+ * A settings value replaces a value inherited from the shell, as Claude documents
+ * ("Claude Code writes each env entry into the process environment, replacing the
+ * value inherited from the shell"), and an empty string is the documented way to
+ * override an export that cannot be unset. The original value of each key is
+ * recorded so a later apply that no longer defines the key restores the shell's
+ * value (or deletes a key the shell never had), so an approved project's env
+ * cannot leak into a later session or project that does not define it. The keys a
+ * repository must not control are dropped from the project scope before any of
+ * this (see sanitizeProjectEnv).
  *
  * Docs: https://code.claude.com/docs/en/settings.md
  */
@@ -57,35 +59,31 @@ export function envFromSettings(settings: unknown): Record<string, string> {
   return out
 }
 
-/** Merge the three env scopes with Claude's per-key precedence managed > user >
- * project: lower scopes are laid down first and higher ones overlay, so each key
- * takes its highest-precedence value and no scope wipes another's keys. */
+/** Merge the three env scopes with Claude's per-key settings precedence managed >
+ * project > user: lower scopes are laid down first and higher ones overlay, so each
+ * key takes its highest-precedence value and no scope wipes another's keys. */
 export function mergeEnvScopes(managed: Record<string, string>, user: Record<string, string>, project: Record<string, string>): Record<string, string> {
-  return { ...project, ...user, ...managed }
+  return { ...user, ...project, ...managed }
 }
 
-/** Assign the merged env into `env`, recording each key set into `owned`. A key already
- * present that this module did not set (a shell export) is left untouched for user and
- * project keys; a `managedKeys` entry overwrites it (an org policy outranks the shell).
- * A key this module set before is updated. A previously-owned key that the current
- * `merged` no longer defines is unset (deleted from `env` and `owned`), so an approved
- * project's env cannot leak into a later apply that does not define it. */
-export function applyEnvSettings(merged: Record<string, string>, env: NodeJS.ProcessEnv, owned: Set<string>, managedKeys: ReadonlySet<string> = new Set()): void {
-  // Unset any key an earlier apply set that the current merge dropped. Iterate a copy
-  // since `owned` is mutated. A shell export this module never owned is left in place.
-  for (const key of Array.from(owned)) {
-    if (!(key in merged)) {
-      delete env[key]
-      owned.delete(key)
-    }
+/** Assign the merged env into `env`. Every settings value applies, replacing a
+ * shell-inherited value, as Claude documents; an empty string is the documented
+ * override for an export that cannot be unset. `owned` records each key's original
+ * value at first ownership, so a later apply that drops the key restores the
+ * shell's value (or deletes a key the shell never had) rather than leaking a stale
+ * setting into the rest of the process. */
+export function applyEnvSettings(merged: Record<string, string>, env: NodeJS.ProcessEnv, owned: Map<string, string | undefined>): void {
+  // Restore any key an earlier apply set that the current merge dropped. Iterate a
+  // copy since `owned` is mutated.
+  for (const [key, original] of Array.from(owned.entries())) {
+    if (key in merged) continue
+    if (original === undefined) delete env[key]
+    else env[key] = original
+    owned.delete(key)
   }
   for (const [key, value] of Object.entries(merged)) {
-    // A shell export outranks user/project (skip), but a managed key outranks even the
-    // shell. Once owned, updates always apply. A managed overwrite is owned like any
-    // set key: its shell value is gone and cannot be restored, so on unset it is deleted.
-    if (key in env && !owned.has(key) && !managedKeys.has(key)) continue
+    if (!owned.has(key)) owned.set(key, env[key])
     env[key] = value
-    owned.add(key)
   }
 }
 
@@ -148,11 +146,10 @@ function projectEnv(cwd: string): Record<string, string> {
 }
 
 export default function envSettingsExtension(pi: ExtensionAPI) {
-  const owned = new Set<string>()
+  const owned = new Map<string, string | undefined>()
 
   const apply = (home: string, project: Record<string, string>): void => {
-    const managed = envFromSettings(readManagedSettings())
-    applyEnvSettings(mergeEnvScopes(managed, userEnv(home), project), process.env, owned, new Set(Object.keys(managed)))
+    applyEnvSettings(mergeEnvScopes(envFromSettings(readManagedSettings()), userEnv(home), project), process.env, owned)
   }
 
   // Factory time: managed + user only. Approval needs the session ctx, so the project

--- a/tests/env-settings.test.ts
+++ b/tests/env-settings.test.ts
@@ -41,70 +41,62 @@ describe('envFromSettings', () => {
 })
 
 describe('mergeEnvScopes', () => {
-  it('merges per key with precedence managed > user > project without wiping other scopes', () => {
-    const merged = mergeEnvScopes({ A: 'm', C: 'mc' }, { A: 'u', B: 'ub' }, { A: 'p', D: 'pd' })
-    expect(merged).toEqual({ A: 'm', B: 'ub', C: 'mc', D: 'pd' })
+  it('merges per key with the documented precedence managed > project > user, without wiping other scopes', () => {
+    // Claude: "env values follow settings precedence" - managed > local > shared
+    // project > user (local overlays project inside projectEnv before this merge).
+    const merged = mergeEnvScopes({ A: 'm', C: 'mc' }, { A: 'u', B: 'ub', E: 'ue' }, { A: 'p', D: 'pd', E: 'pe' })
+    expect(merged).toEqual({ A: 'm', B: 'ub', C: 'mc', D: 'pd', E: 'pe' })
   })
 })
 
 describe('applyEnvSettings', () => {
   it('sets new keys and records them as owned', () => {
     const env: NodeJS.ProcessEnv = {}
-    const owned = new Set<string>()
+    const owned = new Map<string, string | undefined>()
     applyEnvSettings({ A: '1' }, env, owned)
     expect(env.A).toBe('1')
     expect(owned.has('A')).toBe(true)
   })
 
-  it('never overwrites a variable already in the real environment it did not set', () => {
+  it('replaces a shell-inherited value, as Claude documents, and restores it when the key is dropped', () => {
+    // Claude: "When the same variable is set in both your shell and a settings file
+    // env block, the settings file value applies. Claude Code writes each env entry
+    // into the process environment, replacing the value inherited from the shell."
     const env: NodeJS.ProcessEnv = { A: 'shell' }
-    const owned = new Set<string>()
+    const owned = new Map<string, string | undefined>()
     applyEnvSettings({ A: 'settings' }, env, owned)
+    expect(env.A).toBe('settings')
+    applyEnvSettings({}, env, owned)
     expect(env.A).toBe('shell')
-    expect(owned.has('A')).toBe(false)
   })
 
-  it('updates a key it owns on a later refresh', () => {
-    const env: NodeJS.ProcessEnv = {}
-    const owned = new Set<string>()
+  it('honors the documented empty-string override of an export that cannot be unset', () => {
+    // Claude: 'set it to an empty string in the env block: "CLAUDE_CODE_USE_VERTEX": ""'.
+    const env: NodeJS.ProcessEnv = { CLAUDE_CODE_USE_VERTEX: '1' }
+    const owned = new Map<string, string | undefined>()
+    applyEnvSettings({ CLAUDE_CODE_USE_VERTEX: '' }, env, owned)
+    expect(env.CLAUDE_CODE_USE_VERTEX).toBe('')
+  })
+
+  it('updates a key it owns on a later refresh without forgetting the original', () => {
+    const env: NodeJS.ProcessEnv = { A: 'shell' }
+    const owned = new Map<string, string | undefined>()
     applyEnvSettings({ A: '1' }, env, owned)
     applyEnvSettings({ A: '2' }, env, owned)
     expect(env.A).toBe('2')
+    applyEnvSettings({}, env, owned)
+    expect(env.A).toBe('shell')
   })
 
   it('unsets a key it owns once a later apply no longer defines it', () => {
     // Cross-project leak guard: a key an approved project set must not persist into a
     // later apply (session or project) that does not define it.
     const env: NodeJS.ProcessEnv = {}
-    const owned = new Set<string>()
+    const owned = new Map<string, string | undefined>()
     applyEnvSettings({ A: '1' }, env, owned)
     applyEnvSettings({}, env, owned)
     expect('A' in env).toBe(false)
     expect(owned.has('A')).toBe(false)
-  })
-
-  it('leaves a key it never owned (a shell export) untouched on unset', () => {
-    // The unset guard only removes keys this module set, never a shell export it skipped.
-    const env: NodeJS.ProcessEnv = { A: 'shell' }
-    const owned = new Set<string>()
-    applyEnvSettings({ A: 'settings' }, env, owned) // skipped: shell outranks
-    applyEnvSettings({}, env, owned)
-    expect(env.A).toBe('shell')
-  })
-
-  it('lets a managed key overwrite a shell export, but a user key does not', () => {
-    // Managed policy outranks even an ambient shell export; user/project do not.
-    const managedEnv: NodeJS.ProcessEnv = { A: 'shell' }
-    const managedOwned = new Set<string>()
-    applyEnvSettings({ A: 'managed' }, managedEnv, managedOwned, new Set(['A']))
-    expect(managedEnv.A).toBe('managed')
-    expect(managedOwned.has('A')).toBe(true)
-
-    const userEnvVar: NodeJS.ProcessEnv = { A: 'shell' }
-    const userOwned = new Set<string>()
-    applyEnvSettings({ A: 'user' }, userEnvVar, userOwned, new Set())
-    expect(userEnvVar.A).toBe('shell')
-    expect(userOwned.has('A')).toBe(false)
   })
 })
 
@@ -194,12 +186,14 @@ describe('env-settings extension', () => {
     expect(process.env.ENVTEST_PROJECT).toBeUndefined()
   })
 
-  it('does not overwrite a variable already in the real environment', async () => {
+  it('replaces a shell export with the settings value, as Claude documents', async () => {
+    // Claude: "the settings file value applies ... replacing the value inherited
+    // from the shell".
     setReal('ENVTEST_REAL', 'from-shell')
     writeSettings(hoisted.home, 'settings.json', { ENVTEST_REAL: 'from-settings' })
 
     setup()
-    expect(process.env.ENVTEST_REAL).toBe('from-shell')
+    expect(process.env.ENVTEST_REAL).toBe('from-settings')
   })
 
   it('applies managed over user per key at factory time', async () => {
@@ -229,7 +223,7 @@ describe('env-settings extension', () => {
     expect(process.env.ENVTEST_PROJECT).toBeUndefined()
   })
 
-  it('lets managed env override a preexisting shell export, but user env does not', async () => {
+  it('lets every settings scope override a preexisting shell export', async () => {
     track('ENVTEST_MANAGED_OVR', 'ENVTEST_USER_OVR')
     setReal('ENVTEST_MANAGED_OVR', 'from-shell')
     setReal('ENVTEST_USER_OVR', 'from-shell')
@@ -237,8 +231,8 @@ describe('env-settings extension', () => {
     writeSettings(hoisted.home, 'settings.json', { ENVTEST_USER_OVR: 'from-user' })
 
     setup()
-    expect(process.env.ENVTEST_MANAGED_OVR).toBe('from-managed') // managed outranks the shell
-    expect(process.env.ENVTEST_USER_OVR).toBe('from-shell') // user does not
+    expect(process.env.ENVTEST_MANAGED_OVR).toBe('from-managed')
+    expect(process.env.ENVTEST_USER_OVR).toBe('from-user')
   })
 
   it('does not throw and applies nothing when the user settings.json is invalid JSON', () => {


### PR DESCRIPTION
Phase-2 batch 2 from the conformance register (B4-1, B4-2): the env scope merge ranked user above project, inverting the documented settings precedence, while the module header claimed parity; and a shell export outranked user/project values where the docs say the settings value applies, which also made the documented `""` override of a stuck export a no-op.

- Merge precedence is now managed > project (local overlaying shared) > user.
- Every settings scope's value replaces a shell-inherited one; ownership records the original value, so a key dropped from settings restores the shell's value rather than leaking the stale setting or deleting an export this module never owned.
- The topic doc and module header now describe the actual contract.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change (six pins rewritten to the documented contract red-first, discriminating user-vs-project key added)