### PR TITLE
Scan every project config directory up to the repository root

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,7 +4,7 @@ Registers `.claude/commands/**/*.md` as slash commands with Claude's command con
 
 ## Naming and arguments
 
-- Subdirectory commands register as `/dir:name` (`frontend/build.md` is `/frontend:build`); current Claude docs name a command by file name alone, so the qualified form is a pi-code divergence.
+- Commands load from every `.claude/commands` between the working directory and the repository root, the nearest winning a name clash. Subdirectory commands register as `/dir:name` (`frontend/build.md` is `/frontend:build`); current Claude docs name a command by file name alone, so the qualified form is a pi-code divergence.
 - `$ARGUMENTS` (with the `ARGUMENTS:` append when unused), 0-based `$ARGUMENTS[N]`/`$N`, named `arguments:` frontmatter.
 - `${CLAUDE_SESSION_ID}`, `${CLAUDE_EFFORT}`, `${CLAUDE_SKILL_DIR}`, `${CLAUDE_PROJECT_DIR}` in bodies and `allowed-tools` rules.
 

--- a/docs/output-styles.md
+++ b/docs/output-styles.md
@@ -2,7 +2,7 @@
 
 Claude output styles with replace semantics. Source: [`extensions/output-styles.ts`](../extensions/output-styles.ts).
 
-- Reads `.claude/output-styles` plus the active `outputStyle` setting, and styles shipped by enabled plugins (manifest `outputStyles`, default `output-styles/`, ranked below the user's and project's own).
+- Reads every `.claude/output-styles` between the working directory and the repository root (the style closest to the working directory winning a name clash) plus the active `outputStyle` setting, and styles shipped by enabled plugins (manifest `outputStyles`, default `output-styles/`, ranked below the user's and project's own).
 - Claude replace semantics with `keep-coding-instructions`.
 - Bundles the Explanatory, Learning, and Proactive built-ins.
 - `/output-style [name]` switches styles.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,7 @@
 
 Bridges `.claude/skills` into pi's skill discovery. Source: [`extensions/skills.ts`](../extensions/skills.ts).
 
-- Project skills are gated on approval; pi's loader reads `name`, `description`, and `disable-model-invocation` (`allowed-tools` is inert in pi's loader, a documented gap).
+- Project skills are gated on approval and load from every `.claude/skills` between the working directory and the repository root (nearest first); pi's loader reads `name`, `description`, and `disable-model-invocation` (`allowed-tools` is inert in pi's loader, a documented gap).
 - Invoking `/skill:name` expands the body through the shared command pipeline, as Claude documents that commands and skills "work the same way": `` !`cmd` `` spans, `@file` references, `$ARGUMENTS`/positional substitution, and `${CLAUDE_*}` variables, with the same shell-execution gate commands use.
 - A skill with malformed frontmatter degrades to pi's plain expansion (raw body) instead of failing the invocation.
 - Plugin skill directories contribute too, though pi's loader names them without the plugin prefix.

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -2,7 +2,7 @@
 
 Claude-style subagents with parallel, chain, and background modes. Source: [`extensions/subagent/`](../extensions/subagent) (see also its [README](../extensions/subagent/README.md)).
 
-- Built-in Explore/Plan/general-purpose agents, plus `~/.claude/agents`, `~/.pi/agent/agents`, and project `.claude/agents`/`.pi/agents` (scanned recursively into subfolders), merged once the project is trusted; project wins a name clash.
+- Built-in Explore/Plan/general-purpose agents, plus `~/.claude/agents`, `~/.pi/agent/agents`, and project `.claude/agents`/`.pi/agents` (scanned recursively into subfolders), merged once the project is trusted; project wins a name clash. Every `.claude/agents` between the working directory and the repository root is scanned, the definition closest to the working directory winning a same-name clash, as Claude documents.
 - Frontmatter: `tools`/`disallowedTools`, `model` (sonnet/opus/haiku/fable tier aliases or a concrete id), `effort`, `skills` preload, `permissionMode: plan`, `maxTurns`, `memory`, `isolation: worktree`.
 - `memory` (`user`/`project`/`local`) gives the child its own persistent store under `.claude/agent-memory[-local]`, injected with Read/Write/Edit enabled, gated on auto memory; the parent conversation's memory is never loaded into a subagent, matching Claude.
 - `isolation: worktree` runs the child in a temporary git worktree branched from the repository's default branch; the worktree is removed when the agent made no changes and reported in the output when kept; a run that cannot get its worktree fails rather than touching the real checkout. Divergence: pi sets the child's working directory but does not police per-command escapes.

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -52,7 +52,7 @@ import { capForContext } from './internal/output-guard.js'
 import { matchesPathRules } from './internal/path-rules.js'
 import { type InstalledPlugin, installedPlugins } from './internal/plugins.js'
 import { isProjectApproved } from './internal/project-approval.js'
-import { ancestorDirs, findNearestDir, repoRoot } from './internal/project-root.js'
+import { ancestorDirs, repoRoot } from './internal/project-root.js'
 import { claudeSettingsChain } from './internal/settings-chain.js'
 import { createTurnOverride } from './internal/turn-override.js'
 

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -52,7 +52,7 @@ import { capForContext } from './internal/output-guard.js'
 import { matchesPathRules } from './internal/path-rules.js'
 import { type InstalledPlugin, installedPlugins } from './internal/plugins.js'
 import { isProjectApproved } from './internal/project-approval.js'
-import { findNearestDir, repoRoot } from './internal/project-root.js'
+import { ancestorDirs, findNearestDir, repoRoot } from './internal/project-root.js'
 import { claudeSettingsChain } from './internal/settings-chain.js'
 import { createTurnOverride } from './internal/turn-override.js'
 
@@ -120,7 +120,10 @@ function isDirectory(target: string): boolean {
  * the approval walk) and is included only for approved projects. */
 export function commandDirs(cwd: string, home: string, trusted: boolean): string[] {
   const candidates = [path.join(claudeConfigDir(home), 'commands')]
-  if (trusted) candidates.push(findNearestDir(cwd, path.join('.claude', 'commands')) ?? path.join(cwd, '.claude', 'commands'))
+  // Claude scans every .claude/commands between cwd and the repository root, the
+  // nearest winning a name clash: collectCommands lets later directories win, so
+  // the project list goes root-first with the nearest last.
+  if (trusted) candidates.push(...ancestorDirs(cwd, path.join('.claude', 'commands')).reverse())
   const dirs: string[] = []
   for (const dir of candidates) {
     if (!dirs.includes(dir) && isDirectory(dir)) dirs.push(dir)

--- a/extensions/internal/project-root.ts
+++ b/extensions/internal/project-root.ts
@@ -60,6 +60,24 @@ export function findNearestFile(cwd: string, relative: string): string | null {
   return findNearest(cwd, relative, false)
 }
 
+/** Every `relative` directory between cwd and the repository root, nearest first,
+ * matching Claude's "every .claude/<kind> between the working directory and the
+ * repository root" discovery where the entry closest to cwd wins a name clash. */
+export function ancestorDirs(cwd: string, relative: string): string[] {
+  const boundary = repoRoot(cwd) ?? cwd
+  const found: string[] = []
+  let currentDir = cwd
+  while (true) {
+    const candidate = path.join(currentDir, relative)
+    if (statOf(candidate)?.isDirectory()) found.push(candidate)
+    if (currentDir === boundary) break
+    const parentDir = path.dirname(currentDir)
+    if (parentDir === currentDir) break
+    currentDir = parentDir
+  }
+  return found
+}
+
 /** Every `relative` file between the repository root and cwd, ordered root first,
  * matching Claude's root-down ordering for hierarchy-loaded context. */
 export function ancestorFiles(cwd: string, relative: string): string[] {

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -27,7 +27,7 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { installedPlugins } from './internal/plugins.js'
 import { isProjectApproved } from './internal/project-approval.js'
-import { findNearestDir, findNearestFile } from './internal/project-root.js'
+import { ancestorDirs, findNearestDir, findNearestFile } from './internal/project-root.js'
 import { claudeSettingsChain } from './internal/settings-chain.js'
 
 export interface OutputStyle {
@@ -85,7 +85,10 @@ function isDirectory(target: string): boolean {
  */
 export function styleDirs(cwd: string, home: string, trusted: boolean): string[] {
   const dirs = [path.join(claudeConfigDir(home), 'output-styles')]
-  if (trusted) dirs.push(findNearestDir(cwd, path.join('.claude', 'output-styles')) ?? path.join(cwd, '.claude', 'output-styles'))
+  // Claude loads every .claude/output-styles between cwd and the repository root,
+  // using the one closest to cwd for a name clash: styleForName is first-match,
+  // so the nearest directory goes first.
+  if (trusted) dirs.push(...ancestorDirs(cwd, path.join('.claude', 'output-styles')))
   return dirs.filter((dir) => isDirectory(dir))
 }
 

--- a/extensions/skills.ts
+++ b/extensions/skills.ts
@@ -29,7 +29,7 @@ import { parseCommandFile } from './internal/command-file.js'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { installedPlugins } from './internal/plugins.js'
 import { isProjectApprovedSilently } from './internal/project-approval.js'
-import { findNearestDir } from './internal/project-root.js'
+import { ancestorDirs } from './internal/project-root.js'
 
 function isDirectory(target: string): boolean {
   try {
@@ -53,7 +53,10 @@ export function skillDirs(cwd: string, home: string, trusted: boolean): string[]
     const dirs = Array.isArray(declared) ? declared : [typeof declared === 'string' ? declared : 'skills']
     candidates.push(...dirs.map((dir) => path.resolve(plugin.root, String(dir))))
   }
-  if (trusted) candidates.push(findNearestDir(cwd, path.join('.claude', 'skills')) ?? path.join(cwd, '.claude', 'skills'))
+  // Claude loads skills from every .claude/skills between cwd and the repository
+  // root; the list goes nearest-first so findClaudeSkill's first match is the
+  // closest definition (pi's loader receives the same order).
+  if (trusted) candidates.push(...ancestorDirs(cwd, path.join('.claude', 'skills')))
   const dirs: string[] = []
   for (const dir of candidates) {
     if (!dirs.includes(dir) && isDirectory(dir)) dirs.push(dir)

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -13,7 +13,7 @@ import { getAgentDir, parseFrontmatter, stripFrontmatter } from '@earendil-works
 import { parseToolGrants } from '../internal/command-file.js'
 import { claudeConfigDir } from '../internal/config-dir.js'
 import { installedPlugins } from '../internal/plugins.js'
-import { findNearestDir } from '../internal/project-root.js'
+import { ancestorDirs, findNearestDir } from '../internal/project-root.js'
 
 /**
  * `tools:` may be a comma-separated string (the Claude Code format) or a YAML block
@@ -337,13 +337,16 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
   const userDir = path.join(getAgentDir(), 'agents')
   const claudeUserDir = path.join(claudeConfigDir(os.homedir()), 'agents')
   const projectPiDir = findNearestDir(cwd, path.join('.pi', 'agents'))
-  const projectClaudeDir = findNearestDir(cwd, path.join('.claude', 'agents'))
+  // Claude scans every .claude/agents between cwd and the repository root, the
+  // definition closest to cwd winning a name clash; root-first load order makes
+  // the nearer directory's entry overwrite in the map below.
+  const projectClaudeDirs = ancestorDirs(cwd, path.join('.claude', 'agents')).reverse()
 
   // Plugins load after builtins and before the user's own dirs, so a user agent
   // wins a name clash with a plugin's, and ~/.pi/agent/agents wins over ~/.claude.
   const userAgents = scope === 'project' ? [] : [...loadAgentsFromDir(BUILTIN_AGENTS_DIR, 'builtin'), ...pluginAgentDirs(os.homedir()).flatMap((dir) => loadAgentsFromDir(dir, 'plugin')), ...loadAgentsFromDir(claudeUserDir, 'user'), ...loadAgentsFromDir(userDir, 'user')]
   // project .claude/agents loads first so project .pi/agents wins on name conflicts
-  const projectAgents = scope === 'user' ? [] : [...(projectClaudeDir ? loadAgentsFromDir(projectClaudeDir, 'project') : []), ...(projectPiDir ? loadAgentsFromDir(projectPiDir, 'project') : [])]
+  const projectAgents = scope === 'user' ? [] : [...projectClaudeDirs.flatMap((dir) => loadAgentsFromDir(dir, 'project')), ...(projectPiDir ? loadAgentsFromDir(projectPiDir, 'project') : [])]
 
   const agentMap = buildAgentMap(userAgents, projectAgents, scope)
   return { agents: Array.from(agentMap.values()), projectAgentsDir: projectPiDir }

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -197,3 +197,21 @@ describe('agent discovery boundary', () => {
     expect(found.agents.map((a) => a.name)).toContain('mine')
   })
 })
+
+describe('monorepo agent discovery', () => {
+  it('finds root-level project agents from a subdirectory session, nearest winning a name clash', () => {
+    // Claude: "every .claude/agents/ between there and the repository root is
+    // scanned ... Claude Code uses the definition closest to the working directory."
+    const root = mkdtempSync(join(tmpdir(), 'agents-mono-'))
+    writeFileSync(join(root, 'package.json'), '{}')
+    mkdirSync(join(root, '.claude', 'agents'), { recursive: true })
+    writeFileSync(join(root, '.claude', 'agents', 'deployer.md'), '---\nname: deployer\ndescription: root deployer\n---\nroot')
+    writeFileSync(join(root, '.claude', 'agents', 'shared.md'), '---\nname: shared\ndescription: root shared\n---\nroot')
+    const cwd = join(root, 'apps', 'web')
+    mkdirSync(join(cwd, '.claude', 'agents'), { recursive: true })
+    writeFileSync(join(cwd, '.claude', 'agents', 'shared.md'), '---\nname: shared\ndescription: near shared\n---\nnear')
+    const agents = discoverAgents(cwd, 'project').agents
+    expect(agents.find((a) => a.name === 'deployer')?.description).toBe('root deployer')
+    expect(agents.find((a) => a.name === 'shared')?.description).toBe('near shared')
+  })
+})

--- a/tests/config-dir.test.ts
+++ b/tests/config-dir.test.ts
@@ -53,3 +53,31 @@ describe('config-dir sweep', () => {
     expect(userSettings).toBe(path.join('/opt/claude-config', 'settings.json'))
   })
 })
+
+describe('ancestorDirs', () => {
+  it('returns every matching directory from cwd up to the repository root, nearest first', async () => {
+    const { ancestorDirs } = await import('../extensions/internal/project-root.ts')
+    const { mkdirSync, mkdtempSync, writeFileSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+    const root = mkdtempSync(join(tmpdir(), 'walk-'))
+    writeFileSync(join(root, 'package.json'), '{}')
+    mkdirSync(join(root, '.claude', 'agents'), { recursive: true })
+    mkdirSync(join(root, 'apps', 'web', '.claude', 'agents'), { recursive: true })
+    const cwd = join(root, 'apps', 'web')
+    expect(ancestorDirs(cwd, join('.claude', 'agents'))).toEqual([join(cwd, '.claude', 'agents'), join(root, '.claude', 'agents')])
+  })
+
+  it('does not walk past the repository root', async () => {
+    const { ancestorDirs } = await import('../extensions/internal/project-root.ts')
+    const { mkdirSync, mkdtempSync, writeFileSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+    const outer = mkdtempSync(join(tmpdir(), 'walk-'))
+    mkdirSync(join(outer, '.claude', 'agents'), { recursive: true })
+    const root = join(outer, 'repo')
+    mkdirSync(root, { recursive: true })
+    writeFileSync(join(root, 'package.json'), '{}')
+    expect(ancestorDirs(root, join('.claude', 'agents'))).toEqual([])
+  })
+})


### PR DESCRIPTION
Phase-2 batch 3 from the conformance register (B2-F6, B6-F9, B1-L4): agents, commands, skills, and output styles read only the nearest `.claude/<kind>` directory, so a monorepo subdirectory session with its own directory silently lost everything the repository root defined.

- One shared `ancestorDirs` walk (bounded at the repository root, like the trust walk) feeds all four surfaces.
- Name clashes resolve to the definition closest to the working directory, as Claude documents per surface; ordering respects each consumer's existing merge direction (later-wins maps get root-first lists, first-match lookups get nearest-first).
- Topic docs updated.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change (helper walk red-first incl. the root boundary; agent clash behavior red-first)