### PR TITLE
Align MCP config handling with Claude Code docs

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -4,8 +4,8 @@ Connects Claude Code's MCP configuration and registers each server's tools in pi
 
 ## Configuration scopes
 
-- User: `~/.claude.json` (including the per-project `projects[cwd].mcpServers` local scope) and `~/.pi/agent/mcp.json`.
-- Project: `.mcp.json` and `.pi/mcp.json`, loaded once the project is approved; `enabledMcpjsonServers`/`disabledMcpjsonServers`/`enableAllProjectMcpServers` honored, with consent keys counted only from non-repo settings.
+- User: `~/.claude.json` (including the per-project `projects[cwd].mcpServers` local scope) and `~/.pi/agent/mcp.json`. The per-project `disabledMcpServers` toggle list mutes a user or plugin server without removing it.
+- Project: `.mcp.json` and `.pi/mcp.json`, loaded once the project is approved; `enabledMcpjsonServers`/`disabledMcpjsonServers`/`enableAllProjectMcpServers` honored, with consent keys counted only from non-repo settings. Precedence on a name clash is local over project over user.
 - Managed: a `managed-mcp.json` beside `managed-settings.json` takes exclusive control — only its servers load, every other scope and the approval flow suppressed; an empty file disables MCP.
 
 ## Policy
@@ -21,7 +21,7 @@ Managed `allowedMcpServers`/`deniedMcpServers` entries are typed and matched per
 
 ## Budgets
 
-Connect and per-call budgets honor `MCP_TIMEOUT`/`MCP_TOOL_TIMEOUT` over a 4-hour wall default, plus a 5-minute idle timeout that a progress notification resets (`CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT`, `0` disables).
+Connect and per-call budgets honor `MCP_TIMEOUT` (30s default) and `MCP_TOOL_TIMEOUT` (4-hour wall default), plus an idle timeout that a progress notification resets: 5 minutes for remote transports, 30 minutes for stdio (`CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` overrides, `0` disables). A per-server `timeout` of at least 1000 sets the wall budget and floors the idle window; lower values are ignored. Numeric env values accept `2e3` and `64_000` spellings.
 
 ## Surface
 

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -180,7 +180,9 @@ function resolvePlugin(home: string, cacheDir: string, marketplace: string, plug
   const root = path.join(cacheDir, marketplace, pluginDir, version)
   const manifest = readJson(path.join(root, '.claude-plugin', 'plugin.json'))
   const name = typeof manifest.name === 'string' && manifest.name.length > 0 ? manifest.name : pluginDir
-  const id = qualified.replace(/[^A-Za-z0-9]+/g, '-')
+  // Claude: "{id} is the plugin identifier with characters outside a-z, A-Z, 0-9,
+  // _, and - replaced by -", one dash per character, underscores kept.
+  const id = qualified.replace(/[^A-Za-z0-9_-]/g, '-')
   const userConfig = configs[qualified] ?? configs[pluginDir] ?? configs[name]
   return { name, root, dataDir: path.join(claudeConfigDir(home), 'plugins', 'data', id), manifest, ...(userConfig ? { userConfig } : {}) }
 }

--- a/extensions/mcp/config.ts
+++ b/extensions/mcp/config.ts
@@ -99,13 +99,34 @@ export function loadConfigFrom(files: string[]): Record<string, ServerConfig> {
  */
 export function loadUserScope(home: string, cwd: string): Record<string, ServerConfig> {
   const servers = loadConfigFrom(userConfigPaths(home))
+  Object.assign(servers, projectRecord(home, cwd).mcpServers ?? {})
+  return servers
+}
+
+/** The per-project record for `cwd` in ~/.claude.json, or an empty one when the file
+ * is missing, invalid, or has no entry for this project. */
+function projectRecord(home: string, cwd: string): { mcpServers?: Record<string, ServerConfig>; disabledMcpServers?: unknown } {
   try {
     const claudeJson = JSON.parse(fs.readFileSync(claudeJsonPath(home), 'utf-8'))
-    Object.assign(servers, claudeJson.projects?.[cwd]?.mcpServers ?? {})
+    return claudeJson.projects?.[cwd] ?? {}
   } catch {
-    // missing or invalid ~/.claude.json: the top-level user servers already loaded
+    return {}
   }
-  return servers
+}
+
+/** Names the local scope defines for this project. Claude's precedence is local over
+ * project over user, so a local name must also outrank a project .mcp.json entry. */
+export function localScopeServerNames(home: string, cwd: string): Set<string> {
+  return new Set(Object.keys(projectRecord(home, cwd).mcpServers ?? {}))
+}
+
+/** The per-project `disabledMcpServers` toggle list from ~/.claude.json: Claude's /mcp
+ * panel records a server toggled off here (an opt-out list for user-configured and
+ * plugin servers) and does not connect to it. The `enabledMcpServers` opt-in list
+ * covers only default-off built-in servers, which pi-code has none of. */
+export function disabledServerNames(home: string, cwd: string): Set<string> {
+  const listed = projectRecord(home, cwd).disabledMcpServers
+  return new Set(Array.isArray(listed) ? listed.filter((entry): entry is string => typeof entry === 'string') : [])
 }
 
 /** The mcpServers one plugin declares, parsed WITHOUT substitution: an inline map on
@@ -115,18 +136,22 @@ export function loadUserScope(home: string, cwd: string): Record<string, ServerC
  * the parse and headersHelper can be shielded. */
 function rawPluginServerEntries(plugin: InstalledPlugin): Record<string, unknown> {
   const declared = plugin.manifest.mcpServers
-  // An inline map of name -> config; an array is not a valid mcpServers map (it
-  // would register a server named '0'), so it falls through to the path branch.
+  // An inline map of name -> config. The manifest field is string|array|object per
+  // Claude's plugin reference; an array lists config file paths, merged in order.
   if (declared !== null && typeof declared === 'object' && !Array.isArray(declared)) {
     return { ...(declared as Record<string, unknown>) }
   }
-  const file = path.resolve(plugin.root, typeof declared === 'string' ? declared : '.mcp.json')
-  try {
-    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'))
-    return parsed.mcpServers ?? {}
-  } catch {
-    return {}
+  const paths = Array.isArray(declared) ? declared.filter((entry): entry is string => typeof entry === 'string') : [typeof declared === 'string' ? declared : '.mcp.json']
+  const servers: Record<string, unknown> = {}
+  for (const entry of paths) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(path.resolve(plugin.root, entry), 'utf-8'))
+      Object.assign(servers, parsed.mcpServers ?? {})
+    } catch {
+      // Malformed or missing JSON contributes no entries.
+    }
   }
+  return servers
 }
 
 /** Every string in the value mapped through `substitute`, arrays and objects walked. */
@@ -169,7 +194,8 @@ function substitutePathPluginVars(text: string, plugin: InstalledPlugin): string
  * tools alias as mcp__plugin_<plugin>_<server>__<tool> for hook matchers, as
  * Claude scopes them. */
 export function loadPluginServers(plugins: InstalledPlugin[], projectDir?: string): Record<string, ServerConfig> {
-  const fold = (name: string): string => name.replaceAll('-', '_')
+  // Claude keeps hyphens in the alias; only characters outside A-Za-z0-9_- fold to _.
+  const fold = (name: string): string => name.replace(/[^A-Za-z0-9_-]/g, '_')
   const servers: Record<string, ServerConfig> = {}
   for (const plugin of plugins) {
     for (const [name, config] of Object.entries(rawPluginServerEntries(plugin))) {

--- a/extensions/mcp/index.ts
+++ b/extensions/mcp/index.ts
@@ -43,11 +43,11 @@ import { installedPlugins } from '../internal/plugins.js'
 import { isProjectApproved, isProjectApprovedSilently } from '../internal/project-approval.js'
 import { repoRoot } from '../internal/project-root.js'
 import { claudeSettingsChain } from '../internal/settings-chain.js'
-import { loadConfigFrom, loadPluginServers, loadUserScope, projectConfigPaths, type ServerConfig, warnOnTypelessUrl } from './config.js'
+import { disabledServerNames, loadConfigFrom, loadPluginServers, loadUserScope, localScopeServerNames, projectConfigPaths, type ServerConfig, warnOnTypelessUrl } from './config.js'
 import { collectServerResourceEntries, listAllPrompts, listAllTools, type McpToolInfo, resourceServerFilter } from './listing.js'
 import { formatPromptCommandName, formatToolName, type McpContentBlock, type McpPromptInfo, mapContent, mapPromptArguments, normalizeSchema, promptMessageContent } from './mapping.js'
 import { applyServerPolicy, loadManagedMcpServers, type McpPolicy, mcpAllowDeny, projectServerPolicy, splitByPolicy } from './policy.js'
-import { type AuthUi, callRequestOptions, callTimeoutMs, connect, connectTimeoutMs, withTimeout } from './transport.js'
+import { type AuthUi, callRequestOptions, callTimeoutMs, connect, connectTimeoutMs, type ServerCallTuning, serverCallTuning, withTimeout } from './transport.js'
 
 export { managedSettingsPath, setManagedSettingsPath } from '../internal/managed-settings.js'
 // Re-exports for consumers: the module split keeps the extension's public surface
@@ -84,11 +84,19 @@ function authUiFor(ctx: ExtensionContext): AuthUi | undefined {
 export default async function mcpExtension(pi: ExtensionAPI) {
   const clients = new Map<string, Client>()
   const status = new Map<string, { state: string; tools: number }>()
+  // Config per server name, kept for call-time timeout tuning: the idle tier follows
+  // the transport kind, and a declared per-server timeout governs the wall budget.
+  const serverConfigs = new Map<string, ServerConfig>()
+  const callTuning = (name: string): ServerCallTuning => {
+    const config = serverConfigs.get(name)
+    return config ? serverCallTuning(config) : {}
+  }
   // Let other extensions (hooks' mcp_tool type) call a connected server's tool.
   setMcpToolCaller(async (server, tool, input) => {
     const client = clients.get(server)
     if (!client) throw new Error(`MCP server "${server}" is not connected`)
-    const result = await client.callTool({ name: tool, arguments: input }, undefined, callRequestOptions(callTimeoutMs()))
+    const tuning = callTuning(server)
+    const result = await client.callTool({ name: tool, arguments: input }, undefined, callRequestOptions(tuning.serverTimeoutMs ?? callTimeoutMs(), tuning))
     const text = mapContent(result.content as McpContentBlock[], result.structuredContent)
       .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
       .map((part) => part.text)
@@ -138,9 +146,9 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           // own default request timeout is 60s and would otherwise reject first. The outer
           // race uses the wall budget, never the idle window, so a progressing call is not
           // cut off at the idle timeout.
-          const declared = typeof config.timeout === 'number' && config.timeout >= 1000 ? config.timeout : undefined
-          const wall = declared ?? callTimeoutMs()
-          const result = await withTimeout(current.callTool({ name: tool.name, arguments: params as Record<string, unknown> }, undefined, callRequestOptions(wall)), wall, toolName)
+          const tuning = serverCallTuning(config)
+          const wall = tuning.serverTimeoutMs ?? callTimeoutMs()
+          const result = await withTimeout(current.callTool({ name: tool.name, arguments: params as Record<string, unknown> }, undefined, callRequestOptions(wall, tuning)), wall, toolName)
           const content = mapContent(result.content as McpContentBlock[], result.structuredContent)
           const details: { error?: string } = {}
           if (result.isError) {
@@ -193,7 +201,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
             const params: { name: string; arguments?: Record<string, string> } = { name: prompt.name }
             if (Object.keys(promptArgs).length > 0) params.arguments = promptArgs
             const wall = callTimeoutMs()
-            const result = await withTimeout(current.getPrompt(params, callRequestOptions(wall)), wall, commandName)
+            const result = await withTimeout(current.getPrompt(params, callRequestOptions(wall, callTuning(name))), wall, commandName)
             // The prompt drives a turn exactly the way a custom slash command does
             // (see commands.ts), carrying its image blocks through. A prompt that
             // yields no content is reported rather than sent as an empty turn.
@@ -280,7 +288,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
         const client = clients.get(server)
         if (!client) throw new Error(`MCP server "${server}" is not connected`)
         const wall = callTimeoutMs()
-        const result = await withTimeout(client.readResource({ uri }, callRequestOptions(wall)), wall, `read ${uri}`)
+        const result = await withTimeout(client.readResource({ uri }, callRequestOptions(wall, callTuning(server))), wall, `read ${uri}`)
         const blocks = (result.contents as Array<{ uri: string; text?: string; blob?: string; mimeType?: string }>).map((entry): McpContentBlock => {
           if (typeof entry.text === 'string') return { type: 'resource', resource: { uri: entry.uri, text: entry.text } }
           if (entry.blob && entry.mimeType?.startsWith('image/')) return { type: 'image', data: entry.blob, mimeType: entry.mimeType }
@@ -341,6 +349,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
       // Seed in config order before connecting: parallel connects settle in completion
       // order, and /mcp plus the session summary iterate the map's insertion order.
       status.set(name, { state: 'connecting', tools: 0 })
+      serverConfigs.set(name, config)
       pending.push([name, config])
     }
     await Promise.all(
@@ -424,9 +433,12 @@ export default async function mcpExtension(pi: ExtensionAPI) {
    * or whose transport dropped, without duplicate-name warnings. */
   async function connectNormalScopes(ctx: ExtensionContext, policy: McpPolicy, authUi?: AuthUi): Promise<void> {
     // Plugin servers merge under the user scope (plugins are user-installed);
-    // the user's own entry wins a name clash with a plugin's.
+    // the user's own entry wins a name clash with a plugin's. A server toggled off
+    // in ~/.claude.json's per-project disabledMcpServers list never connects.
     const pluginServers = loadPluginServers(installedPlugins(os.homedir()), repoRoot(ctx.cwd) ?? ctx.cwd)
-    const scoped = applyServerPolicy({ ...pluginServers, ...loadUserScope(os.homedir(), ctx.cwd) }, policy)
+    const disabled = disabledServerNames(os.homedir(), ctx.cwd)
+    const merged = Object.fromEntries(Object.entries({ ...pluginServers, ...loadUserScope(os.homedir(), ctx.cwd) }).filter(([name]) => !disabled.has(name)))
+    const scoped = applyServerPolicy(merged, policy)
     // Claude's precedence is project over user for a duplicate name. A project .mcp.json
     // server only outranks the user's own when it will actually connect (the user already
     // consented to it, or an approved project's), so a merely-present untrusted project
@@ -436,7 +448,12 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // The stored project decision, read without prompting: consent recorded inside
     // the project only counts once the project itself has been approved.
     const projectPolicy = projectServerPolicy(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
-    const { consented, gated } = splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), policy), projectPolicy)
+    const { consented: consentedRaw, gated } = splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), policy), projectPolicy)
+    // Claude's scope precedence is local over project: a name the local scope defines
+    // stays with the local (user-side) definition, so the project's entry is dropped
+    // here rather than allowed to shadow it.
+    const localNames = localScopeServerNames(os.homedir(), ctx.cwd)
+    const consented = Object.fromEntries(Object.entries(consentedRaw).filter(([name]) => !localNames.has(name)))
     const projectWinners = new Set(Object.keys(consented))
     const userServers = Object.fromEntries(Object.entries(scoped).filter(([name]) => !clients.has(name) && !projectWinners.has(name)))
     // The consented project servers carry no ordering dependency on the user scope:

--- a/extensions/mcp/mapping.ts
+++ b/extensions/mcp/mapping.ts
@@ -5,7 +5,6 @@
  */
 
 import { DEFAULT_MAX_BYTES } from '@earendil-works/pi-coding-agent'
-import { splitArgs } from '../internal/command-file.js'
 import { capForContext } from '../internal/output-guard.js'
 
 export function formatToolName(server: string, tool: string): string {

--- a/extensions/mcp/mapping.ts
+++ b/extensions/mcp/mapping.ts
@@ -12,12 +12,13 @@ export function formatToolName(server: string, tool: string): string {
   return `${server}_${tool}`.replaceAll('-', '_')
 }
 
-/** Claude exposes server prompts as /mcp__<server>__<prompt> slash commands. Both
- * names normalize like formatToolName, extended to spaces: dashes and spaces each
- * become an underscore. */
+/** Claude exposes server prompts as /mcp__<server>__<prompt> slash commands: any
+ * character in the server name outside A-Za-z0-9_- becomes an underscore (hyphens
+ * stay), and the prompt name is used as the server declares it. Divergence: pi
+ * dispatches commands on the first whitespace-delimited token, so whitespace in the
+ * prompt name also folds to an underscore or the command would be unreachable. */
 export function formatPromptCommandName(server: string, prompt: string): string {
-  const normalize = (name: string): string => name.replace(/[\s-]/g, '_')
-  return `mcp__${normalize(server)}__${normalize(prompt)}`
+  return `mcp__${server.replace(/[^A-Za-z0-9_-]/g, '_')}__${prompt.replace(/\s/g, '_')}`
 }
 
 export interface McpPromptArgumentInfo {
@@ -32,17 +33,16 @@ export interface McpPromptInfo {
   arguments?: McpPromptArgumentInfo[]
 }
 
-/** Claude passes prompt arguments space-separated after the command. Tokens map
- * positionally onto the declared arguments, split the way slash-command args are
- * (quoted runs stay together); the last declared argument absorbs any trailing
- * tokens so free text at the end is not silently dropped. Declared arguments with
- * no token are omitted, and the server enforces its own `required`. */
+/** Claude passes prompt arguments space-separated after the command and "splits the
+ * arguments on whitespace, so each argument is a single token": no quote handling,
+ * one token per declared argument, extra trailing tokens dropped. Declared arguments
+ * with no token are omitted, and the server enforces its own `required`. */
 export function mapPromptArguments(declared: ReadonlyArray<{ name: string }> | undefined, args: string): Record<string, string> {
-  const tokens = splitArgs(args)
+  const tokens = args.split(/\s+/).filter((token) => token !== '')
   const names = (declared ?? []).map((argument) => argument.name)
   const mapped: Record<string, string> = {}
   for (let index = 0; index < names.length && index < tokens.length; index++) {
-    mapped[names[index]] = index === names.length - 1 ? tokens.slice(index).join(' ') : tokens[index]
+    mapped[names[index]] = tokens[index]
   }
   return mapped
 }

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -17,38 +17,60 @@ import { FileOAuthProvider } from '../internal/mcp-oauth.js'
 import { expandCwd, interpolateEnv, type ServerConfig, type StdioServerConfig } from './config.js'
 import { runInteractiveOAuth, serializeInteractiveOAuth } from './oauth-flow.js'
 
-const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
+// Claude's MCP_TIMEOUT default: 30 seconds per connect attempt.
+const DEFAULT_CONNECT_TIMEOUT_MS = 30_000
 // Claude's MCP_TOOL_TIMEOUT default is effectively hours: the per-call wall-clock budget
 // is only a ceiling, and the idle timeout below is the real guard. 4h matches that model,
 // so a legitimately slow-but-progressing tool is not killed at the old 2 minutes.
 const DEFAULT_CALL_TIMEOUT_MS = 14_400_000
 // The idle timeout: the longest a call may go with no response or progress before it is
-// abandoned. Claude uses a separate idle guard (minutes) rather than the hours-long
-// wall-clock budget; the SDK resets this window on every progress notification.
+// abandoned. Claude uses a separate idle guard rather than the hours-long wall-clock
+// budget, defaulting to five minutes for remote transports and 30 minutes for stdio
+// servers; the SDK resets this window on every progress notification.
 const DEFAULT_CALL_IDLE_TIMEOUT_MS = 300_000
+const DEFAULT_STDIO_CALL_IDLE_TIMEOUT_MS = 1_800_000
+
+/** Claude's numeric env vars accept scientific notation and digit-separator spellings
+ * (2e3 as 2000, 64_000 as 64000). A non-numeric value is undefined, not zero. */
+function parseNumericEnv(raw: string): number | undefined {
+  const cleaned = raw.replaceAll('_', '')
+  if (cleaned.trim() === '') return undefined
+  const value = Number(cleaned)
+  return Number.isFinite(value) ? Math.floor(value) : undefined
+}
 
 /** A positive-integer env override, or the default when unset or unparseable. */
 function envTimeout(name: string, fallback: number): number {
   const raw = process.env[name]
   if (raw === undefined) return fallback
-  const value = Number.parseInt(raw, 10)
-  return Number.isInteger(value) && value > 0 ? value : fallback
+  const value = parseNumericEnv(raw)
+  return value !== undefined && value > 0 ? value : fallback
 }
 
 // Claude honors MCP_TIMEOUT (connect) and MCP_TOOL_TIMEOUT (per-call), both in ms.
 export const connectTimeoutMs = (): number => envTimeout('MCP_TIMEOUT', DEFAULT_CONNECT_TIMEOUT_MS)
 export const callTimeoutMs = (): number => envTimeout('MCP_TOOL_TIMEOUT', DEFAULT_CALL_TIMEOUT_MS)
 
+/** Per-server inputs to the idle-window choice: the transport kind picks the default
+ * tier, and a per-server `timeout` of at least 1000 also floors the idle window. */
+export interface ServerCallTuning {
+  stdio?: boolean
+  serverTimeoutMs?: number
+}
+
 /** The idle timeout in ms: the longest a call may go with no response or progress before
- * it is abandoned, overridable by CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT, with 0 disabling it
- * (leaving only the wall-clock budget). Unlike envTimeout, an explicit 0 is honored as
- * "disabled" rather than falling back to the default. */
-function idleTimeoutMs(): number {
+ * it is abandoned. Defaults to Claude's tiers (five minutes remote, 30 minutes stdio),
+ * overridable by CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT, with 0 disabling it (leaving only
+ * the wall-clock budget). Unlike envTimeout, an explicit 0 is honored as "disabled"
+ * rather than falling back to the default. A per-server timeout of at least 1000 floors
+ * the enabled window, so a server granted a long wall budget is not idled out earlier. */
+function idleTimeoutMs(tuning: ServerCallTuning): number {
   const raw = process.env.CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT
-  if (raw === undefined) return DEFAULT_CALL_IDLE_TIMEOUT_MS
-  const value = Number.parseInt(raw, 10)
-  if (value === 0) return 0
-  return Number.isInteger(value) && value > 0 ? value : DEFAULT_CALL_IDLE_TIMEOUT_MS
+  const override = raw === undefined ? undefined : parseNumericEnv(raw)
+  if (override === 0) return 0
+  const base = override !== undefined && override > 0 ? override : tuning.stdio ? DEFAULT_STDIO_CALL_IDLE_TIMEOUT_MS : DEFAULT_CALL_IDLE_TIMEOUT_MS
+  const floor = tuning.serverTimeoutMs !== undefined && tuning.serverTimeoutMs >= 1000 ? tuning.serverTimeoutMs : 0
+  return Math.max(base, floor)
 }
 
 /** The SDK RequestOptions for a call under pi's two-tier timeout: a wall-clock ceiling and,
@@ -60,10 +82,18 @@ function idleTimeoutMs(): number {
  * wall budget, only the wall budget applies. The outer withTimeout race is a wall-clock
  * backstop and must be raced against `wall`, never the idle window, so a legitimately
  * progressing call is not cut off. */
-export function callRequestOptions(wall: number): { timeout: number; resetTimeoutOnProgress?: boolean; maxTotalTimeout?: number; onprogress?: () => void } {
-  const idle = idleTimeoutMs()
+export function callRequestOptions(wall: number, tuning: ServerCallTuning = {}): { timeout: number; resetTimeoutOnProgress?: boolean; maxTotalTimeout?: number; onprogress?: () => void } {
+  const idle = idleTimeoutMs(tuning)
   if (idle === 0 || idle >= wall) return { timeout: wall }
   return { timeout: idle, resetTimeoutOnProgress: true, maxTotalTimeout: wall, onprogress: () => {} }
+}
+
+/** The tuning one server's config yields: its transport kind, and its declared
+ * per-server timeout. Per Claude, timeout values below 1000 are ignored and fall
+ * through to MCP_TOOL_TIMEOUT. */
+export function serverCallTuning(config: ServerConfig): ServerCallTuning {
+  const declared = typeof config.timeout === 'number' && config.timeout >= 1000 ? config.timeout : undefined
+  return { stdio: isStdio(config), ...(declared !== undefined ? { serverTimeoutMs: declared } : {}) }
 }
 
 /** Claude reports a config entry that has a url but no type as an error; pi-code

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -68,7 +68,8 @@ function idleTimeoutMs(tuning: ServerCallTuning): number {
   const raw = process.env.CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT
   const override = raw === undefined ? undefined : parseNumericEnv(raw)
   if (override === 0) return 0
-  const base = override !== undefined && override > 0 ? override : tuning.stdio ? DEFAULT_STDIO_CALL_IDLE_TIMEOUT_MS : DEFAULT_CALL_IDLE_TIMEOUT_MS
+  const tierDefault = tuning.stdio ? DEFAULT_STDIO_CALL_IDLE_TIMEOUT_MS : DEFAULT_CALL_IDLE_TIMEOUT_MS
+  const base = override !== undefined && override > 0 ? override : tierDefault
   const floor = tuning.serverTimeoutMs !== undefined && tuning.serverTimeoutMs >= 1000 ? tuning.serverTimeoutMs : 0
   return Math.max(base, floor)
 }

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -470,6 +470,56 @@ describe('mcp startup config scoping', () => {
     expect(hoisted.transports[0].options.command).toBe('proj-server')
   })
 
+  it('lets a local-scope server outrank a consented project server of the same name', async () => {
+    // Claude's scope precedence is local over project over user: the per-project
+    // entry in ~/.claude.json wins the name clash with the project's .mcp.json.
+    withTools([{ name: 'query' }])
+    const harness = await setup({ project: { shared: { command: 'proj-server' } } })
+    writeFileSync(join(harness.home, '.claude.json'), JSON.stringify({ projects: { [harness.cwd]: { mcpServers: { shared: { command: 'local-server' } } } } }))
+    mkdirSync(join(harness.home, '.claude'), { recursive: true })
+    writeFileSync(join(harness.home, '.claude', 'settings.json'), JSON.stringify({ enabledMcpjsonServers: ['shared'] }))
+    await harness.sessionStart(true)
+
+    expect(hoisted.transports).toHaveLength(1)
+    expect(hoisted.transports[0].options.command).toBe('local-server')
+  })
+
+  it('never connects a user server listed in the per-project disabledMcpServers toggle', async () => {
+    // Claude records the /mcp panel's off toggle per project in ~/.claude.json under
+    // disabledMcpServers, an opt-out list for user-configured and plugin servers.
+    withTools([{ name: 'query' }])
+    const harness = await setup()
+    writeFileSync(
+      join(harness.home, '.claude.json'),
+      JSON.stringify({
+        mcpServers: { muted: { command: 'muted-server' }, live: { command: 'live-server' } },
+        projects: { [harness.cwd]: { disabledMcpServers: ['muted'] } },
+      }),
+    )
+    await harness.sessionStart()
+
+    expect(hoisted.transports).toHaveLength(1)
+    expect(hoisted.transports[0].options.command).toBe('live-server')
+  })
+
+  it('scopes the disabledMcpServers toggle to its own project', async () => {
+    // The toggle is recorded per project; another project's entry must not mute
+    // this session's server.
+    withTools([{ name: 'query' }])
+    const harness = await setup()
+    writeFileSync(
+      join(harness.home, '.claude.json'),
+      JSON.stringify({
+        mcpServers: { muted: { command: 'muted-server' } },
+        projects: { '/some/other/project': { disabledMcpServers: ['muted'] } },
+      }),
+    )
+    await harness.sessionStart()
+
+    expect(hoisted.transports).toHaveLength(1)
+    expect(hoisted.transports[0].options.command).toBe('muted-server')
+  })
+
   it('connects project config only once across repeated sessions', async () => {
     withTools([{ name: 'query' }])
     const harness = await setup({ project: { proj: { command: 'proj-server' } } })
@@ -1048,6 +1098,20 @@ describe('mcp tool execution', () => {
     expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 5000 })
   })
 
+  it('accepts scientific-notation and digit-separator spellings of MCP_TOOL_TIMEOUT', async () => {
+    // Claude's numeric env vars "accept scientific notation and digit-separator
+    // spellings", reading 2e3 as 2000 and 64_000 as 64000.
+    setEnv('MCP_TOOL_TIMEOUT', '64_000')
+    hoisted.control.callTool = () => new Promise<CallResult>(() => {})
+    const harness = await registerOne()
+    vi.useFakeTimers()
+
+    const pending = harness.tools[0].execute('call-1', {})
+    const assertion = expect(pending).rejects.toThrow('timed out after 64000ms')
+    await vi.advanceTimersByTimeAsync(64_000)
+    await assertion
+  })
+
   it('passes the two-tier timeout to the SDK so its shorter default cannot fire first', async () => {
     hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
     const harness = await registerOne()
@@ -1055,8 +1119,9 @@ describe('mcp tool execution', () => {
     await harness.tools[0].execute('call-1', {})
 
     // The SDK gets the idle window as its per-quiet-period deadline (reset on progress),
-    // capped at the 4h wall; its own 60s default can no longer fire first.
-    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 300_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
+    // capped at the 4h wall; its own 60s default can no longer fire first. registerOne
+    // is a stdio server, so the idle tier is Claude's 30-minute stdio window.
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 1_800_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
   })
 })
 
@@ -1066,15 +1131,26 @@ describe('mcp tool-call idle timeout', () => {
     return setupStarted({ user: { srv: config } })
   }
 
-  it('layers the default 300s idle window under the 4h wall budget, resetting on progress', async () => {
+  it('gives a stdio server the 30-minute idle window under the 4h wall budget, resetting on progress', async () => {
     hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
     const harness = await registerGo()
 
     await harness.tools[0].execute('c1', {})
 
-    // The idle window is the SDK's per-quiet-period deadline, reset on every progress
-    // notification; maxTotalTimeout caps the wall clock; onprogress is required so the
-    // server addresses progress here and the SDK resets the timer on it.
+    // Claude: the idle window "defaults to five minutes for HTTP, SSE, WebSocket...
+    // and to 30 minutes for stdio servers". The idle window is the SDK's
+    // per-quiet-period deadline, reset on every progress notification; maxTotalTimeout
+    // caps the wall clock; onprogress is required so the server addresses progress
+    // here and the SDK resets the timer on it.
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 1_800_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
+  })
+
+  it('gives a remote server the 5-minute idle window under the 4h wall budget', async () => {
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
+    const harness = await registerGo({ type: 'http', url: 'https://mcp.example.com/mcp' })
+
+    await harness.tools[0].execute('c1', {})
+
     expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 300_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
   })
 
@@ -1099,15 +1175,39 @@ describe('mcp tool-call idle timeout', () => {
     expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 14_400_000 })
   })
 
-  it('keeps a per-server timeout as the wall-clock ceiling above the idle window', async () => {
-    // A 10 min per-server budget, wider than the 5 min idle window: the idle timeout still
-    // guards each quiet period, and the per-server value caps the wall clock.
+  it('collapses to a plain wall timeout when the per-server budget sits under the idle window', async () => {
+    // A 10 min per-server budget under the 30 min stdio idle window: the idle window
+    // can never fire before the wall, so only the wall budget applies.
     hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
     const harness = await registerGo({ command: 'x', timeout: 600_000 })
 
     await harness.tools[0].execute('c1', {})
 
-    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 300_000, resetTimeoutOnProgress: true, maxTotalTimeout: 600_000, onprogress: expect.any(Function) })
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 600_000 })
+  })
+
+  it('floors an overridden idle window at a per-server timeout of at least 1000', async () => {
+    // Claude: "A per-server timeout of at least 1000 also acts as a floor on the idle
+    // timeout". The 60s override is lifted to the 10 min per-server budget, which
+    // equals the wall, so only the wall budget applies.
+    setEnv('CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT', '60000')
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
+    const harness = await registerGo({ type: 'http', url: 'https://mcp.example.com/mcp', timeout: 600_000 })
+
+    await harness.tools[0].execute('c1', {})
+
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 600_000 })
+  })
+
+  it('ignores a per-server timeout below 1000, falling through to the MCP_TOOL_TIMEOUT wall', async () => {
+    // Claude: per-server timeout "Values below 1000 are ignored and fall through to
+    // MCP_TOOL_TIMEOUT", and such a value places no floor on the idle window.
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'ok' }] })
+    const harness = await registerGo({ command: 'x', timeout: 500 })
+
+    await harness.tools[0].execute('c1', {})
+
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 1_800_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
   })
 
   it('uses a plain wall timeout when a per-server budget is tighter than the idle window', async () => {
@@ -1168,20 +1268,34 @@ describe('mcp failure reporting', () => {
     expect(await statusLinesOf(harness)).toEqual(['broken: failed: plain string failure (0 tools)'])
   })
 
-  it('times out a connect that never settles after the connect budget', async () => {
+  it('times out a connect that never settles after the 30s default connect budget', async () => {
+    // Claude's MCP_TIMEOUT default is 30 seconds.
     hoisted.control.connect = () => new Promise<void>(() => {})
     vi.useFakeTimers()
 
     const harness = await setup({ user: { hung: { command: 'sleep' } } })
     const booting = harness.sessionStart()
-    await vi.advanceTimersByTimeAsync(10_000)
+    await vi.advanceTimersByTimeAsync(30_000)
     await booting
 
-    expect(await statusLinesOf(harness)).toEqual(['hung: failed: connect hung timed out after 10000ms (0 tools)'])
+    expect(await statusLinesOf(harness)).toEqual(['hung: failed: connect hung timed out after 30000ms (0 tools)'])
   })
 
   it('honors MCP_TIMEOUT for the connect budget', async () => {
     setEnv('MCP_TIMEOUT', '2000')
+    hoisted.control.connect = () => new Promise<void>(() => {})
+    vi.useFakeTimers()
+
+    const harness = await setup({ user: { hung: { command: 'sleep' } } })
+    const booting = harness.sessionStart()
+    await vi.advanceTimersByTimeAsync(2_000)
+    await booting
+
+    expect(await statusLinesOf(harness)).toEqual(['hung: failed: connect hung timed out after 2000ms (0 tools)'])
+  })
+
+  it('accepts a scientific-notation MCP_TIMEOUT spelling, reading 2e3 as 2000', async () => {
+    setEnv('MCP_TIMEOUT', '2e3')
     hoisted.control.connect = () => new Promise<void>(() => {})
     vi.useFakeTimers()
 
@@ -1202,7 +1316,7 @@ describe('mcp failure reporting', () => {
 
     const harness = await setup({ user: { slow: { command: 'x' } } })
     const booting = harness.sessionStart()
-    await vi.advanceTimersByTimeAsync(10_000)
+    await vi.advanceTimersByTimeAsync(30_000)
     resolveConnect?.() // the server finishes connecting after the deadline
     await booting
 
@@ -1215,10 +1329,10 @@ describe('mcp failure reporting', () => {
 
     const harness = await setup({ user: { slow: { command: 'x' } } })
     const booting = harness.sessionStart()
-    await vi.advanceTimersByTimeAsync(10_000)
+    await vi.advanceTimersByTimeAsync(30_000)
     await booting
 
-    expect(await statusLinesOf(harness)).toEqual(['slow: failed: list tools slow timed out after 10000ms (0 tools)'])
+    expect(await statusLinesOf(harness)).toEqual(['slow: failed: list tools slow timed out after 30000ms (0 tools)'])
   })
 
   it('keeps connecting the remaining servers after one fails', async () => {
@@ -1477,9 +1591,10 @@ describe('small MCP parity', () => {
     expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 1500 })
 
     // Below Claude's documented 1s minimum the per-server value is ignored, so the call
-    // falls back to the global default, whose SDK deadline is the idle window under the 4h wall.
+    // falls back to the global default, whose SDK deadline is the idle window (the
+    // 30-minute stdio tier) under the 4h wall.
     await harness.tools[1].execute('c2', {})
-    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 300_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
+    expect(hoisted.callOptions.at(-1)).toEqual({ timeout: 1_800_000, resetTimeoutOnProgress: true, maxTotalTimeout: 14_400_000, onprogress: expect.any(Function) })
   })
 
   it('expands environment variables in cwd', async () => {
@@ -1717,11 +1832,12 @@ describe('mcp prompts as slash commands', () => {
     hoisted.control.listPrompts = async () => ({ prompts })
   }
 
-  it('registers a normalized /mcp__server__prompt command for each advertised prompt', async () => {
+  it('registers a /mcp__server__prompt command per advertised prompt, keeping the declared name', async () => {
+    // Claude uses the prompt name as the server declares it, so the hyphen stays.
     withPrompts([{ name: 'code-review', description: 'Review code' }])
     const harness = await setupStarted({ user: { demo: { command: 'x' } } })
 
-    expect(harness.commandNames()).toContain('mcp__demo__code_review')
+    expect(harness.commandNames()).toContain('mcp__demo__code-review')
   })
 
   it('does not list prompts from a server that lacks the prompts capability', async () => {
@@ -1815,7 +1931,9 @@ describe('mcp prompts as slash commands', () => {
   })
 
   it('skips a second same-server prompt whose name normalizes onto one already taken', async () => {
-    withPrompts([{ name: 'deploy-prod' }, { name: 'deploy_prod' }])
+    // Hyphens no longer fold, so the collision surface is whitespace (pi's dispatch
+    // constraint): two prompts differing only by space vs underscore clash.
+    withPrompts([{ name: 'deploy prod' }, { name: 'deploy_prod' }])
     const harness = await setupStarted({ user: { demo: { command: 'x' } } })
 
     expect(harness.commandNames().filter((n) => n === 'mcp__demo__deploy_prod')).toEqual(['mcp__demo__deploy_prod'])

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -367,23 +367,35 @@ describe('mcp adapter helpers', () => {
 })
 
 describe('mcp prompt command naming', () => {
-  it('builds mcp__server__prompt with dashes and spaces normalized to underscores', () => {
+  it('keeps hyphens in the server name, folding only characters outside A-Za-z0-9_-', () => {
+    // Claude: "replaces any character in the server name outside A-Z, a-z, 0-9, _,
+    // and - with _, and uses the prompt name as the server declares it".
     expect(formatPromptCommandName('demo', 'greet')).toBe('mcp__demo__greet')
-    expect(formatPromptCommandName('my-server', 'code review')).toBe('mcp__my_server__code_review')
+    expect(formatPromptCommandName('my-server', 'pr-review')).toBe('mcp__my-server__pr-review')
+    // Per-character replacement: each out-of-class character becomes its own underscore.
+    expect(formatPromptCommandName('my server', 'greet')).toBe('mcp__my_server__greet')
+    expect(formatPromptCommandName('a!b', 'x')).toBe('mcp__a_b__x')
+  })
+
+  it('keeps the prompt name as declared, except whitespace, which pi command dispatch cannot carry', () => {
+    // Divergence: Claude uses the prompt name verbatim; pi dispatches commands on the
+    // first whitespace-delimited token, so a space would make the command unreachable.
+    expect(formatPromptCommandName('demo', 'code review')).toBe('mcp__demo__code_review')
   })
 })
 
 describe('mcp prompt argument mapping', () => {
-  it('maps space-separated tokens positionally onto the declared arguments', () => {
+  it('maps whitespace-separated tokens positionally onto the declared arguments', () => {
     expect(mapPromptArguments([{ name: 'a' }, { name: 'b' }], 'one two')).toEqual({ a: 'one', b: 'two' })
   })
 
-  it('keeps a quoted run together as one value, like slash-command args', () => {
-    expect(mapPromptArguments([{ name: 'a' }, { name: 'b' }], '"one two" three')).toEqual({ a: 'one two', b: 'three' })
+  it('treats a quoted run as plain tokens: Claude splits on whitespace, one token per argument', () => {
+    // Claude: "splits the arguments on whitespace, so each argument is a single token".
+    expect(mapPromptArguments([{ name: 'a' }, { name: 'b' }], '"one two" three')).toEqual({ a: '"one', b: 'two"' })
   })
 
-  it('folds extra trailing tokens into the last declared argument so no input is dropped', () => {
-    expect(mapPromptArguments([{ name: 'a' }, { name: 'b' }], 'one two three four')).toEqual({ a: 'one', b: 'two three four' })
+  it('gives each declared argument exactly one token, dropping extra trailing tokens', () => {
+    expect(mapPromptArguments([{ name: 'a' }, { name: 'b' }], 'one two three four')).toEqual({ a: 'one', b: 'two' })
   })
 
   it('omits declared arguments with no token, and maps nothing when none are declared', () => {
@@ -465,5 +477,27 @@ describe('plugin server substitution safety', () => {
     expect(api.headers.Authorization).toBe('Bearer sekrit')
     expect(api.headersHelper).toMatch(/\/helper\.sh$/)
     expect(api.headersHelper).not.toContain('${CLAUDE_PLUGIN_ROOT}')
+  })
+
+  it('keeps hyphens in the tool alias prefix, folding only characters outside A-Za-z0-9_-', async () => {
+    // Claude's plugin tool names keep the plugin and server names' hyphens; only
+    // characters outside A-Za-z0-9_- become underscores.
+    const { loadPluginServers } = await import('../extensions/mcp/index.ts')
+    const withName = { ...(plugin({ 'db-tools': { command: 'srv' } }) as { name: string }), name: 'my-plugin' }
+    const servers = loadPluginServers([withName as never], '/work/repo')
+    expect((servers['db-tools'] as { aliasPrefix: string }).aliasPrefix).toBe('mcp__plugin_my-plugin_db-tools__')
+  })
+
+  it('loads a manifest mcpServers array as a list of config file paths, merging all of them', async () => {
+    // plugins-reference: mcpServers is string|array|object; the array form lists
+    // MCP config paths.
+    const { loadPluginServers } = await import('../extensions/mcp/index.ts')
+    const base = plugin() as { name: string; root: string; manifest: Record<string, unknown> }
+    writeFileSync(join(base.root, 'a.json'), JSON.stringify({ mcpServers: { alpha: { command: 'a-srv' } } }))
+    writeFileSync(join(base.root, 'b.json'), JSON.stringify({ mcpServers: { beta: { command: 'b-srv' } } }))
+    base.manifest = { mcpServers: ['./a.json', './b.json'] }
+    const servers = loadPluginServers([base as never], '/work/repo')
+    expect((servers.alpha as { command: string }).command).toBe('a-srv')
+    expect((servers.beta as { command: string }).command).toBe('b-srv')
   })
 })

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -60,6 +60,17 @@ describe('installedPlugins', () => {
     expect(plugins[0].dataDir).toBe(join(h, '.claude', 'plugins', 'data', 'formatter-community'))
   })
 
+  it('keeps underscores and hyphens in the data-dir id, folding only characters outside a-zA-Z0-9_-', () => {
+    // plugins-reference: "{id} is the plugin identifier with characters outside a-z,
+    // A-Z, 0-9, _, and - replaced by -".
+    const h = home()
+    install(h, 'my-market', 'my_plugin', '1.0.0')
+    enable(h, { 'my_plugin@my-market': true })
+
+    const plugins = installedPlugins(h, [])
+    expect(plugins[0].dataDir).toBe(join(h, '.claude', 'plugins', 'data', 'my_plugin-my-market'))
+  })
+
   it('skips plugins that are not enabled or explicitly disabled', () => {
     const h = home()
     install(h, 'community', 'formatter', '1.0.0')


### PR DESCRIPTION
Closes nothing; part of the docs-conformance campaign.

## Timeouts (extensions/mcp/transport.ts)
- Default connect timeout is now 30s (Claude's MCP_TIMEOUT default), up from 10s.
- The call idle window is tiered per transport: 5 minutes for remote servers, 30 minutes for stdio, matching Claude's documented defaults.
- A per-server `timeout` of at least 1000 acts as a floor on the idle window; values below 1000 stay ignored.
- `MCP_TIMEOUT`, `MCP_TOOL_TIMEOUT`, and `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` accept scientific-notation and digit-separator spellings (`2e3`, `64_000`).
- Per-server tuning now reaches the hooks `mcp_tool` call path, prompts, and resource reads (previously only namespaced tool calls).

## Scopes and toggles (extensions/mcp/config.ts, index.ts)
- A name defined in the local scope (`projects[cwd].mcpServers` in `~/.claude.json`) now outranks a consented project `.mcp.json` server, completing Claude's local > project > user precedence.
- The per-project `disabledMcpServers` toggle list is honored: a listed user or plugin server never connects. (`enabledMcpServers` covers only default-off built-in servers, which pi-code has none of.)

## Plugin config (config.ts, internal/plugins.ts)
- The manifest `mcpServers` array form (a list of config file paths) now loads and merges all files.
- Plugin tool alias prefixes keep hyphens; only characters outside `A-Za-z0-9_-` fold to `_`.
- The `${CLAUDE_PLUGIN_DATA}` id keeps underscores and hyphens, replacing each out-of-class character with `-` per the plugins reference.

## Prompt commands (mapping.ts)
- `/mcp__server__prompt` names keep hyphens: server-name characters outside `A-Za-z0-9_-` fold to `_`, and the prompt name is used as declared (whitespace still folds, since pi dispatches commands on the first token).
- Prompt arguments split on whitespace with one token per declared argument, per the documented contract (no quote grouping, no trailing-token absorption).

Docs: `docs/mcp.md` updated to the new budgets, toggle list, and precedence.

All changes are covered by tests that failed before the change (17 red tests across `tests/mcp.test.ts`, `tests/mcp-more.test.ts`, `tests/plugins.test.ts`).