### PR TITLE
Align MCP transport auth and session context with Claude docs

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -16,8 +16,9 @@ Managed `allowedMcpServers`/`deniedMcpServers` entries are typed and matched per
 
 - stdio, HTTP (streamable with SSE fallback), SSE, and WebSocket by `type`. WebSocket is url-only: any `headers`/`bearerToken`/`headersHelper` on a ws server is ignored with a warning (the SDK transport carries no headers; Claude documents header auth for ws, so authenticated ws servers cannot be used yet).
 - `${VAR}` / `${VAR:-default}` expansion in values.
-- A `headersHelper` command's stdout JSON merges into the transport headers (http/sse).
-- Bearer tokens, or OAuth for remote servers: browser login on 401 after a confirm, CSRF-guarded loopback callback, tokens under `~/.pi/agent/mcp-oauth`, silent refresh later.
+- Stdio servers get `CLAUDE_PROJECT_DIR` (and `CLAUDE_PLUGIN_ROOT` for a plugin's server) in their environment; every client answers `roots/list` with the session's launch directory.
+- A `headersHelper` command's stdout JSON merges into the transport headers (http/sse). The helper runs with `CLAUDE_CODE_MCP_SERVER_NAME` and `CLAUDE_CODE_MCP_SERVER_URL` set (credential-expanded url parts shown as `REDACTED`); a project- or plugin-supplied helper runs without credential-named variables (`TOKEN`/`SECRET`/`PASSWORD`/`KEY`/`AUTH`).
+- Bearer tokens, or OAuth for remote servers: browser login on 401/403 after a confirm, CSRF-guarded loopback callback, tokens under `~/.pi/agent/mcp-oauth`, silent refresh later. A configured `Authorization` header (static, bearer, or helper-supplied) is the server's authentication: auth failures report as failed connections with no OAuth fallback.
 
 ## Budgets
 

--- a/extensions/mcp/config.ts
+++ b/extensions/mcp/config.ts
@@ -20,6 +20,10 @@ export interface StdioServerConfig {
   timeout?: number
   /** Plugin servers alias their tools mcp__plugin_<plugin>_<server>__<tool>. */
   aliasPrefix?: string
+  /** Root of the plugin that supplied this server; exported as CLAUDE_PLUGIN_ROOT. */
+  pluginRoot?: string
+  /** Loaded from the project scope, whose helpers run credential-stripped. */
+  projectScope?: boolean
 }
 
 export interface HttpServerConfig {
@@ -35,6 +39,10 @@ export interface HttpServerConfig {
   timeout?: number
   /** Plugin servers alias their tools mcp__plugin_<plugin>_<server>__<tool>. */
   aliasPrefix?: string
+  /** Root of the plugin that supplied this server; exported as CLAUDE_PLUGIN_ROOT. */
+  pluginRoot?: string
+  /** Loaded from the project scope, whose helpers run credential-stripped. */
+  projectScope?: boolean
 }
 
 export type ServerConfig = StdioServerConfig | HttpServerConfig
@@ -200,7 +208,7 @@ export function loadPluginServers(plugins: InstalledPlugin[], projectDir?: strin
   for (const plugin of plugins) {
     for (const [name, config] of Object.entries(rawPluginServerEntries(plugin))) {
       const substituted = substitutedPluginServer(plugin, name, config, projectDir)
-      if (substituted) servers[name] = { ...substituted, aliasPrefix: `mcp__plugin_${fold(plugin.name)}_${fold(name)}__` }
+      if (substituted) servers[name] = { ...substituted, aliasPrefix: `mcp__plugin_${fold(plugin.name)}_${fold(name)}__`, pluginRoot: plugin.root }
     }
   }
   return servers

--- a/extensions/mcp/index.ts
+++ b/extensions/mcp/index.ts
@@ -20,8 +20,9 @@
  * environment plus its own `env` block, not the whole process environment.
  *
  * Servers advertising the `prompts` capability get their prompts registered as Claude's
- * /mcp__<server>__<prompt> slash commands (names normalized dashes/spaces to underscores,
- * args space-separated and mapped positionally); the prompt result drives a turn via
+ * /mcp__<server>__<prompt> slash commands (server-name characters outside A-Za-z0-9_-
+ * fold to underscores, args split on whitespace and mapped positionally, one token
+ * per declared argument); the prompt result drives a turn via
  * sendUserMessage, exactly how custom slash commands do. Servers advertising `resources`
  * make the global list_mcp_resources / read_mcp_resource tools available, mirroring
  * Claude's automatic resource tools. Resource and prompt output rides the same
@@ -47,7 +48,7 @@ import { disabledServerNames, loadConfigFrom, loadPluginServers, loadUserScope, 
 import { collectServerResourceEntries, listAllPrompts, listAllTools, type McpToolInfo, resourceServerFilter } from './listing.js'
 import { formatPromptCommandName, formatToolName, type McpContentBlock, type McpPromptInfo, mapContent, mapPromptArguments, normalizeSchema, promptMessageContent } from './mapping.js'
 import { applyServerPolicy, loadManagedMcpServers, type McpPolicy, mcpAllowDeny, projectServerPolicy, splitByPolicy } from './policy.js'
-import { type AuthUi, callRequestOptions, callTimeoutMs, connect, connectTimeoutMs, type ServerCallTuning, serverCallTuning, withTimeout } from './transport.js'
+import { type AuthUi, callRequestOptions, callTimeoutMs, connect, connectTimeoutMs, type ServerCallTuning, type SessionDirs, serverCallTuning, withTimeout } from './transport.js'
 
 export { managedSettingsPath, setManagedSettingsPath } from '../internal/managed-settings.js'
 // Re-exports for consumers: the module split keeps the extension's public surface
@@ -87,6 +88,9 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   // Config per server name, kept for call-time timeout tuning: the idle tier follows
   // the transport kind, and a declared per-server timeout governs the wall budget.
   const serverConfigs = new Map<string, ServerConfig>()
+  // The session's directories, set at session_start before any connect: the launch
+  // directory answers roots/list, the project root feeds CLAUDE_PROJECT_DIR.
+  let sessionDirs: SessionDirs | undefined
   const callTuning = (name: string): ServerCallTuning => {
     const config = serverConfigs.get(name)
     return config ? serverCallTuning(config) : {}
@@ -356,7 +360,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
       pending.map(async ([name, config]) => {
         warnOnTypelessUrl(name, config)
         try {
-          const client = await connect(name, config, authUi)
+          const client = await connect(name, config, authUi, sessionDirs)
           clients.set(name, client)
           const tools = await withTimeout(listAllTools(client), connectTimeoutMs(), `list tools ${name}`)
           registerTools(name, config, tools)
@@ -448,7 +452,10 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // The stored project decision, read without prompting: consent recorded inside
     // the project only counts once the project itself has been approved.
     const projectPolicy = projectServerPolicy(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
-    const { consented: consentedRaw, gated } = splitByPolicy(applyServerPolicy(loadConfigFrom(projectConfigPaths(ctx.cwd)), policy), projectPolicy)
+    // Tag the scope on each project server: a repository-supplied headersHelper runs
+    // with credential variables stripped, unlike a user-scope one.
+    const projectServers = Object.fromEntries(Object.entries(loadConfigFrom(projectConfigPaths(ctx.cwd))).map(([name, config]) => [name, { ...config, projectScope: true }]))
+    const { consented: consentedRaw, gated } = splitByPolicy(applyServerPolicy(projectServers, policy), projectPolicy)
     // Claude's scope precedence is local over project: a name the local scope defines
     // stays with the local (user-side) definition, so the project's entry is dropped
     // here rather than allowed to shadow it.
@@ -480,6 +487,9 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // withdrawn tool keeps its registration and surfaces the server's own error), which
     // is why serverToolCount reads from `registered` to recover the true count here.
     status.clear()
+    // Claude answers roots/list with the session's launch directory and exports the
+    // project root as CLAUDE_PROJECT_DIR to stdio servers; both derive from ctx.cwd.
+    sessionDirs = { projectDir: repoRoot(ctx.cwd) ?? ctx.cwd, launchDir: ctx.cwd }
     const authUi = authUiFor(ctx)
     // The allow/deny lists filter every scope, including a managed-mcp.json set. They
     // merge from managed settings plus the trust-gated settings chain, as Claude

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -5,6 +5,7 @@
  */
 
 import { execFile } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
 // SSE is deprecated in favour of Streamable HTTP, but the SDK notes servers still on
 // the old spec exist, so this stays as a fallback for the migration period.
 import { type OAuthClientProvider, UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
@@ -13,8 +14,9 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js' // 
 import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/websocket.js'
+import { ListRootsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { FileOAuthProvider } from '../internal/mcp-oauth.js'
-import { expandCwd, interpolateEnv, type ServerConfig, type StdioServerConfig } from './config.js'
+import { expandCwd, type HttpServerConfig, interpolateEnv, type ServerConfig, type StdioServerConfig } from './config.js'
 import { runInteractiveOAuth, serializeInteractiveOAuth } from './oauth-flow.js'
 
 // Claude's MCP_TIMEOUT default: 30 seconds per connect attempt.
@@ -128,6 +130,67 @@ function isStdio(config: ServerConfig): config is StdioServerConfig {
   return 'command' in config && (config.type === undefined || config.type === 'stdio')
 }
 
+/** The session's directories: the launch directory answers roots/list, and the
+ * project root becomes CLAUDE_PROJECT_DIR in a stdio server's environment. */
+export interface SessionDirs {
+  projectDir: string
+  launchDir: string
+}
+
+/** A client that, like Claude, declares the roots capability and answers roots/list
+ * with the session's launch directory. pi's directory set is static, so no
+ * roots/list_changed notification is ever sent. */
+function makeClient(session?: SessionDirs): Client {
+  if (!session) return new Client({ name: 'pi-code-mcp', version: '0.1.0' })
+  const client = new Client({ name: 'pi-code-mcp', version: '0.1.0' }, { capabilities: { roots: {} } })
+  client.setRequestHandler(ListRootsRequestSchema, () => ({ roots: [{ uri: pathToFileURL(session.launchDir).href }] }))
+  return client
+}
+
+/** Claude's credential heuristic for helper environments: any name with TOKEN,
+ * SECRET, PASSWORD, KEY, or AUTH in it in either case (Git's GIT_CONFIG_KEY_<n>
+ * excepted), plus a fixed list of credential names outside the pattern. */
+const CREDENTIAL_NAME_EXTRAS = new Set(['ANTHROPIC_CUSTOM_HEADERS'])
+function isCredentialEnvName(name: string): boolean {
+  if (/^GIT_CONFIG_KEY_\d+$/.test(name)) return false
+  return /TOKEN|SECRET|PASSWORD|KEY|AUTH/i.test(name) || CREDENTIAL_NAME_EXTRAS.has(name)
+}
+
+/** process.env with every credential-named value replaced by REDACTED, used to
+ * expand the url a helper is shown without handing it the credential. */
+function redactedEnv(): NodeJS.ProcessEnv {
+  return Object.fromEntries(Object.entries(process.env).map(([key, value]) => [key, isCredentialEnvName(key) ? 'REDACTED' : value]))
+}
+
+/** The environment a headersHelper runs with: Claude's CLAUDE_CODE_MCP_SERVER_NAME
+ * and CLAUDE_CODE_MCP_SERVER_URL (credential-expanded url parts REDACTED), plus
+ * CLAUDE_PLUGIN_ROOT for a plugin's server. A helper a repository or plugin
+ * supplies is a command the user did not write, so it runs without the
+ * credential-named variables; a user-scope helper keeps them. */
+function helperEnv(name: string, config: HttpServerConfig): NodeJS.ProcessEnv {
+  const stripped = config.projectScope === true || config.pluginRoot !== undefined
+  const env: NodeJS.ProcessEnv = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (stripped && isCredentialEnvName(key)) continue
+    env[key] = value
+  }
+  env.CLAUDE_CODE_MCP_SERVER_NAME = name
+  env.CLAUDE_CODE_MCP_SERVER_URL = interpolateEnv(config.url, redactedEnv())
+  if (config.pluginRoot !== undefined) env.CLAUDE_PLUGIN_ROOT = config.pluginRoot
+  return env
+}
+
+/** The env a stdio server process starts with: the SDK allowlist, the config's own
+ * env block, and Claude's path variables (CLAUDE_PROJECT_DIR, and CLAUDE_PLUGIN_ROOT
+ * for a plugin's server). */
+function stdioEnv(config: StdioServerConfig, fill: (value: string) => string, session?: SessionDirs): Record<string, string> {
+  const env: Record<string, string> = { ...getDefaultEnvironment() }
+  for (const [key, value] of Object.entries(config.env ?? {})) env[key] = fill(value)
+  if (session) env.CLAUDE_PROJECT_DIR = session.projectDir
+  if (config.pluginRoot !== undefined) env.CLAUDE_PLUGIN_ROOT = config.pluginRoot
+  return env
+}
+
 export async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined
   const timeout = new Promise<never>((_, reject) => {
@@ -143,8 +206,8 @@ export async function withTimeout<T>(promise: Promise<T>, ms: number, label: str
   }
 }
 
-export async function connect(name: string, config: ServerConfig, authUi?: AuthUi): Promise<Client> {
-  const client = new Client({ name: 'pi-code-mcp', version: '0.1.0' })
+export async function connect(name: string, config: ServerConfig, authUi?: AuthUi, session?: SessionDirs): Promise<Client> {
+  const client = makeClient(session)
   // Names referenced by ${VAR} with no value and no default, gathered across this
   // server's interpolated fields so the connect can warn once rather than fail with a
   // mystery 401 or a command that lost an argument.
@@ -157,12 +220,10 @@ export async function connect(name: string, config: ServerConfig, authUi?: AuthU
     // Start from the SDK's allowlist (PATH, HOME, SHELL, ...) rather than the whole
     // process env: a server should not receive ANTHROPIC_API_KEY or GITHUB_TOKEN just
     // for being launched. A server that needs a variable names it in its own env block.
-    const env: Record<string, string> = { ...getDefaultEnvironment() }
-    for (const [key, value] of Object.entries(config.env ?? {})) env[key] = fill(value)
     const transport = new StdioClientTransport({
       command: fill(config.command),
       args: (config.args ?? []).map((arg) => fill(arg)),
-      env,
+      env: stdioEnv(config, fill, session),
       cwd: expandCwd(config.cwd),
       stderr: 'ignore',
     })
@@ -192,26 +253,30 @@ export async function connect(name: string, config: ServerConfig, authUi?: AuthU
   if (token) headers.Authorization = `Bearer ${token}`
   // A headersHelper generates connect-time headers for non-OAuth auth schemes; its
   // JSON stdout merges over the static headers.
-  if (config.headersHelper) Object.assign(headers, await runHeadersHelper(fill(config.headersHelper)))
+  if (config.headersHelper) Object.assign(headers, await runHeadersHelper(fill(config.headersHelper), helperEnv(name, config)))
   warnMissing()
+  // Claude: a configured Authorization header, whether static, a bearer token, or
+  // helper output, is the server's authentication; there is no OAuth fallback for it.
+  const configuredAuth = Boolean(token) || Object.keys(headers).some((header) => header.toLowerCase() === 'authorization')
   const sseTransport = (authProvider?: OAuthClientProvider) => new SSEClientTransport(url, { requestInit: { headers }, authProvider }) // NOSONAR: explicitly declared or deliberate legacy transport
   if (config.type === 'sse') {
-    return await connectHttpFamily(name, config, sseTransport, `connect ${name} (sse)`, token, authUi)
+    return await connectHttpFamily(name, config, sseTransport, `connect ${name} (sse)`, configuredAuth, authUi, session)
   }
   try {
-    return await connectHttpFamily(name, config, (authProvider) => new StreamableHTTPClientTransport(url, { requestInit: { headers }, authProvider }), `connect ${name}`, token, authUi)
+    return await connectHttpFamily(name, config, (authProvider) => new StreamableHTTPClientTransport(url, { requestInit: { headers }, authProvider }), `connect ${name}`, configuredAuth, authUi, session)
   } catch (error) {
     // An explicitly declared streamable transport must not silently degrade to SSE.
     if (config.type !== undefined || isUnauthorized(error)) throw error
-    return await connectHttpFamily(name, config, sseTransport, `connect ${name} (sse)`, token, authUi)
+    return await connectHttpFamily(name, config, sseTransport, `connect ${name} (sse)`, configuredAuth, authUi, session)
   }
 }
 
-/** Run a headersHelper command and parse its JSON stdout into headers. A failure or
- * a 10s timeout yields no extra headers rather than blocking the connection. */
-function runHeadersHelper(command: string): Promise<Record<string, string>> {
+/** Run a headersHelper command and parse its JSON stdout into headers, under the
+ * environment helperEnv built. A failure or a 10s timeout yields no extra headers
+ * rather than blocking the connection. */
+function runHeadersHelper(command: string, env: NodeJS.ProcessEnv): Promise<Record<string, string>> {
   return new Promise((resolve) => {
-    execFile('/bin/sh', ['-c', command], { timeout: 10_000 }, (error, stdout) => {
+    execFile('/bin/sh', ['-c', command], { timeout: 10_000, env }, (error, stdout) => {
       resolve(error ? {} : parseHelperHeaders(stdout))
     })
   })
@@ -229,12 +294,12 @@ export interface AuthUi {
 export class OAuthRequiredError extends Error {}
 
 /** Whether a connect failure is an authentication problem: the SDK's own
- * UnauthorizedError, a transport error carrying HTTP 401 (which is what a 401
- * throws when no authProvider was attached, so a first-time login is detected),
- * or our own marker. */
+ * UnauthorizedError, a transport error carrying HTTP 401 or 403 (Claude: "either
+ * status code flags it" for OAuth), or our own marker. */
 export function isUnauthorized(error: unknown): boolean {
   if (error instanceof UnauthorizedError || error instanceof OAuthRequiredError) return true
-  return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 401
+  const code = typeof error === 'object' && error !== null ? (error as { code?: unknown }).code : undefined
+  return code === 401 || code === 403
 }
 
 // SSEClientTransport is deprecated in favour of Streamable HTTP, but both concrete
@@ -249,22 +314,23 @@ export type MakeTransport = (authProvider?: OAuthClientProvider) => HttpFamilyTr
  * demands one. Stored tokens ride the first attempt so the SDK refreshes
  * silently; a 401 without tokens asks the user, opens the browser, catches the
  * loopback redirect, and exchanges the code via the SDK's finishAuth.
- * Bearer-token servers never enter the OAuth path: an explicit token is the
- * user saying how auth works.
+ * A server with configured authentication (a bearer token, a static Authorization
+ * header, or one from a headersHelper) never enters the OAuth path: the credential
+ * to fix is the configured one, so an auth failure reports as a failed connection.
  */
-async function connectHttpFamily(name: string, config: { url: string }, makeTransport: MakeTransport, label: string, bearerToken: string | undefined, authUi: AuthUi | undefined): Promise<Client> {
-  const newClient = () => new Client({ name: 'pi-code-mcp', version: '0.1.0' })
+async function connectHttpFamily(name: string, config: { url: string }, makeTransport: MakeTransport, label: string, hasConfiguredAuth: boolean, authUi: AuthUi | undefined, session?: SessionDirs): Promise<Client> {
+  const newClient = () => makeClient(session)
   // Stored tokens ride the first attempt so the SDK refreshes them; with none, no
   // provider is attached, so a 401 surfaces as a transport error carrying code 401
   // (isUnauthorized detects it) and only the interactive provider below ever runs
   // dynamic registration, keeping it bound to the real callback port.
-  const silent = bearerToken ? undefined : new FileOAuthProvider(name, () => {})
+  const silent = hasConfiguredAuth ? undefined : new FileOAuthProvider(name, () => {})
   try {
     const client = newClient()
     await connectWithTimeout(client, makeTransport(silent?.hasTokens() ? silent : undefined), label)
     return client
   } catch (error) {
-    if (bearerToken || !isUnauthorized(error)) throw error
+    if (hasConfiguredAuth || !isUnauthorized(error)) throw error
     if (!authUi) throw new OAuthRequiredError(`${name} requires a login; run pi interactively to authenticate`)
     return await serializeInteractiveOAuth(() => runInteractiveOAuth(name, config, makeTransport, label, authUi, newClient))
   }

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -65,6 +65,9 @@ const hoisted = vi.hoisted(() => {
     // Codes handed to a transport's finishAuth, so the interactive OAuth exchange is observable.
     finishAuthCalls: [] as string[],
     notify: new Map<string, () => void | Promise<void>>(),
+    // Client constructor options (capabilities) and roots/list-style request handlers.
+    clientOptions: [] as Array<unknown>,
+    requests: new Map<string, (request: unknown) => unknown>(),
     control: {} as {
       connect: (transport: TransportRecord, client: ClientRecord) => Promise<void>
       listTools: (args: { cursor?: string }, client: ClientRecord) => Promise<ListPage>
@@ -89,8 +92,16 @@ vi.mock('node:os', async (importOriginal) => {
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: class FakeClient implements ClientRecord {
     transport?: TransportRecord
-    constructor(public info: { name: string; version: string }) {
+    constructor(
+      public info: { name: string; version: string },
+      options?: unknown,
+    ) {
       hoisted.clients.push(this)
+      hoisted.clientOptions.push(options)
+    }
+    setRequestHandler(schema: unknown, handler: (request: unknown) => unknown): void {
+      const shape = (schema as { shape?: { method?: { value?: string } } })?.shape
+      hoisted.requests.set(shape?.method?.value ?? 'unknown', handler)
     }
     async connect(transport: TransportRecord): Promise<void> {
       this.transport = transport
@@ -356,6 +367,8 @@ beforeEach(() => {
   hoisted.finishAuthCalls.length = 0
   hoisted.control = defaultControl()
   hoisted.notify.clear()
+  hoisted.clientOptions.length = 0
+  hoisted.requests.clear()
 })
 
 afterEach(() => {
@@ -2224,5 +2237,133 @@ describe('managed-mcp.json exclusive control', () => {
     await expect(starting).resolves.toBeUndefined()
     // The managed server still connected despite the hung eviction close.
     expect(hoisted.transports.map((t) => t.options.command)).toEqual(['u', 'm'])
+  })
+})
+
+describe('mcp stdio session context', () => {
+  it('sets CLAUDE_PROJECT_DIR in a stdio server environment, as Claude documents', async () => {
+    withTools([{ name: 'go' }])
+    const harness = await setupStarted({ user: { srv: { command: 'x' }, plugged: { command: 'y', pluginRoot: '/plug/root' } } })
+
+    // The harness cwd has no repo markers, so the project root falls back to cwd.
+    const env = hoisted.transports[0].options.env as Record<string, string>
+    expect(env.CLAUDE_PROJECT_DIR).toBe(harness.cwd)
+    // A plugin-provided stdio server also gets CLAUDE_PLUGIN_ROOT, which Claude
+    // exports to MCP server subprocesses.
+    const pluggedEnv = hoisted.transports[1].options.env as Record<string, string>
+    expect(pluggedEnv.CLAUDE_PLUGIN_ROOT).toBe('/plug/root')
+  })
+
+  it('declares the roots capability and answers roots/list with the session launch directory', async () => {
+    withTools([{ name: 'go' }])
+    const harness = await setupStarted({ user: { srv: { command: 'x' } } })
+
+    // Claude Code answers roots/list with the session's launch directory (pi has no
+    // additional working directories, so the set is static and never changes).
+    expect(hoisted.clientOptions[0]).toMatchObject({ capabilities: { roots: {} } })
+    const handler = hoisted.requests.get('roots/list')
+    expect(handler).toBeDefined()
+    const result = handler?.({ method: 'roots/list' }) as { roots: Array<{ uri: string }> }
+    expect(result.roots).toHaveLength(1)
+    expect(result.roots[0].uri).toBe(`file://${harness.cwd}`)
+  })
+})
+
+describe('mcp headersHelper environment', () => {
+  it('passes the server name and a credential-redacted url to the helper', async () => {
+    // Claude sets CLAUDE_CODE_MCP_SERVER_NAME and CLAUDE_CODE_MCP_SERVER_URL when
+    // executing the helper; a url part expanded from a credential-named variable
+    // reaches the helper as REDACTED while the transport gets the real value.
+    setEnv('TEST_HELPER_KEY', 'sekret')
+    withTools([{ name: 'go' }])
+    const helper = `echo "{\\"X-N\\":\\"$CLAUDE_CODE_MCP_SERVER_NAME\\",\\"X-U\\":\\"$CLAUDE_CODE_MCP_SERVER_URL\\"}"`
+    await setupStarted({ user: { srv: { type: 'http', url: 'https://api.example/${TEST_HELPER_KEY}/mcp', headersHelper: helper } } })
+
+    const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
+    expect(headers['X-N']).toBe('srv')
+    expect(headers['X-U']).toBe('https://api.example/REDACTED/mcp')
+    expect(String(hoisted.transports[0].url)).toBe('https://api.example/sekret/mcp')
+  })
+
+  it('strips credential-named variables from a project server helper environment', async () => {
+    // A helper a repository supplies runs without credential variables such as
+    // ANTHROPIC_API_KEY: any name with TOKEN/SECRET/PASSWORD/KEY/AUTH in it.
+    setEnv('MY_PROJ_TOKEN', 'leak')
+    withTools([{ name: 'go' }])
+    const helper = `echo "{\\"X-T\\":\\"\${MY_PROJ_TOKEN-absent}\\"}"`
+    const harness = await setup({ project: { proj: { type: 'http', url: 'https://api.example/mcp', headersHelper: helper } } })
+    mkdirSync(join(harness.home, '.claude'), { recursive: true })
+    writeFileSync(join(harness.home, '.claude', 'settings.json'), JSON.stringify({ enabledMcpjsonServers: ['proj'] }))
+    await harness.sessionStart(true)
+
+    const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
+    expect(headers['X-T']).toBe('absent')
+  })
+
+  it('keeps credential variables for a user-scope helper, which the user wrote', async () => {
+    setEnv('MY_USER_TOKEN', 'mine')
+    withTools([{ name: 'go' }])
+    const helper = `echo "{\\"X-T\\":\\"\${MY_USER_TOKEN-absent}\\"}"`
+    await setupStarted({ user: { srv: { type: 'http', url: 'https://api.example/mcp', headersHelper: helper } } })
+
+    const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
+    expect(headers['X-T']).toBe('mine')
+  })
+
+  it('gives a plugin server helper CLAUDE_PLUGIN_ROOT and the credential stripping', async () => {
+    setEnv('MY_PLUGIN_TOKEN', 'leak')
+    withTools([{ name: 'go' }])
+    const helper = `echo "{\\"X-R\\":\\"$CLAUDE_PLUGIN_ROOT\\",\\"X-T\\":\\"\${MY_PLUGIN_TOKEN-absent}\\"}"`
+    await setupStarted({ user: { srv: { type: 'http', url: 'https://api.example/mcp', headersHelper: helper, pluginRoot: '/plug/root' } } })
+
+    const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
+    expect(headers['X-R']).toBe('/plug/root')
+    expect(headers['X-T']).toBe('absent')
+  })
+})
+
+describe('mcp configured authorization', () => {
+  it('fails a 401 server with a static Authorization header instead of starting OAuth', async () => {
+    // Claude: for a server whose Authorization header you configured, a 401 or 403
+    // while connecting reports the connection as failed; the credential to fix is
+    // the configured one, so there is no OAuth fallback.
+    withTools([{ name: 'go' }])
+    hoisted.control.connect = async () => {
+      throw Object.assign(new Error('denied'), { code: 401 })
+    }
+    let confirms = 0
+    const harness = await setup({
+      user: { locked: { type: 'http', url: 'https://api.example/mcp', headers: { Authorization: 'Bearer abc' } } },
+      confirm: async () => {
+        confirms++
+        return true
+      },
+    })
+    await harness.sessionStart()
+
+    expect(confirms).toBe(0)
+    const [line] = await statusLinesOf(harness)
+    expect(line.startsWith('locked: failed: ')).toBe(true)
+  })
+
+  it('fails a 401 server whose helper supplied Authorization instead of starting OAuth', async () => {
+    withTools([{ name: 'go' }])
+    hoisted.control.connect = async () => {
+      throw Object.assign(new Error('denied'), { code: 401 })
+    }
+    let confirms = 0
+    const helper = `echo "{\\"Authorization\\":\\"Bearer xyz\\"}"`
+    const harness = await setup({
+      user: { locked: { type: 'http', url: 'https://api.example/mcp', headersHelper: helper } },
+      confirm: async () => {
+        confirms++
+        return true
+      },
+    })
+    await harness.sessionStart()
+
+    expect(confirms).toBe(0)
+    const [line] = await statusLinesOf(harness)
+    expect(line.startsWith('locked: failed: ')).toBe(true)
   })
 })

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -479,6 +479,22 @@ describe('plugin server substitution safety', () => {
     expect(api.headersHelper).not.toContain('${CLAUDE_PLUGIN_ROOT}')
   })
 
+  it('treats 403 as an authentication failure alongside 401, as Claude documents', async () => {
+    // Claude: "either status code flags it in /mcp so you can complete the OAuth flow".
+    const { isUnauthorized } = await import('../extensions/mcp/transport.ts')
+    expect(isUnauthorized(Object.assign(new Error('denied'), { code: 403 }))).toBe(true)
+    expect(isUnauthorized(Object.assign(new Error('denied'), { code: 401 }))).toBe(true)
+    expect(isUnauthorized(Object.assign(new Error('gone'), { code: 404 }))).toBe(false)
+  })
+
+  it('records the plugin root on plugin server configs for the helper environment', async () => {
+    // Claude sets CLAUDE_PLUGIN_ROOT when a plugin provides the server's headersHelper.
+    const { loadPluginServers } = await import('../extensions/mcp/index.ts')
+    const declared = plugin({ api: { type: 'http', url: 'https://api.example.com' } }) as { root: string }
+    const servers = loadPluginServers([declared as never], '/work/repo')
+    expect((servers.api as { pluginRoot?: string }).pluginRoot).toBe(declared.root)
+  })
+
   it('keeps hyphens in the tool alias prefix, folding only characters outside A-Za-z0-9_-', async () => {
     // Claude's plugin tool names keep the plugin and server names' hyphens; only
     // characters outside A-Za-z0-9_- become underscores.


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #146).

## Session context (extensions/mcp/transport.ts, index.ts)
- Stdio servers now get `CLAUDE_PROJECT_DIR` (the project root) in their environment, and `CLAUDE_PLUGIN_ROOT` when a plugin supplied the server.
- Every client declares the `roots` capability and answers `roots/list` with the session's launch directory. pi's directory set is static, so no `roots/list_changed` is ever sent.

## headersHelper environment (transport.ts, config.ts)
- The helper runs with `CLAUDE_CODE_MCP_SERVER_NAME` and `CLAUDE_CODE_MCP_SERVER_URL` set; url parts that expanded from credential-named variables reach the helper as `REDACTED` while the transport keeps the real value.
- A project- or plugin-supplied helper (a command the user did not write) runs without credential-named environment variables: any name containing `TOKEN`, `SECRET`, `PASSWORD`, `KEY`, or `AUTH` in either case (Git's `GIT_CONFIG_KEY_<n>` excepted) plus `ANTHROPIC_CUSTOM_HEADERS`. User-scope helpers keep the full environment.
- `CLAUDE_PLUGIN_ROOT` is set for plugin servers' helpers. Plugin server configs now carry `pluginRoot`; project-scope configs are tagged at load.

## Authorization semantics (transport.ts)
- `isUnauthorized` treats 403 like 401, per "either status code flags it".
- A configured `Authorization` header, whether static, a bearer token, or helper output, is the server's authentication: an auth failure reports the connection as failed and never falls back to OAuth.

Docs: `docs/mcp.md` transport section updated; a stale header comment describing the pre-#146 prompt-name folding fixed.

All changes covered by tests that failed before the change (9 red tests), plus mutation checks on the two assertions that never independently failed (stdio plugin root, user-scope credential keep).