### PR TITLE
Skip Stop hooks on interrupt, honor per-type timeouts and the prompt-hook contract

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -9,7 +9,7 @@ Runs Claude Code's `.claude/settings.json` hooks on pi's lifecycle events. Sourc
 - **PostToolUseFailure**: notify-only (the tool already failed); the hook's stderr is shown to the model.
 - **SessionStart**: context injection before the first prompt.
 - **UserPromptSubmit**: blocks the prompt or injects context ahead of it.
-- **Stop**: a block (or `additionalContext`) feeds back as a new turn, with `stop_hook_active` as the loop guard and a consecutive-block cap of 8 (`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`; `0` disables the cap).
+- **Stop**: a block (or `additionalContext`) feeds back as a new turn, with `stop_hook_active` as the loop guard and a consecutive-block cap of 8 (`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`; `0` disables the cap). Does not run when the turn ended on a user interrupt, as Claude documents.
 - **SubagentStart / SubagentStop**: notify-only (a child has already exited by SubagentStop).
 - **PreCompact / PostCompact / SessionEnd / Notification** (`idle_prompt`, the one type pi can source): notify-only.
 - **InstructionsLoaded**: observational; fires per loaded context file at session start, plus `path_glob_match` on a scoped-rule attach and `include` per resolved `@import`, deduped per session. `nested_traversal`/`compact` reasons never fire (pi does not lazily load nested CLAUDE.md or reload after compaction).
@@ -39,5 +39,6 @@ Runs Claude Code's `.claude/settings.json` hooks on pi's lifecycle events. Sourc
 
 ## Divergences from Claude Code
 
-- A timed-out PreToolUse/UserPromptSubmit hook fails closed at a 60s default (Claude: 600s for PreToolUse, 30s for UserPromptSubmit, both non-blocking), since pi has no permission prompt to fall back on.
+- A timed-out PreToolUse/UserPromptSubmit hook fails closed at a 60s default (Claude: 600s for PreToolUse, 30s for UserPromptSubmit, both non-blocking), since pi has no permission prompt to fall back on. Prompt hooks default to Claude's 30s and agent hooks to 60s; SessionEnd hooks share Claude's 1.5-second budget, raised by a declared per-hook `timeout` up to 60 seconds, so a slow hook cannot stall session exit.
+- Prompt hooks honor the `model` override (resolved against the models this user can run) and append the input JSON to the prompt when `$ARGUMENTS` is absent, as documented.
 - `disableAllHooks` in any scope turns the system off; `/hooks` prints the resolved configuration.

--- a/extensions/hooks/index.ts
+++ b/extensions/hooks/index.ts
@@ -95,7 +95,7 @@ import { claudeToolInput, claudeToolName, claudeToolResponse, piToolOutput } fro
 import { formatHooksSummary, type HookCommand, type HookMatcher, type HooksConfig, hookFiles, isBackgroundHook, loadHooks, loadPluginHooks, readAllowedHttpHookUrls, readDisableAllHooks } from './config.js'
 import { blockedToolCall, jsonBlockVerdict, postToolFeedback, promptContext, runPreToolUse, runUserPromptSubmit, surfaceSystemMessages, tryParseJson } from './decisions.js'
 import { allCommands, matchingCommands, passesIfFilter } from './matcher.js'
-import { type HookRunner, type HookRunResult, runAgentHook, runHookCommand, runHttpHook, runMcpToolHook, runPromptHook, timeoutMs } from './runners.js'
+import { type HookRunner, type HookRunResult, runAgentHook, runHookCommand, runHttpHook, runMcpToolHook, runPromptHook, sessionEndTimeoutMs, timeoutMs } from './runners.js'
 
 export * from './config.js'
 export * from './decisions.js'
@@ -185,6 +185,16 @@ export default function hooksExtension(pi: ExtensionAPI) {
     if (ctx.thinkingLevel) common.effort = { level: ctx.thinkingLevel }
     return common
   }
+  /** Claude's prompt-hook `model` override, resolved against the models this user
+   * can run (exact id first, then a substring match); the session model otherwise. */
+  const resolveHookModel = (ctx: ExtensionContext, override: string | undefined): ExtensionContext['model'] => {
+    if (!override) return ctx.model
+    const available = (ctx as { modelRegistry?: { getAvailable?: () => ReadonlyArray<{ id: string; name?: string }> } }).modelRegistry?.getAvailable?.() ?? []
+    const needle = override.toLowerCase()
+    const match = available.find((model) => model.id.toLowerCase() === needle) ?? available.find((model) => model.id.toLowerCase().includes(needle) || model.name?.toLowerCase().includes(needle))
+    return (match as ExtensionContext['model']) ?? ctx.model
+  }
+
   /** Kills for background hooks still running; Claude kills async hooks at teardown,
    * so session_shutdown reaps anything left rather than let a hung hook pin the
    * event loop past a one-shot run's end. */
@@ -220,7 +230,7 @@ export default function hooksExtension(pi: ExtensionAPI) {
       const merged = { ...commonPayload(ctx), ...extra, ...(payload as Record<string, unknown>) }
       const dispatch = (onChild?: (kill: () => void) => void): Promise<HookRunResult> => {
         if (hook.type === 'http') return runHttpHook(hook, merged, ms, allowedHttpHookUrls)
-        if (hook.type === 'prompt') return runPromptHook(hook, merged, ctx.model, ms)
+        if (hook.type === 'prompt') return runPromptHook(hook, merged, resolveHookModel(ctx, hook.model), ms)
         if (hook.type === 'agent') return runAgentHook(hook, merged, ms, (ctx.model as { id?: string } | undefined)?.id)
         if (hook.type === 'mcp_tool') return runMcpToolHook(hook, merged, ms)
         return runHookCommand(hook.command, merged, ms, projectDir, hook.args, onChild)
@@ -483,6 +493,14 @@ export default function hooksExtension(pi: ExtensionAPI) {
       stopHookActive = false
       return
     }
+    // Claude: Stop does not run when the stoppage was a user interrupt; pi marks
+    // the aborted turn's final assistant message stopReason "aborted".
+    const turnMessages = (event as { messages?: Array<{ role: string; stopReason?: string }> }).messages ?? []
+    const lastAssistant = [...turnMessages].reverse().find((message) => message.role === 'assistant')
+    if (lastAssistant?.stopReason === 'aborted') {
+      stopHookActive = false
+      return
+    }
     // Claude's Stop payload carries the turn's final assistant text so a hook need
     // not re-read the transcript; included only when there is one.
     const lastText = lastAssistantText((event as { messages?: Array<{ role: string; content: unknown }> }).messages ?? [])
@@ -543,7 +561,11 @@ export default function hooksExtension(pi: ExtensionAPI) {
 
   pi.on('session_shutdown', async (event, ctx) => {
     const reason = claudeSpelling(SESSION_END_REASON, event.reason)
-    const results = await runNotifyHooks(matchingCommands(config.SessionEnd, reason.names), { hook_event_name: 'SessionEnd', reason: reason.value }, boundRunner(ctx))
+    // SessionEnd rides Claude's short shared budget (see sessionEndTimeoutMs) so a
+    // slow hook cannot stall session exit, /new or /resume.
+    const sessionEndCommands = matchingCommands(config.SessionEnd, reason.names).filter((command) => passesIfFilter(command, undefined))
+    const runner = boundRunner(ctx)
+    const results = await Promise.all(sessionEndCommands.map((command) => runner(command, { hook_event_name: 'SessionEnd', reason: reason.value }, sessionEndTimeoutMs(command))))
     surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
     // Claude kills async hooks still running at teardown; the session that spawned
     // these is over, and their delivery would target a disposed context anyway.

--- a/extensions/hooks/runners.ts
+++ b/extensions/hooks/runners.ts
@@ -20,6 +20,12 @@ import { type HookCommand, httpUrlAllowed, isBackgroundHook } from './config.js'
 // raise their own per-hook `timeout`.
 const DEFAULT_TIMEOUT_S = 60
 
+/** Claude's per-type defaults where they are safe to mirror: 30s for `prompt`
+ * hooks and 60s for `agent` hooks. Command/http/mcp_tool keep the flat 60s
+ * documented divergence from Claude's 600 (a gated hook fails closed here, so ten
+ * minutes of default budget would wedge the turn). */
+const TYPE_DEFAULT_TIMEOUT_S: Record<string, number> = { prompt: 30, agent: 60 }
+
 export interface HookRunResult {
   code: number
   stdout: string
@@ -49,8 +55,18 @@ export function timeoutMs(command: HookCommand): number {
   // Non-positive values fall back to the default: a 0ms timer would fire before the
   // hook runs, and a timed-out PreToolUse hook fails closed, bricking the tool.
   const declared = command.timeout
-  const seconds = typeof declared === 'number' && declared > 0 ? Math.min(declared, MAX_TIMEOUT_S) : DEFAULT_TIMEOUT_S
+  const fallback = TYPE_DEFAULT_TIMEOUT_S[command.type ?? 'command'] ?? DEFAULT_TIMEOUT_S
+  const seconds = typeof declared === 'number' && declared > 0 ? Math.min(declared, MAX_TIMEOUT_S) : fallback
   return seconds * 1000
+}
+
+/** Claude's SessionEnd budget: hooks share 1.5 seconds so session exit (and /new,
+ * /resume) cannot stall on a slow hook; a declared per-hook `timeout` raises the
+ * budget to match, up to 60 seconds. */
+export function sessionEndTimeoutMs(command: HookCommand): number {
+  const declared = command.timeout
+  if (typeof declared === 'number' && declared > 0) return Math.min(declared, 60) * 1000
+  return 1500
 }
 
 /** Memory backstop for a runaway hook. A decision payload is orders of magnitude smaller. */
@@ -217,7 +233,11 @@ export async function runPromptHook(hook: HookCommand, payload: unknown, model: 
   if (!model) return { code: 1, stdout: '', stderr: 'no model available for prompt hook', timedOut: false }
   // A replacer function, so `$$`/`$&`/`` $` ``/`$'` inside the payload JSON are inserted
   // verbatim rather than read as replacement patterns (a Bash `echo $$` is a common trigger).
-  const prompt = substituteArguments(hook.prompt, payload)
+  // Claude: when $ARGUMENTS is not present, the input JSON is appended to the
+  // prompt, so the model never evaluates blind.
+  const template = hook.prompt ?? ''
+  const withInput = template.includes('$ARGUMENTS') ? template : `${template}\n\n$ARGUMENTS`
+  const prompt = substituteArguments(withInput, payload)
   const signal = AbortSignal.timeout(timeoutMs)
   try {
     const { text: answer } = await completeText(model, prompt, { system: PROMPT_HOOK_SYSTEM, maxTokens: 512, signal })

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -7,7 +7,7 @@ import { PassThrough } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import contextImports from '../extensions/context-imports.ts'
-import hooksExtension, { type HookRunner, interpretHookResult, isBackgroundHook, loadHooks, matchingCommands, runHookCommand, runPreToolUse, runUserPromptSubmit, timeoutMs } from '../extensions/hooks/index.ts'
+import hooksExtension, { type HookRunner, interpretHookResult, isBackgroundHook, loadHooks, matchingCommands, runHookCommand, runPreToolUse, runPromptHook, runUserPromptSubmit, sessionEndTimeoutMs, timeoutMs } from '../extensions/hooks/index.ts'
 import { setManagedSettingsPath } from '../extensions/internal/managed-settings.ts'
 import { setCompleteBackend } from '../extensions/internal/model-complete.ts'
 
@@ -2076,5 +2076,57 @@ describe('prompt-style decisions on Stop and PostToolUse', () => {
     script('review', { stdout: [JSON.stringify({ ok: false, reason: 'lint failed' })], code: 0 })
     const patch = (await ext.toolResult('bash', { input: { command: 'x' }, content: [{ type: 'text', text: 'out' }] })) as { content: Array<{ text?: string }> }
     expect(patch.content.some((block) => block.text?.includes('lint failed'))).toBe(true)
+  })
+})
+
+describe('hooks polish: interrupts, timeout defaults, prompt-hook contract', () => {
+  const withHooks = async (config: Record<string, unknown>) => {
+    writeSettings(hoisted.home, 'settings.json', config)
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('does not run Stop hooks when the turn ended on a user interrupt', async () => {
+    // Claude: Stop "does not run if the stoppage occurred due to a user interrupt";
+    // pi marks the aborted turn's final assistant message stopReason "aborted".
+    const ext = await withHooks({ Stop: [{ hooks: [{ command: 'stopper' }] }] })
+    await ext.agentEnd([{ role: 'assistant', content: [{ type: 'text', text: 'partial' }], stopReason: 'aborted' }])
+    expect(commandsRun()).toEqual([])
+  })
+
+  it('still runs Stop hooks for a normally completed turn', async () => {
+    const ext = await withHooks({ Stop: [{ hooks: [{ command: 'stopper' }] }] })
+    await ext.agentEnd([{ role: 'assistant', content: [{ type: 'text', text: 'done' }], stopReason: 'stop' }])
+    expect(commandsRun()).toEqual(['stopper'])
+  })
+
+  it('gives prompt hooks the documented 30s default and keeps command hooks at the noted 60s', () => {
+    // Claude defaults: 30 for prompt, 60 for agent; the 60s command default is
+    // pi-code's documented fail-closed divergence from Claude's 600.
+    expect(timeoutMs({ command: 'x', type: 'prompt' })).toBe(30_000)
+    expect(timeoutMs({ command: 'x', type: 'agent' })).toBe(60_000)
+    expect(timeoutMs({ command: 'x' })).toBe(60_000)
+  })
+
+  it('caps SessionEnd hooks at the documented 1.5s budget, raised by a declared timeout up to 60s', () => {
+    // Claude: "SessionEnd hooks share a 1.5-second budget; if your settings set a
+    // longer per-hook timeout, Claude Code raises the budget to match, up to 60s."
+    expect(sessionEndTimeoutMs({ command: 'x' })).toBe(1500)
+    expect(sessionEndTimeoutMs({ command: 'x', timeout: 10 })).toBe(10_000)
+    expect(sessionEndTimeoutMs({ command: 'x', timeout: 300 })).toBe(60_000)
+  })
+
+  it('appends the input JSON to a prompt hook that has no $ARGUMENTS placeholder', async () => {
+    // Claude: "If $ARGUMENTS is not present, input JSON is appended to the prompt."
+    let seenPrompt = ''
+    setCompleteBackend((async (_model: unknown, context: { messages: Array<{ content: string }> }) => {
+      seenPrompt = context.messages[0]?.content ?? ''
+      return { role: 'assistant', content: [{ type: 'text', text: '{}' }], api: 'x', provider: 'x', model: 'm', usage: {}, stopReason: 'stop', timestamp: 0 }
+    }) as never)
+    const result = await runPromptHook({ command: '', type: 'prompt', prompt: 'Should this stop?' }, { hook_event_name: 'Stop' }, { id: 'session-model' } as never, 5000)
+    expect(result.code).toBe(0)
+    expect(seenPrompt).toContain('Should this stop?')
+    expect(seenPrompt).toContain('"hook_event_name":"Stop"')
   })
 })


### PR DESCRIPTION
Phase-2 batch 5, the last target item from the conformance register (B3-M6, B3-M8, B3-M9).

- **Stop on interrupt**: Stop hooks no longer fire when the turn ended on a user interrupt (the aborted turn's final assistant message carries `stopReason: "aborted"`); previously a blocking Stop hook could restart the very turn the user killed.
- **Timeout defaults**: prompt hooks default to Claude's 30s (agent hooks 60s); SessionEnd hooks share Claude's 1.5-second budget, raised by a declared per-hook `timeout` up to 60s, so session exit, `/new` and `/resume` cannot stall on a slow hook. The 60s command-hook default remains the documented fail-closed divergence.
- **Prompt-hook contract**: the `model` override resolves against the available-model roster, and the input JSON is appended when `$ARGUMENTS` is absent, so the hook's model never evaluates blind.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change (all four behaviors red-first, incl. the both-ways interrupt guard)