### PR TITLE
Align MCP connection lifecycle and oauth config with Claude docs

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -19,6 +19,8 @@ Managed `allowedMcpServers`/`deniedMcpServers` entries are typed and matched per
 - Stdio servers get `CLAUDE_PROJECT_DIR` (and `CLAUDE_PLUGIN_ROOT` for a plugin's server) in their environment; every client answers `roots/list` with the session's launch directory.
 - A `headersHelper` command's stdout JSON merges into the transport headers (http/sse). The helper runs with `CLAUDE_CODE_MCP_SERVER_NAME` and `CLAUDE_CODE_MCP_SERVER_URL` set (credential-expanded url parts shown as `REDACTED`); a project- or plugin-supplied helper runs without credential-named variables (`TOKEN`/`SECRET`/`PASSWORD`/`KEY`/`AUTH`).
 - Bearer tokens, or OAuth for remote servers: browser login on 401/403 after a confirm, CSRF-guarded loopback callback, tokens under `~/.pi/agent/mcp-oauth`, silent refresh later. A configured `Authorization` header (static, bearer, or helper-supplied) is the server's authentication: auth failures report as failed connections with no OAuth fallback.
+- The per-server `oauth` object: `clientId` (secret via `MCP_CLIENT_SECRET`) replaces dynamic registration, `callbackPort` fixes the loopback port, `scopes` pins the requested scopes. `authServerMetadataUrl` is accepted but warned as unsupported (the MCP SDK has no discovery override).
+- Lifecycle: a transient first-connect failure of a remote server (5xx, refused, timeout) retries up to three times; a remote server that drops mid-session reconnects with exponential backoff (five attempts, 1s doubling); stdio servers are not auto-reconnected. A tool call rejected with 401/403 reconnects once (re-running the `headersHelper`, refreshing OAuth tokens) and retries once.
 
 ## Budgets
 

--- a/extensions/internal/mcp-oauth.ts
+++ b/extensions/internal/mcp-oauth.ts
@@ -28,6 +28,17 @@ interface StoredAuth {
   redirectPort?: number
 }
 
+/** Claude's per-server `oauth` config object: a pre-registered client (secret via
+ * MCP_CLIENT_SECRET), a fixed callback port for pre-registered redirect URIs, and
+ * pinned scopes. authServerMetadataUrl is accepted but unsupported (the MCP SDK
+ * offers no discovery override); the connect path warns when it is set. */
+export interface OAuthServerConfig {
+  clientId?: string
+  callbackPort?: number
+  scopes?: string
+  authServerMetadataUrl?: string
+}
+
 /** A server name is config-controlled text; the digest keeps hostile names inside
  * the store directory and distinct names from colliding after sanitization. */
 function storeFileFor(serverName: string): string {
@@ -55,9 +66,10 @@ export class FileOAuthProvider implements OAuthClientProvider {
   // page cannot inject an authorization code into this login (RFC 8252 8.9).
   private readonly loginState = crypto.randomBytes(16).toString('hex')
 
-  constructor(serverName: string, onRedirect: (authorizationUrl: URL) => void) {
+  constructor(serverName: string, onRedirect: (authorizationUrl: URL) => void, oauth?: OAuthServerConfig) {
     this.storePath = storeFileFor(serverName)
     this.onRedirect = onRedirect
+    this.oauth = oauth
     try {
       this.data = JSON.parse(fs.readFileSync(this.storePath, 'utf-8'))
     } catch {
@@ -65,14 +77,22 @@ export class FileOAuthProvider implements OAuthClientProvider {
     }
   }
 
+  private readonly oauth?: OAuthServerConfig
+
+  /** The client secret for a pre-configured client, from Claude's MCP_CLIENT_SECRET. */
+  private clientSecret(): string | undefined {
+    return this.oauth?.clientId ? process.env.MCP_CLIENT_SECRET : undefined
+  }
+
   private persist(): void {
     fs.mkdirSync(path.dirname(this.storePath), { recursive: true })
     fs.writeFileSync(this.storePath, JSON.stringify(this.data), { mode: 0o600 })
   }
 
-  /** The port a prior login registered, so a re-login can bind the same one. */
+  /** The configured callbackPort (Claude: for pre-registered redirect URIs), else
+   * the port a prior login registered, so a re-login can bind the same one. */
   savedRedirectPort(): number | undefined {
-    return this.data.redirectPort
+    return this.oauth?.callbackPort ?? this.data.redirectPort
   }
 
   /** Record the loopback port the callback server actually bound; the redirect
@@ -96,11 +116,19 @@ export class FileOAuthProvider implements OAuthClientProvider {
       grant_types: ['authorization_code', 'refresh_token'],
       response_types: ['code'],
       // A local CLI is a public client; PKCE carries the proof instead of a secret.
-      token_endpoint_auth_method: 'none',
+      // A pre-configured client with an MCP_CLIENT_SECRET authenticates with it.
+      token_endpoint_auth_method: this.clientSecret() ? 'client_secret_post' : 'none',
+      // Claude: oauth.scopes pins the scopes requested during authorization.
+      ...(this.oauth?.scopes ? { scope: this.oauth.scopes } : {}),
     }
   }
 
   clientInformation(): OAuthClientInformationMixed | undefined {
+    // A pre-configured clientId replaces dynamic registration entirely.
+    if (this.oauth?.clientId) {
+      const secret = this.clientSecret()
+      return { client_id: this.oauth.clientId, ...(secret ? { client_secret: secret } : {}) }
+    }
     return this.data.client
   }
 

--- a/extensions/mcp/config.ts
+++ b/extensions/mcp/config.ts
@@ -7,6 +7,7 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { claudeConfigDir } from '../internal/config-dir.js'
+import type { OAuthServerConfig } from '../internal/mcp-oauth.js'
 import type { InstalledPlugin } from '../internal/plugins.js'
 import { findNearestFile } from '../internal/project-root.js'
 
@@ -32,6 +33,8 @@ export interface HttpServerConfig {
   headers?: Record<string, string>
   bearerToken?: string
   bearerTokenEnv?: string
+  /** Claude's oauth object: pre-registered client, fixed callback port, pinned scopes. */
+  oauth?: OAuthServerConfig
   /** A command whose JSON stdout is merged into the connect headers, for auth
    * schemes other than OAuth/static tokens (Claude's headersHelper). */
   headersHelper?: string

--- a/extensions/mcp/index.ts
+++ b/extensions/mcp/index.ts
@@ -48,7 +48,7 @@ import { disabledServerNames, loadConfigFrom, loadPluginServers, loadUserScope, 
 import { collectServerResourceEntries, listAllPrompts, listAllTools, type McpToolInfo, resourceServerFilter } from './listing.js'
 import { formatPromptCommandName, formatToolName, type McpContentBlock, type McpPromptInfo, mapContent, mapPromptArguments, normalizeSchema, promptMessageContent } from './mapping.js'
 import { applyServerPolicy, loadManagedMcpServers, type McpPolicy, mcpAllowDeny, projectServerPolicy, splitByPolicy } from './policy.js'
-import { type AuthUi, callRequestOptions, callTimeoutMs, connect, connectTimeoutMs, type ServerCallTuning, type SessionDirs, serverCallTuning, withTimeout } from './transport.js'
+import { type AuthUi, callRequestOptions, callTimeoutMs, connect, connectTimeoutMs, connectWithRetries, isUnauthorized, type ServerCallTuning, type SessionDirs, serverCallTuning, withTimeout } from './transport.js'
 
 export { managedSettingsPath, setManagedSettingsPath } from '../internal/managed-settings.js'
 // Re-exports for consumers: the module split keeps the extension's public surface
@@ -91,16 +91,25 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   // The session's directories, set at session_start before any connect: the launch
   // directory answers roots/list, the project root feeds CLAUDE_PROJECT_DIR.
   let sessionDirs: SessionDirs | undefined
+  // Shutdown closes clients while they are still in the map; the onclose handlers
+  // must not schedule reconnects for that deliberate teardown.
+  let shuttingDown = false
   const callTuning = (name: string): ServerCallTuning => {
     const config = serverConfigs.get(name)
     return config ? serverCallTuning(config) : {}
   }
   // Let other extensions (hooks' mcp_tool type) call a connected server's tool.
+  // The same 401/403 reconnect-and-retry-once as registered tools, when the
+  // server's config is known; a name with no stored config calls through once.
   setMcpToolCaller(async (server, tool, input) => {
-    const client = clients.get(server)
-    if (!client) throw new Error(`MCP server "${server}" is not connected`)
-    const tuning = callTuning(server)
-    const result = await client.callTool({ name: tool, arguments: input }, undefined, callRequestOptions(tuning.serverTimeoutMs ?? callTimeoutMs(), tuning))
+    const config = serverConfigs.get(server)
+    const result = config
+      ? await callToolWithAuthRetry(server, config, { name: tool, arguments: input }, `${server}: ${tool}`)
+      : await (async () => {
+          const client = clients.get(server)
+          if (!client) throw new Error(`MCP server "${server}" is not connected`)
+          return await client.callTool({ name: tool, arguments: input }, undefined, callRequestOptions(callTimeoutMs()))
+        })()
     const text = mapContent(result.content as McpContentBlock[], result.structuredContent)
       .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
       .map((part) => part.text)
@@ -142,17 +151,13 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           // present at registration: pi has no tool unregister, so after a server drops
           // and a later session_start reconnects it, registerTools skips re-registration
           // and this closure would otherwise keep calling the old, closed client.
-          const current = clients.get(name)
-          if (!current) throw new Error(`MCP server "${name}" is not connected`)
           // The per-server timeout (Claude's, 1s floor) or MCP_TOOL_TIMEOUT is the
           // wall-clock ceiling; callRequestOptions layers the idle timeout under it, which
-          // the SDK enforces (resetting on progress). Pass the options to the SDK too: its
-          // own default request timeout is 60s and would otherwise reject first. The outer
-          // race uses the wall budget, never the idle window, so a progressing call is not
-          // cut off at the idle timeout.
-          const tuning = serverCallTuning(config)
-          const wall = tuning.serverTimeoutMs ?? callTimeoutMs()
-          const result = await withTimeout(current.callTool({ name: tool.name, arguments: params as Record<string, unknown> }, undefined, callRequestOptions(wall, tuning)), wall, toolName)
+          // the SDK enforces (resetting on progress). The outer race uses the wall
+          // budget, never the idle window, so a progressing call is not cut off at the
+          // idle timeout. A 401/403 reconnects once (fresh helper headers or refreshed
+          // OAuth tokens) and retries once.
+          const result = await callToolWithAuthRetry(name, config, { name: tool.name, arguments: params as Record<string, unknown> }, toolName)
           const content = mapContent(result.content as McpContentBlock[], result.structuredContent)
           const details: { error?: string } = {}
           if (result.isError) {
@@ -165,6 +170,53 @@ export default async function mcpExtension(pi: ExtensionAPI) {
       })
     }
     return count
+  }
+
+  /** Claude's mid-session reconnect for a dropped remote server: five attempts with
+   * a delay doubling from one second. connectServers redoes the full bring-up
+   * (tools, prompts, subscriptions, a fresh onclose) and its duplicate guard skips
+   * out if another path already reconnected the name. Runs without authUi: a server
+   * that now needs a login ends failed, and after the fifth failure the last
+   * attempt's failed status stands, with a session restart as the manual retry. */
+  async function reconnectWithBackoff(name: string, config: ServerConfig): Promise<void> {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 1000 * 2 ** attempt))
+      if (shuttingDown || clients.has(name)) return
+      await connectServers({ [name]: config }, undefined, true)
+      if (clients.has(name)) return
+    }
+  }
+
+  /** Claude's 401/403 tool-call recovery: drop the client and reconnect once, so the
+   * headersHelper re-runs (fresh credential) or the OAuth tokens refresh, then the
+   * caller retries the call once. The map delete precedes the close so the onclose
+   * guard does not also schedule a backoff reconnect. */
+  async function reconnectForAuth(name: string, config: ServerConfig): Promise<void> {
+    const old = clients.get(name)
+    if (old) {
+      clients.delete(name)
+      await withTimeout(old.close(), 3000, 'close').catch(() => {})
+    }
+    await connectServers({ [name]: config }, undefined, true)
+  }
+
+  /** A tool call with the auth retry: on a 401/403 rejection, reconnect once and
+   * retry once; a second auth failure surfaces to the caller. */
+  async function callToolWithAuthRetry(name: string, config: ServerConfig, args: { name: string; arguments: Record<string, unknown> }, label: string): Promise<Awaited<ReturnType<Client['callTool']>>> {
+    const tuning = serverCallTuning(config)
+    const wall = tuning.serverTimeoutMs ?? callTimeoutMs()
+    const callOnce = async () => {
+      const current = clients.get(name)
+      if (!current) throw new Error(`MCP server "${name}" is not connected`)
+      return await withTimeout(current.callTool(args, undefined, callRequestOptions(wall, tuning)), wall, label)
+    }
+    try {
+      return await callOnce()
+    } catch (error) {
+      if (!isUnauthorized(error)) throw error
+      await reconnectForAuth(name, config)
+      return await callOnce()
+    }
   }
 
   // Prompt command name -> the server and prompt that own it, so a refresh re-listing
@@ -340,7 +392,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     }
   }
 
-  async function connectServers(servers: Record<string, ServerConfig>, authUi?: AuthUi): Promise<void> {
+  async function connectServers(servers: Record<string, ServerConfig>, authUi?: AuthUi, noRetry = false): Promise<void> {
     const pending: [string, ServerConfig][] = []
     for (const [name, config] of Object.entries(servers)) {
       // A later scope must not take the name of a server that already connected: it
@@ -360,7 +412,9 @@ export default async function mcpExtension(pi: ExtensionAPI) {
       pending.map(async ([name, config]) => {
         warnOnTypelessUrl(name, config)
         try {
-          const client = await connect(name, config, authUi, sessionDirs)
+          // First connections retry transient failures (Claude: up to three times for
+          // HTTP/SSE); the backoff reconnect below carries its own schedule instead.
+          const client = noRetry ? await connect(name, config, authUi, sessionDirs) : await connectWithRetries(name, config, authUi, sessionDirs)
           clients.set(name, client)
           const tools = await withTimeout(listAllTools(client), connectTimeoutMs(), `list tools ${name}`)
           registerTools(name, config, tools)
@@ -382,6 +436,11 @@ export default async function mcpExtension(pi: ExtensionAPI) {
             if (clients.get(name) !== client) return
             clients.delete(name)
             status.set(name, { state: 'disconnected', tools: 0 })
+            // Claude reconnects a dropped remote server with exponential backoff;
+            // stdio servers are local processes and are not reconnected. Shutdown
+            // closes clients while they are still in the map, so the flag guards
+            // against scheduling a reconnect for a deliberate teardown.
+            if (!shuttingDown && !serverCallTuning(config).stdio) void reconnectWithBackoff(name, config)
           }
         } catch (error) {
           status.set(name, { state: `failed: ${error instanceof Error ? error.message : String(error)}`, tools: 0 })
@@ -487,6 +546,9 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // withdrawn tool keeps its registration and surfaces the server's own error), which
     // is why serverToolCount reads from `registered` to recover the true count here.
     status.clear()
+    // A same-process session switch (/new, /resume) shut the last session down;
+    // this one may reconnect again.
+    shuttingDown = false
     // Claude answers roots/list with the session's launch directory and exports the
     // project root as CLAUDE_PROJECT_DIR to stdio servers; both derive from ctx.cwd.
     sessionDirs = { projectDir: repoRoot(ctx.cwd) ?? ctx.cwd, launchDir: ctx.cwd }
@@ -519,6 +581,9 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   })
 
   pi.on('session_shutdown', async () => {
+    // Closing fires each client's onclose while it is still in the map; the flag
+    // stops those handlers (and any in-flight backoff loop) from reconnecting.
+    shuttingDown = true
     // Close in parallel with a per-client timeout so one hung server can't stall pi's exit.
     await Promise.all([...clients.values()].map((client) => withTimeout(client.close(), 3000, 'close').catch(() => {})))
     // Drop the closed clients and their status now rather than waiting on each client's

--- a/extensions/mcp/oauth-flow.ts
+++ b/extensions/mcp/oauth-flow.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { FileOAuthProvider, openBrowser, startCallbackServer, waitForAuthCode } from '../internal/mcp-oauth.js'
+import { FileOAuthProvider, type OAuthServerConfig, openBrowser, startCallbackServer, waitForAuthCode } from '../internal/mcp-oauth.js'
 import { type AuthUi, connectWithTimeout, isUnauthorized, type MakeTransport, OAuthRequiredError } from './transport.js'
 
 /** Browser logins are human-paced; a connect-sized timeout would cut them off. */
@@ -45,13 +45,17 @@ export function serializeInteractiveOAuth<T>(run: () => Promise<T>): Promise<T> 
  * token exchange error) is wrapped as an auth failure, not a transport mismatch: that
  * keeps the typeless-url caller from retrying over SSE and prompting for a second login.
  */
-export async function runInteractiveOAuth(name: string, config: { url: string }, makeTransport: MakeTransport, label: string, authUi: AuthUi, newClient: () => Client): Promise<Client> {
+export async function runInteractiveOAuth(name: string, config: { url: string; oauth?: OAuthServerConfig }, makeTransport: MakeTransport, label: string, authUi: AuthUi, newClient: () => Client): Promise<Client> {
   const approved = await authUi.confirm(`MCP server "${name}" requires login`, `Open your browser to authorize ${config.url}?`)
   if (!approved) throw new OAuthRequiredError(`login declined for ${name}`)
-  const provider = new FileOAuthProvider(name, (authorizationUrl) => {
-    openBrowser(String(authorizationUrl))
-    authUi.notify(`Authorize "${name}" in the browser. If it did not open: ${authorizationUrl}`, 'info')
-  })
+  const provider = new FileOAuthProvider(
+    name,
+    (authorizationUrl) => {
+      openBrowser(String(authorizationUrl))
+      authUi.notify(`Authorize "${name}" in the browser. If it did not open: ${authorizationUrl}`, 'info')
+    },
+    config.oauth,
+  )
   const { server, port } = await startCallbackServer(provider.savedRedirectPort())
   provider.bindRedirectPort(port)
   try {

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -15,7 +15,7 @@ import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotoc
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/websocket.js'
 import { ListRootsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
-import { FileOAuthProvider } from '../internal/mcp-oauth.js'
+import { FileOAuthProvider, type OAuthServerConfig } from '../internal/mcp-oauth.js'
 import { expandCwd, type HttpServerConfig, interpolateEnv, type ServerConfig, type StdioServerConfig } from './config.js'
 import { runInteractiveOAuth, serializeInteractiveOAuth } from './oauth-flow.js'
 
@@ -247,6 +247,11 @@ export async function connect(name: string, config: ServerConfig, authUi?: AuthU
     await connectWithTimeout(client, transport, `connect ${name} (ws)`)
     return client
   }
+  // The SDK's OAuth discovery has no override seam, so a configured metadata URL
+  // cannot be honored; say so instead of silently using standard discovery.
+  if (config.oauth?.authServerMetadataUrl) {
+    console.warn(`pi-code-mcp: server ${name} sets oauth.authServerMetadataUrl, which the MCP SDK cannot override; using standard discovery`)
+  }
   const headers: Record<string, string> = {}
   for (const [key, value] of Object.entries(config.headers ?? {})) headers[key] = fill(value)
   const token = resolveBearerToken(config)
@@ -268,6 +273,33 @@ export async function connect(name: string, config: ServerConfig, authUi?: AuthU
     // An explicitly declared streamable transport must not silently degrade to SSE.
     if (config.type !== undefined || isUnauthorized(error)) throw error
     return await connectHttpFamily(name, config, sseTransport, `connect ${name} (sse)`, configuredAuth, authUi, session)
+  }
+}
+
+/** Whether a connect failure is worth retrying: a 5xx response, a refused or reset
+ * connection, or a timeout. Auth and not-found errors need a configuration change. */
+function isTransientConnectError(error: unknown): boolean {
+  if (isUnauthorized(error)) return false
+  const code = typeof error === 'object' && error !== null ? (error as { code?: unknown }).code : undefined
+  if (typeof code === 'number') return code >= 500
+  return /ECONNREFUSED|ECONNRESET|ETIMEDOUT|timed out after/.test(String(error))
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Connect with Claude's first-connection retry: an HTTP or SSE server's transient
+ * failure (5xx, connection refused, timeout) is retried up to three times with a
+ * 1s-doubling delay. Stdio and WebSocket connects are attempted once, as are auth
+ * and not-found failures. */
+export async function connectWithRetries(name: string, config: ServerConfig, authUi?: AuthUi, session?: SessionDirs): Promise<Client> {
+  const retriable = !isStdio(config) && config.type !== 'ws' && config.type !== 'websocket'
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await connect(name, config, authUi, session)
+    } catch (error) {
+      if (!retriable || attempt >= 3 || !isTransientConnectError(error)) throw error
+      await delay(1000 * 2 ** attempt)
+    }
   }
 }
 
@@ -318,13 +350,15 @@ export type MakeTransport = (authProvider?: OAuthClientProvider) => HttpFamilyTr
  * header, or one from a headersHelper) never enters the OAuth path: the credential
  * to fix is the configured one, so an auth failure reports as a failed connection.
  */
-async function connectHttpFamily(name: string, config: { url: string }, makeTransport: MakeTransport, label: string, hasConfiguredAuth: boolean, authUi: AuthUi | undefined, session?: SessionDirs): Promise<Client> {
+async function connectHttpFamily(name: string, config: { url: string; oauth?: OAuthServerConfig }, makeTransport: MakeTransport, label: string, hasConfiguredAuth: boolean, authUi: AuthUi | undefined, session?: SessionDirs): Promise<Client> {
   const newClient = () => makeClient(session)
   // Stored tokens ride the first attempt so the SDK refreshes them; with none, no
   // provider is attached, so a 401 surfaces as a transport error carrying code 401
   // (isUnauthorized detects it) and only the interactive provider below ever runs
-  // dynamic registration, keeping it bound to the real callback port.
-  const silent = hasConfiguredAuth ? undefined : new FileOAuthProvider(name, () => {})
+  // dynamic registration, keeping it bound to the real callback port. A
+  // pre-configured client (oauth.clientId) rides the silent provider too, so its
+  // stored tokens refresh with the configured credentials.
+  const silent = hasConfiguredAuth ? undefined : new FileOAuthProvider(name, () => {}, config.oauth)
   try {
     const client = newClient()
     await connectWithTimeout(client, makeTransport(silent?.hasTokens() ? silent : undefined), label)

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2367,3 +2367,146 @@ describe('mcp configured authorization', () => {
     expect(line.startsWith('locked: failed: ')).toBe(true)
   })
 })
+
+describe('mcp automatic reconnection', () => {
+  const dropLastClient = (): void => {
+    const client = hoisted.clients.at(-1) as { onclose?: () => void }
+    client.onclose?.()
+  }
+
+  it('reconnects a dropped remote server after a one-second backoff', async () => {
+    // Claude reconnects a remote server that drops mid-session with exponential
+    // backoff, starting at one second.
+    withTools([{ name: 'go' }])
+    const harness = await setupStarted({ user: { remote: { type: 'http', url: 'https://api.example/mcp' } } })
+    const before = hoisted.transports.length
+    vi.useFakeTimers()
+
+    dropLastClient()
+    expect((await statusLinesOf(harness))[0]).toContain('disconnected')
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(hoisted.transports.length).toBeGreaterThan(before)
+    expect((await statusLinesOf(harness))[0]).toContain('remote: connected')
+  })
+
+  it('doubles the delay each attempt and gives up after five failed reconnects', async () => {
+    withTools([{ name: 'go' }])
+    const harness = await setupStarted({ user: { remote: { type: 'http', url: 'https://api.example/mcp' } } })
+    const before = hoisted.transports.length
+    hoisted.control.connect = async () => {
+      throw new Error('still down')
+    }
+    vi.useFakeTimers()
+
+    dropLastClient()
+    // Delays 1+2+4+8+16 = 31s cover all five attempts.
+    await vi.advanceTimersByTimeAsync(31_000)
+    const afterFive = hoisted.transports.length
+    expect(afterFive - before).toBe(5)
+
+    // No sixth attempt, and the server reports failed.
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(hoisted.transports.length).toBe(afterFive)
+    expect((await statusLinesOf(harness))[0]).toContain('remote: failed')
+  })
+
+  it('does not reconnect a dropped stdio server, which is a local process', async () => {
+    withTools([{ name: 'go' }])
+    const harness = await setupStarted({ user: { local: { command: 'x' } } })
+    const before = hoisted.transports.length
+    vi.useFakeTimers()
+
+    dropLastClient()
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    expect(hoisted.transports.length).toBe(before)
+    expect((await statusLinesOf(harness))[0]).toContain('disconnected')
+  })
+
+  it('retries a transient first connect of a remote server, but not an auth error', async () => {
+    // Claude retries an HTTP/SSE first connection after a transient error (5xx,
+    // connection refused, timeout), up to three times.
+    withTools([{ name: 'go' }])
+    let attempts = 0
+    hoisted.control.connect = async () => {
+      attempts++
+      if (attempts === 1) throw Object.assign(new Error('bad gateway'), { code: 502 })
+    }
+    vi.useFakeTimers()
+    const harness = await setup({ user: { flaky: { type: 'http', url: 'https://api.example/mcp' } } })
+    const starting = harness.sessionStart()
+    await vi.advanceTimersByTimeAsync(1000)
+    await starting
+
+    expect(attempts).toBe(2)
+    expect((await statusLinesOf(harness))[0]).toContain('flaky: connected')
+  })
+
+  it('gives up a transient first connect after three retries', async () => {
+    withTools([{ name: 'go' }])
+    let attempts = 0
+    hoisted.control.connect = async () => {
+      attempts++
+      throw Object.assign(new Error('bad gateway'), { code: 502 })
+    }
+    vi.useFakeTimers()
+    const harness = await setup({ user: { down: { type: 'http', url: 'https://api.example/mcp' } } })
+    const starting = harness.sessionStart()
+    await vi.advanceTimersByTimeAsync(31_000)
+    await starting
+
+    expect(attempts).toBe(4)
+    expect((await statusLinesOf(harness))[0]).toContain('down: failed')
+  })
+
+  it('does not retry a not-found first connect or a stdio spawn failure', async () => {
+    withTools([{ name: 'go' }])
+    let attempts = 0
+    hoisted.control.connect = async () => {
+      attempts++
+      throw Object.assign(new Error('no such endpoint'), { code: 404 })
+    }
+    vi.useFakeTimers()
+    const harness = await setup({ user: { gone: { type: 'http', url: 'https://api.example/mcp' }, broken: { command: 'x' } } })
+    const starting = harness.sessionStart()
+    await vi.advanceTimersByTimeAsync(31_000)
+    await starting
+
+    expect(attempts).toBe(2) // one per server, no retries
+  })
+})
+
+describe('mcp tool-call auth retry', () => {
+  it('reconnects and retries a tool call once after a 401, picking up fresh headers', async () => {
+    // Claude: on a 401/403 tool result, re-run the helper, reconnect, retry once.
+    withTools([{ name: 'go' }])
+    let calls = 0
+    hoisted.control.callTool = async () => {
+      calls++
+      if (calls === 1) throw Object.assign(new Error('expired'), { code: 401 })
+      return { content: [{ type: 'text', text: 'ok' }] }
+    }
+    const harness = await setupStarted({ user: { srv: { type: 'http', url: 'https://api.example/mcp' } } })
+    const before = hoisted.transports.length
+
+    const result = await harness.tools[0].execute('c1', {})
+
+    expect(calls).toBe(2)
+    expect(hoisted.transports.length).toBeGreaterThan(before)
+    expect((result.content[0] as { text: string }).text).toBe('ok')
+  })
+
+  it('retries the call only once: a second 401 surfaces as the error', async () => {
+    withTools([{ name: 'go' }])
+    let calls = 0
+    hoisted.control.callTool = async () => {
+      calls++
+      throw Object.assign(new Error('expired'), { code: 401 })
+    }
+    const harness = await setupStarted({ user: { srv: { type: 'http', url: 'https://api.example/mcp' } } })
+
+    await expect(harness.tools[0].execute('c1', {})).rejects.toThrow('expired')
+    expect(calls).toBe(2)
+  })
+})

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -88,6 +88,36 @@ describe('FileOAuthProvider', () => {
     expect(a.state()).not.toBe(b.state()) // a fresh token per attempt
   })
 
+  it('serves pre-configured oauth credentials from the config instead of dynamic registration', () => {
+    // Claude's oauth object: clientId names a pre-registered client, and the client
+    // secret comes from the MCP_CLIENT_SECRET environment variable.
+    const saved = process.env.MCP_CLIENT_SECRET
+    process.env.MCP_CLIENT_SECRET = 'shh'
+    try {
+      const provider = new FileOAuthProvider('pre', () => {}, { clientId: 'cid-9' })
+      expect(provider.clientInformation()).toEqual({ client_id: 'cid-9', client_secret: 'shh' })
+    } finally {
+      if (saved === undefined) delete process.env.MCP_CLIENT_SECRET
+      else process.env.MCP_CLIENT_SECRET = saved
+    }
+  })
+
+  it('serves a public pre-configured client when no MCP_CLIENT_SECRET is set', () => {
+    delete process.env.MCP_CLIENT_SECRET
+    const provider = new FileOAuthProvider('pre', () => {}, { clientId: 'cid-9' })
+    expect(provider.clientInformation()).toEqual({ client_id: 'cid-9' })
+  })
+
+  it('pins the requested scopes from oauth.scopes in the client metadata', () => {
+    const provider = new FileOAuthProvider('scoped', () => {}, { scopes: 'channels:read chat:write' })
+    expect(provider.clientMetadata.scope).toBe('channels:read chat:write')
+  })
+
+  it('prefers the configured callbackPort over a previously bound port', () => {
+    const provider = new FileOAuthProvider('ported', () => {}, { callbackPort: 8123 })
+    expect(provider.savedRedirectPort()).toBe(8123)
+  })
+
   it('fails closed when the code verifier is read before one is saved', () => {
     // The SDK asks for the PKCE verifier during the token exchange; a fresh provider has
     // none, so it must throw rather than hand back an empty proof.


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #148).

## Reconnection (extensions/mcp/index.ts, transport.ts)
- A remote server that drops mid-session reconnects automatically with exponential backoff: five attempts, delays doubling from one second. Stdio servers are local processes and are not reconnected. A `shuttingDown` flag keeps the deliberate shutdown teardown (which closes clients while they are still mapped) from scheduling reconnects.
- A remote server's failed first connection retries up to three times on a transient error (a 5xx response, a connection refused, a timeout); auth and not-found errors, stdio, and WebSocket connects are attempted once. The backoff reconnect uses its own schedule and skips the first-connect retry.

## Tool-call auth recovery (index.ts)
- A tool call rejected with 401/403 drops the client, reconnects once (which re-runs the `headersHelper` for fresh credentials and refreshes stored OAuth tokens), and retries the call once; a second auth failure surfaces. Applies to registered server tools and the hooks `mcp_tool` calling seam.

## oauth config object (internal/mcp-oauth.ts, config.ts, oauth-flow.ts)
- `oauth.clientId` serves pre-configured client credentials instead of dynamic registration, with the client secret read from `MCP_CLIENT_SECRET` (`token_endpoint_auth_method` becomes `client_secret_post` when a secret is present).
- `oauth.callbackPort` fixes the loopback callback port for pre-registered redirect URIs.
- `oauth.scopes` pins the requested scopes via the client metadata `scope` field.
- `oauth.authServerMetadataUrl` is accepted but warned as unsupported: the MCP SDK's discovery has no override seam (documented divergence).

Docs: `docs/mcp.md` gains the oauth object and lifecycle sections.

All changes covered by tests that failed before the change (10 red tests), plus mutation checks on the two guards that never independently failed (stdio no-reconnect, non-transient no-retry).