### PR TITLE
Honor bracket globs, excludes, and symlinks in rules; add the gated release script

### DIFF
--- a/docs/claude-md.md
+++ b/docs/claude-md.md
@@ -16,3 +16,5 @@ Context files and path-scoped rules, beyond what pi loads natively. Sources: [`e
 
 - `~/.claude/rules` and `.claude/rules` (nearest at or above cwd).
 - Unscoped rules are inlined in full; `paths:`-scoped rules are surfaced as pointers and auto-attached: the rule body is appended to a read/edit/write result when a matching file is touched, once per rule per session.
+- Rule `paths` globs support bracket expressions (`[jt]`, ranges, `[!...]` negation); an unreadable `[` makes the pattern invalid (matching nothing) and `\[` matches a literal bracket, as Claude documents. Attach matching compares realpaths, so a symlinked checkout still matches.
+- `claudeMdExcludes` covers rules files too: the docs' monorepo recipe of excluding another team's `.claude/rules/**` works, with globs matched against both the lexical and resolved path.

--- a/extensions/claude-rules.ts
+++ b/extensions/claude-rules.ts
@@ -21,8 +21,10 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
+import { claudeMdExcludeFiles, isExcludedPath, readClaudeMdExcludes } from './context-imports.js'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { publishInstructionLoad } from './internal/instruction-events.js'
+import { readManagedSettings } from './internal/managed-settings.js'
 import { type CompiledGlob, compileGlobs, matchesCompiledGlobs } from './internal/path-rules.js'
 import { isProjectApproved } from './internal/project-approval.js'
 import { findNearestDir } from './internal/project-root.js'
@@ -147,12 +149,36 @@ interface RuleSet {
 
 const EMPTY_RULES: RuleSet = { inline: [], scoped: [] }
 
+/** The canonical form of a path. A target that does not exist yet (a write
+ * creating a new file) canonicalises its nearest existing ancestor and keeps the
+ * remaining segments, so both sides of the attach match compare realpaths even
+ * for brand-new files in a symlinked checkout. */
+function realpathOr(target: string): string {
+  try {
+    return fs.realpathSync(target)
+  } catch {
+    const dir = path.dirname(target)
+    if (dir === target) return target
+    return path.join(realpathOr(dir), path.basename(target))
+  }
+}
+
 /** Unscoped rules are inlined; path-scoped ones keep their scope as pointers,
- * mirroring Claude Code, where scoped rules attach only to matching files. */
-function readRules(rulesDir: string): RuleSet {
+ * mirroring Claude Code, where scoped rules attach only to matching files. Files
+ * matching `claudeMdExcludes` are skipped entirely, as the docs' monorepo recipe
+ * (excluding another team's `.claude/rules/**`) relies on; the check runs on the
+ * realpath so a symlink cannot dodge an exclusion. */
+function readRules(rulesDir: string, isExcluded?: (realPath: string) => boolean): RuleSet {
   const inline: string[] = []
   const scoped: ScopedRule[] = []
   for (const file of findMarkdownFiles(rulesDir)) {
+    if (isExcluded) {
+      // Both spellings count: a glob written against the lexical path and one
+      // written against the resolved real path each exclude, which can only
+      // widen an exclusion, never dodge one.
+      const lexical = path.join(rulesDir, file)
+      if (isExcluded(lexical) || isExcluded(realpathOr(lexical))) continue
+    }
     let parsed: Frontmatter
     try {
       parsed = parseFrontmatter(fs.readFileSync(path.join(rulesDir, file), 'utf-8'))
@@ -223,15 +249,20 @@ export default function claudeRulesExtension(pi: ExtensionAPI) {
   let attachTargets: AttachTarget[] = []
 
   pi.on('session_start', async (_event, ctx) => {
-    globalRules = readRules(globalRulesDir)
     // Project rules are repository text landing in the system prompt, so they load
     // only once the project is approved. isProjectTrusted alone is true for a repo
     // pi never asked about; see project-approval.
     const approved = await isProjectApproved(ctx)
+    // Claude's claudeMdExcludes covers rules files too (the docs' monorepo recipe
+    // excludes another team's .claude/rules/**), so the same merged glob list the
+    // context loader honors gates rule files here.
+    const excludeGlobs = readClaudeMdExcludes(claudeMdExcludeFiles(ctx.cwd, os.homedir(), approved), readManagedSettings())
+    const isExcluded = (realPath: string): boolean => isExcludedPath(realPath, excludeGlobs, os.homedir())
+    globalRules = readRules(globalRulesDir, isExcluded)
     // Nearest at-or-above cwd, so a subdirectory session still reads the rules the
     // approval walk gated on.
     const projectRulesDir = approved ? findNearestDir(ctx.cwd, path.join('.claude', 'rules')) : null
-    projectRules = projectRulesDir ? readRules(projectRulesDir) : EMPTY_RULES
+    projectRules = projectRulesDir ? readRules(projectRulesDir, isExcluded) : EMPTY_RULES
 
     // Global globs are relative to cwd; project globs to the project root (the dir
     // holding .claude), so `db/**` in a repo rule matches repo-relative paths even
@@ -239,8 +270,8 @@ export default function claudeRulesExtension(pi: ExtensionAPI) {
     // than on every tool result; rebuilt per session so a re-run re-attaches.
     const projectRoot = projectRulesDir ? path.dirname(path.dirname(projectRulesDir)) : ctx.cwd
     attachTargets = [
-      ...globalRules.scoped.map((rule) => ({ globs: rule.paths, compiled: compileGlobs(rule.paths), body: rule.body, root: ctx.cwd, file: path.join(globalRulesDir, rule.rel), memoryType: 'User' as const })),
-      ...projectRules.scoped.map((rule) => ({ globs: rule.paths, compiled: compileGlobs(rule.paths), body: rule.body, root: projectRoot, file: path.join(projectRulesDir ?? path.join(ctx.cwd, '.claude', 'rules'), rule.rel), memoryType: 'Project' as const })),
+      ...globalRules.scoped.map((rule) => ({ globs: rule.paths, compiled: compileGlobs(rule.paths), body: rule.body, root: realpathOr(ctx.cwd), file: path.join(globalRulesDir, rule.rel), memoryType: 'User' as const })),
+      ...projectRules.scoped.map((rule) => ({ globs: rule.paths, compiled: compileGlobs(rule.paths), body: rule.body, root: realpathOr(projectRoot), file: path.join(projectRulesDir ?? path.join(ctx.cwd, '.claude', 'rules'), rule.rel), memoryType: 'Project' as const })),
     ]
     pendingScopedRules = attachTargets.length
     // Relative to cwd, which the read tool resolves: an ancestor dir yields a
@@ -274,7 +305,9 @@ export default function claudeRulesExtension(pi: ExtensionAPI) {
     if (event.toolName !== 'read' && event.toolName !== 'edit' && event.toolName !== 'write') return
     const rel = (event.input as { path?: unknown } | undefined)?.path
     if (typeof rel !== 'string' || rel.length === 0) return
-    const abs = path.resolve(ctx.cwd, rel)
+    // Realpath both sides (roots canonicalise at session_start): a tool reporting
+    // the resolved real path in a symlinked checkout must still match.
+    const abs = realpathOr(path.resolve(ctx.cwd, rel))
 
     const bodies: string[] = []
     const remaining: AttachTarget[] = []

--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -7,8 +7,10 @@
  * root (the settings source), and bare or `./` from the current directory. As
  * allow rules, a single-segment directory pattern anchors at cwd; a bare
  * filename matches at any depth. `*` stays within one segment, `**` crosses
- * directories. Matching is lexical, on resolved paths; bracket expressions are
- * not supported and match literally, which can only over-block, never widen.
+ * directories. Matching is lexical, on resolved paths. Bracket expressions parse
+ * per Claude's documented glob contract: `[abc]` classes with ranges and `!`
+ * negation, an unreadable `[` making the pattern match nothing, and `\[` for a
+ * literal bracket.
  */
 
 import * as path from 'node:path'

--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -79,7 +79,6 @@ function expandBraces(pattern: string): string[] | null {
   return expanded
 }
 
-/** One glob pattern, braces already expanded, as a regular expression source. */
 /** The end index of a bracket expression starting at `start` (`[`), or -1 when it
  * cannot be read as one, which per Claude makes the whole pattern invalid. A `]`
  * directly after the opening (or after a leading negation) is a literal member. */
@@ -99,6 +98,18 @@ function bracketClass(body: string): string {
   const negated = body.startsWith('!') || body.startsWith('^')
   const members = (negated ? body.slice(1) : body).replace(/[\\\]^]/g, (ch) => `\\${ch}`)
   return `[${negated ? '^' : ''}${members}]`
+}
+
+/** A `*` run starting at `i`: a double star followed by a slash spans whole
+ * directories, a bare double star crosses segments, and a single `*` stays within
+ * one. Returns the regex source and the index after the run. */
+function translateStar(pattern: string, i: number): { source: string; next: number } {
+  if (pattern[i + 1] === '*') {
+    const prevSlash = i === 0 || pattern[i - 1] === '/'
+    if (prevSlash && pattern[i + 2] === '/') return { source: '(?:[^/]+/)*', next: i + 3 }
+    return { source: '.*', next: i + 2 }
+  }
+  return { source: '[^/]*', next: i + 1 }
 }
 
 function translateGlob(pattern: string): string | null {
@@ -122,19 +133,9 @@ function translateGlob(pattern: string): string | null {
       continue
     }
     if (ch === '*') {
-      if (pattern[i + 1] === '*') {
-        const prevSlash = i === 0 || pattern[i - 1] === '/'
-        if (prevSlash && pattern[i + 2] === '/') {
-          out += '(?:[^/]+/)*' // `**/` spans zero or more whole directories
-          i += 3
-          continue
-        }
-        out += '.*'
-        i += 2
-        continue
-      }
-      out += '[^/]*'
-      i += 1
+      const star = translateStar(pattern, i)
+      out += star.source
+      i = star.next
       continue
     }
     if (ch === '?') {
@@ -159,7 +160,7 @@ const NEVER_MATCH = '(?!)'
 export function globToRegExpSource(pattern: string): string {
   const alternatives = expandBraces(pattern) ?? [pattern]
   const sources = alternatives.map(translateGlob)
-  if (sources.some((source) => source === null)) return NEVER_MATCH
+  if (sources.includes(null)) return NEVER_MATCH
   if (sources.length === 1) return sources[0] as string
   return `(?:${sources.join('|')})`
 }

--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -80,11 +80,47 @@ function expandBraces(pattern: string): string[] | null {
 }
 
 /** One glob pattern, braces already expanded, as a regular expression source. */
-function translateGlob(pattern: string): string {
+/** The end index of a bracket expression starting at `start` (`[`), or -1 when it
+ * cannot be read as one, which per Claude makes the whole pattern invalid. A `]`
+ * directly after the opening (or after a leading negation) is a literal member. */
+function bracketEnd(pattern: string, start: number): number {
+  let i = start + 1
+  if (pattern[i] === '!' || pattern[i] === '^') i += 1
+  if (pattern[i] === ']') i += 1
+  for (; i < pattern.length; i += 1) {
+    if (pattern[i] === ']') return i
+  }
+  return -1
+}
+
+/** A bracket expression body as a regex character class, escaping regex-relevant
+ * characters while keeping `-` ranges; a leading `!` (or `^`) negates. */
+function bracketClass(body: string): string {
+  const negated = body.startsWith('!') || body.startsWith('^')
+  const members = (negated ? body.slice(1) : body).replace(/[\\\]^]/g, (ch) => `\\${ch}`)
+  return `[${negated ? '^' : ''}${members}]`
+}
+
+function translateGlob(pattern: string): string | null {
   let out = ''
   let i = 0
   while (i < pattern.length) {
     const ch = pattern[i]
+    // Claude: to match a literal bracket, escape it; the escape consumes both chars.
+    if (ch === '\\' && (pattern[i + 1] === '[' || pattern[i + 1] === ']')) {
+      out += escapeRegExp(pattern[i + 1])
+      i += 2
+      continue
+    }
+    // Claude: `[` starts a bracket expression such as `[abc]`; a `[` that cannot be
+    // read as one makes the pattern invalid, matching nothing.
+    if (ch === '[') {
+      const end = bracketEnd(pattern, i)
+      if (end === -1) return null
+      out += bracketClass(pattern.slice(i + 1, end))
+      i = end + 1
+      continue
+    }
     if (ch === '*') {
       if (pattern[i + 1] === '*') {
         const prevSlash = i === 0 || pattern[i - 1] === '/'
@@ -112,13 +148,20 @@ function translateGlob(pattern: string): string {
   return out
 }
 
+/** A regex source that matches nothing: the compiled form of an invalid pattern. */
+const NEVER_MATCH = '(?!)'
+
 /** One gitignore-style pattern as an anchored regular expression source. Brace
  * groups (`{ts,tsx}`, nested, Cartesian across groups) expand into ORed
- * alternatives; an over-budget expansion falls back to the literal pattern. */
+ * alternatives; an over-budget expansion falls back to the literal pattern. An
+ * invalid pattern (an unreadable bracket expression) matches nothing, as Claude
+ * documents, rather than matching its literal spelling. */
 export function globToRegExpSource(pattern: string): string {
   const alternatives = expandBraces(pattern) ?? [pattern]
-  if (alternatives.length === 1) return translateGlob(alternatives[0])
-  return `(?:${alternatives.map(translateGlob).join('|')})`
+  const sources = alternatives.map(translateGlob)
+  if (sources.some((source) => source === null)) return NEVER_MATCH
+  if (sources.length === 1) return sources[0] as string
+  return `(?:${sources.join('|')})`
 }
 
 /** A rule resolved to an absolute glob per its anchor form. */

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,52 @@
+#!/bin/zsh
+# Gated merge-and-release: the ONLY sanctioned way to merge a PR and cut a release.
+#
+# Usage: scripts/release.sh <pr-number> <version> "<release notes>"
+#
+# Every stage is &&-chained so a red stage stops everything after it, and the gate
+# checks three independent sources before any merge:
+#   1. `gh pr checks` UNPIPED - piping through tail/head swallows the exit code,
+#      which once let a PR merge through a red SonarCloud check.
+#   2. The SonarCloud findings API - a green quality gate can still carry findings.
+#   3. The SonarCloud quality-gate API - findings can be zero while the gate fails
+#      a condition such as new-code coverage.
+# The publish is verified against the registry, not the pipeline's exit code.
+set -u
+
+REPO_KEY=ilovepixelart_pi-code
+PR=${1:?pr number}
+VERSION=${2:?version}
+NOTES=${3:?release notes}
+
+gate() {
+  local pr=$1
+  gh pr checks "$pr" > /dev/null \
+    && python3 ~/.claude/scripts/sonar-findings.py "$REPO_KEY" "$pr" \
+    && [ "$(curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$REPO_KEY&pullRequest=$pr" | python3 -c 'import json,sys; print(json.load(sys.stdin)["projectStatus"]["status"])')" = "OK" ] \
+    && echo "GATE-OK-$pr"
+}
+
+wait_ci() {
+  local branch=$1
+  until gh run list --branch "$branch" --json headSha,status -q '.[] | select(.headSha=="'"$(git rev-parse HEAD)"'") | .status' | grep -q completed; do sleep 20; done
+}
+
+BRANCH=$(gh pr view "$PR" --json headRefName -q .headRefName) \
+  && git checkout "$BRANCH" && git pull \
+  && wait_ci "$BRANCH" && gate "$PR" \
+  && gh pr merge "$PR" --squash \
+  && git checkout main && git pull \
+  && git checkout -b "release/$VERSION" \
+  && npm version "$VERSION" --no-git-tag-version \
+  && npm run check > "/tmp/release-$VERSION-check.log" 2>&1 \
+  && git add package.json package-lock.json \
+  && git commit -m "Release $VERSION" \
+  && git push origin "HEAD:release/$VERSION" \
+  && BUMP_PR=$(gh pr create --title "Release $VERSION" --body "Version bump to $VERSION." | grep -o '[0-9]*$') \
+  && wait_ci "release/$VERSION" && gate "$BUMP_PR" \
+  && gh pr merge "$BUMP_PR" --squash --delete-branch \
+  && git checkout main && git pull \
+  && gh release create "v$VERSION" --target main --title "$VERSION" --notes "$NOTES" \
+  && until gh run list --workflow=publish.yaml --limit 1 --json status,conclusion -q '.[0] | select(.status=="completed") | .conclusion' | grep -q success; do sleep 30; done \
+  && until [ "$(npm view pi-code version 2>/dev/null)" = "$VERSION" ]; do sleep 30; done \
+  && echo "RELEASED-$VERSION"

--- a/tests/claude-rules.test.ts
+++ b/tests/claude-rules.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -423,7 +423,7 @@ describe('extension wiring', () => {
       await handlers.get('session_start')?.({}, approvedCtx(cwd))
 
       await handlers.get('tool_result')?.(readResult('db/schema.sql'), { cwd })
-      expect(instructionEvents()).toEqual([{ file_path: join(cwd, '.claude', 'rules', 'testing.md'), memory_type: 'Project', load_reason: 'path_glob_match', globs: ['db/**'], trigger_file_path: join(cwd, 'db', 'schema.sql') }])
+      expect(instructionEvents()).toEqual([{ file_path: join(cwd, '.claude', 'rules', 'testing.md'), memory_type: 'Project', load_reason: 'path_glob_match', globs: ['db/**'], trigger_file_path: join(realpathSync(cwd), 'db', 'schema.sql') }])
 
       // The rule attaches once per session, so the event fires once too.
       await handlers.get('tool_result')?.(readResult('db/other.sql'), { cwd })
@@ -440,7 +440,7 @@ describe('extension wiring', () => {
       await handlers.get('session_start')?.({}, { cwd, isProjectTrusted: () => true, ui: { notify: () => {} } })
       await handlers.get('tool_result')?.(readResult('db/schema.sql'), { cwd })
 
-      expect(instructionEvents()).toEqual([{ file_path: join(rulesDir, 'sql.md'), memory_type: 'User', load_reason: 'path_glob_match', globs: ['db/**'], trigger_file_path: join(cwd, 'db', 'schema.sql') }])
+      expect(instructionEvents()).toEqual([{ file_path: join(rulesDir, 'sql.md'), memory_type: 'User', load_reason: 'path_glob_match', globs: ['db/**'], trigger_file_path: join(realpathSync(cwd), 'db', 'schema.sql') }])
     })
 
     it('publishes nothing for a non-matching touch', async () => {
@@ -457,5 +457,57 @@ describe('extension wiring', () => {
 describe('parseFrontmatter CRLF', () => {
   it('parses CRLF frontmatter authored on Windows', () => {
     expect(parseFrontmatter('---\r\npaths:\r\n  - "**/*.ts"\r\n---\r\nbody').paths).toEqual(['**/*.ts'])
+  })
+})
+
+describe('claudeMdExcludes and symlinked checkouts', () => {
+  let savedAgentDir: string | undefined
+  beforeEach(() => {
+    hoisted.home = mkdtempSync(join(tmpdir(), 'rules-home-'))
+    savedAgentDir = process.env.PI_CODING_AGENT_DIR
+    process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), 'rules-agent-'))
+  })
+  afterEach(() => {
+    if (savedAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR
+    else process.env.PI_CODING_AGENT_DIR = savedAgentDir
+  })
+
+  const wire = () => {
+    const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>()
+    claudeRules({ on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn) } as never)
+    return handlers
+  }
+  const approvedCtx = (cwd: string): Record<string, unknown> => ({ cwd, isProjectTrusted: () => true, hasUI: true, ui: { notify: () => {}, confirm: async () => true } })
+
+  it('honors claudeMdExcludes for rules files, as the docs monorepo recipe shows', async () => {
+    // Claude's worked example excludes "other-team/.claude/rules/**".
+    const cwd = mkdtempSync(join(tmpdir(), 'rules-'))
+    mkdirSync(join(cwd, '.claude', 'rules'), { recursive: true })
+    writeFileSync(join(cwd, '.claude', 'rules', 'noisy.md'), 'NOISY RULE BODY')
+    writeFileSync(join(cwd, '.claude', 'settings.json'), JSON.stringify({ claudeMdExcludes: [`${cwd}/.claude/rules/**`] }))
+    const handlers = wire()
+    await handlers.get('session_start')?.({}, approvedCtx(cwd))
+    const result = (await handlers.get('before_agent_start')?.({ systemPrompt: 'BASE' }, {})) as { systemPrompt: string } | undefined
+    expect(result?.systemPrompt ?? 'BASE').not.toContain('NOISY RULE BODY')
+  })
+
+  it('attaches a scoped rule when the file is reached through a symlinked checkout path', async () => {
+    // Claude: "matching also works when Claude reaches a file through a symlinked
+    // path to the project directory".
+    const real = mkdtempSync(join(tmpdir(), 'rules-real-'))
+    mkdirSync(join(real, '.claude', 'rules'), { recursive: true })
+    mkdirSync(join(real, 'db'), { recursive: true })
+    writeFileSync(join(real, 'db', 'schema.sql'), 'x')
+    writeFileSync(join(real, '.claude', 'rules', 'db.md'), '---\npaths:\n  - "db/**"\n---\nUse parameterized queries.')
+    const linkParent = mkdtempSync(join(tmpdir(), 'rules-link-'))
+    const linked = join(linkParent, 'checkout')
+    symlinkSync(real, linked)
+    const handlers = wire()
+    await handlers.get('session_start')?.({}, approvedCtx(linked))
+    // The tool reports the resolved REAL path while the session cwd is the symlink:
+    // lexically the file sits outside the root, only realpaths agree.
+    const result = await handlers.get('tool_result')?.({ toolName: 'read', input: { path: join(real, 'db', 'schema.sql') }, content: [{ type: 'text', text: 'FILE BODY' }], isError: false }, { cwd: linked })
+    const texts = ((result as { content?: Array<{ text?: string }> } | undefined)?.content ?? []).map((block) => block.text ?? '')
+    expect(texts.join('\n')).toContain('parameterized queries')
   })
 })

--- a/tests/path-rules.test.ts
+++ b/tests/path-rules.test.ts
@@ -108,3 +108,32 @@ describe('compileGlobs', () => {
     expect(matchesCompiledGlobs('anything', [])).toBe(false)
   })
 })
+
+const { pathMatchesGlobs } = await import('../extensions/claude-rules.ts')
+
+describe('bracket expressions', () => {
+  // Claude: "Glob syntax treats [ as the start of a bracket expression such as
+  // [abc]. A pattern with a [ that can't be read as a bracket expression ... is
+  // invalid: it matches nothing ... To match a literal [ ... escape it."
+  it('matches a character class against real files, not the literal bracket text', () => {
+    expect(pathMatchesGlobs('src/a.ts', ['src/*.[jt]s'])).toBe(true)
+    expect(pathMatchesGlobs('src/a.js', ['src/*.[jt]s'])).toBe(true)
+    expect(pathMatchesGlobs('src/a.cs', ['src/*.[jt]s'])).toBe(false)
+    expect(pathMatchesGlobs('src/a.[jt]s', ['src/*.[jt]s'])).toBe(false)
+  })
+
+  it('supports ranges and negation', () => {
+    expect(pathMatchesGlobs('v1.txt', ['v[0-9].txt'])).toBe(true)
+    expect(pathMatchesGlobs('vX.txt', ['v[0-9].txt'])).toBe(false)
+    expect(pathMatchesGlobs('vX.txt', ['v[!0-9].txt'])).toBe(true)
+  })
+
+  it('treats an unclosable bracket as an invalid pattern that matches nothing', () => {
+    expect(pathMatchesGlobs('photos [2024/x.png', ['photos [2024/**'])).toBe(false)
+    expect(pathMatchesGlobs('anything', ['photos [2024/**'])).toBe(false)
+  })
+
+  it('matches a literal bracket through the documented escape', () => {
+    expect(pathMatchesGlobs('photos [2024/x.png', ['photos \\[2024/**'])).toBe(true)
+  })
+})


### PR DESCRIPTION
Phase-2 batch 4 from the conformance register (B1-M1, B1-M3, B1-L7), plus the release-process hardening.

- **Bracket expressions** in rule `paths` globs parse per the documented contract: `[jt]` classes, ranges, `[!...]` negation; a `[` that cannot be read as a bracket expression makes the pattern invalid (matching nothing, never its literal spelling); `\[` matches a literal bracket. Previously such rules silently never attached.
- **`claudeMdExcludes` reaches rules files**, so the docs' monorepo recipe (excluding another team's `.claude/rules/**`) works; globs match against both the lexical and resolved path, which can only widen an exclusion.
- **Symlinked checkouts**: attach matching canonicalises both sides, using the nearest existing ancestor for files not yet written, so scoped rules attach when tools report resolved real paths.
- **`scripts/release.sh`**: the gated merge-and-release chain as a vetted script - unpiped `gh pr checks`, the Sonar findings API, and the quality-gate API must all pass before any merge, with the publish verified against the registry. Encodes the lesson from the one merge that slipped through a piped check.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change (bracket contract red-first from the doc's own examples; excludes and the discriminating symlink direction red-first)