### PR TITLE
Align hook timing, mcp_tool input, model-switch events, and dedup with Claude docs

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -11,7 +11,8 @@ Runs Claude Code's `.claude/settings.json` hooks on pi's lifecycle events. Sourc
 - **UserPromptSubmit**: blocks the prompt or injects context ahead of it.
 - **Stop**: a block (or `additionalContext`) feeds back as a new turn, with `stop_hook_active` as the loop guard and a consecutive-block cap of 8 (`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`; `0` disables the cap). Does not run when the turn ended on a user interrupt, as Claude documents.
 - **SubagentStart / SubagentStop**: notify-only (a child has already exited by SubagentStop).
-- **PreCompact / PostCompact / SessionEnd / Notification** (`idle_prompt`, the one type pi can source): notify-only.
+- **PreCompact / PostCompact / SessionEnd / Notification** (`idle_prompt`, the one type pi can source): notify-only. `idle_prompt` fires when the turn ended about 60 seconds ago and the user hasn't typed since, per Claude's timing; input or the next turn cancels it. After compaction, **SessionStart** also fires with source `compact`.
+- **PostModelSwitch**: fires after the session's model changes, matched against the new model id; stdout/`additionalContext` reaches the model on the next turn. `requested_model` is `null` (pi does not carry the requested alias) and the cost-estimate fields are absent rather than fabricated. PreModelSwitch stays unbridged: pi's `model_select` event has no veto seam, and a blocking hook whose decision is silently ignored would be worse than an absent event. MessageDisplay is likewise unbridged (pi has no display-replacement seam).
 - **InstructionsLoaded**: observational; fires per loaded context file at session start, plus `path_glob_match` on a scoped-rule attach and `include` per resolved `@import`, deduped per session. `nested_traversal`/`compact` reasons never fire (pi does not lazily load nested CLAUDE.md or reload after compaction).
 
 ## Hook types
@@ -19,7 +20,7 @@ Runs Claude Code's `.claude/settings.json` hooks on pi's lifecycle events. Sourc
 - `type: "command"` (default): runs via `sh -c` with the event JSON on stdin, or exec form (`command` as an argv array, no shell); executes with `CLAUDECODE=1` and `CLAUDE_PROJECT_DIR` set.
 - `type: "http"`: POSTs the payload; a 2xx JSON body renders the decision, everything else is non-blocking per Claude's contract. Targets are gated by `allowedHttpHookUrls` (union of managed and settings scopes; unset allows all, `[]` blocks every http hook).
 - `type: "prompt"`: evaluates in-process against the session model.
-- `type: "mcp_tool"`: calls a connected server's tool.
+- `type: "mcp_tool"`: calls a connected server's tool. String values in `input` support `${path}` substitution from the hook's JSON input (`${tool_input.file_path}`); without `input` the tool is called with no arguments.
 - `type: "agent"` (experimental): spawns a read-only Read/Grep/Glob subagent that returns the JSON decision.
 - For all non-command types: a missing model/server/runner is non-blocking; only a PreToolUse timeout fails closed.
 
@@ -28,6 +29,7 @@ Runs Claude Code's `.claude/settings.json` hooks on pi's lifecycle events. Sourc
 - Payloads use Claude's vocabulary for pi's built-ins: `Bash`/`Edit`/`Write`/`Read`/`Grep`/`Glob` names, the documented input shapes with absolute `file_path`, and the documented Bash/Write response shapes; `updatedInput` is translated back to pi's shape (an incomplete rewrite keeps the original input).
 - Every payload carries `session_id`, `transcript_path`, `cwd`, `permission_mode`, `effort`; tool events add `tool_use_id`.
 - Claude matcher semantics, including `mcp__server__tool` names; Stop and UserPromptSubmit ignore a stray matcher.
+- Identical handlers collapse across settings files only; a plugin's copy of the same handler stays separate, and http handlers differing only in headers are distinct.
 - The `if` permission-rule filter (`"Bash(git *)"`, `"Edit(*.ts)"`) runs on tool events only; a hook carrying it never runs elsewhere.
 - `permissionDecision: "ask"` prompts via a confirm dialog (blocks when headless); `"defer"` blocks the call, since pi cannot resume a deferred one.
 - Exit-2 blocking messages prefer the JSON reason over stderr.

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -138,6 +138,14 @@ export function loadHooks(files: string[], sources?: Map<HookMatcher, string>): 
   return config
 }
 
+/** Claude dedups identical handlers across settings files only; a plugin's copy
+ * stays separate, so plugin entries carry their origin into the dedup key. */
+function stampOrigin(entries: HookMatcher[], origin: string): void {
+  for (const entry of entries) {
+    for (const hook of entry.hooks ?? []) hook.origin = origin
+  }
+}
+
 function mergeHooksJson(config: HooksConfig, raw: string, source: string, sources?: Map<HookMatcher, string>, origin?: string): void {
   let parsed: { hooks?: HooksConfig }
   try {
@@ -153,11 +161,7 @@ function mergeHooksJson(config: HooksConfig, raw: string, source: string, source
     // call for the rest of the session failed with an opaque type error.
     const usable = matchers.filter((entry) => isUsableMatcher(entry, source, event))
     if (usable.length === 0) continue
-    // Claude dedups identical handlers across settings files only; a plugin's copy
-    // stays separate, so plugin entries carry their origin into the dedup key.
-    if (origin !== undefined) {
-      for (const entry of usable) for (const hook of entry.hooks ?? []) hook.origin = origin
-    }
+    if (origin !== undefined) stampOrigin(usable, origin)
     config[event] = [...(config[event] ?? []), ...usable]
     // Each parse produces fresh entry objects, so object identity keys the /hooks
     // viewer's source attribution without touching the entries themselves.

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -41,6 +41,9 @@ export interface HookCommand {
   /** prompt/agent entries: an optional model override; agent adds a system prompt. */
   model?: string
   systemPrompt?: string
+  /** Dedup scope: unset for settings files (identical handlers collapse across
+   * them); a plugin's or skill's copy carries its origin and stays separate. */
+  origin?: string
 }
 export interface HookMatcher {
   matcher?: string
@@ -135,7 +138,7 @@ export function loadHooks(files: string[], sources?: Map<HookMatcher, string>): 
   return config
 }
 
-function mergeHooksJson(config: HooksConfig, raw: string, source: string, sources?: Map<HookMatcher, string>): void {
+function mergeHooksJson(config: HooksConfig, raw: string, source: string, sources?: Map<HookMatcher, string>, origin?: string): void {
   let parsed: { hooks?: HooksConfig }
   try {
     parsed = JSON.parse(raw)
@@ -150,6 +153,11 @@ function mergeHooksJson(config: HooksConfig, raw: string, source: string, source
     // call for the rest of the session failed with an opaque type error.
     const usable = matchers.filter((entry) => isUsableMatcher(entry, source, event))
     if (usable.length === 0) continue
+    // Claude dedups identical handlers across settings files only; a plugin's copy
+    // stays separate, so plugin entries carry their origin into the dedup key.
+    if (origin !== undefined) {
+      for (const entry of usable) for (const hook of entry.hooks ?? []) hook.origin = origin
+    }
     config[event] = [...(config[event] ?? []), ...usable]
     // Each parse produces fresh entry objects, so object identity keys the /hooks
     // viewer's source attribution without touching the entries themselves.
@@ -167,12 +175,12 @@ export function loadPluginHooks(config: HooksConfig, plugins: InstalledPlugin[],
     // numeric event keys), so it falls through to the default path rather than
     // silently registering nothing.
     if (declared !== null && typeof declared === 'object' && !Array.isArray(declared)) {
-      mergeHooksJson(config, substitutePluginVars(JSON.stringify({ hooks: declared }), plugin), `${plugin.name} (plugin.json)`, sources)
+      mergeHooksJson(config, substitutePluginVars(JSON.stringify({ hooks: declared }), plugin), `${plugin.name} (plugin.json)`, sources, `plugin:${plugin.name}`)
       continue
     }
     const file = path.resolve(plugin.root, typeof declared === 'string' ? declared : path.join('hooks', 'hooks.json'))
     try {
-      mergeHooksJson(config, substitutePluginVars(fs.readFileSync(file, 'utf-8'), plugin), file, sources)
+      mergeHooksJson(config, substitutePluginVars(fs.readFileSync(file, 'utf-8'), plugin), file, sources, `plugin:${plugin.name}`)
     } catch {
       // a plugin without hooks contributes nothing
     }

--- a/extensions/hooks/index.ts
+++ b/extensions/hooks/index.ts
@@ -20,7 +20,12 @@
  * - Stop            -> pi `agent_end` (a block feeds its reason back as a new turn,
  *                      with stop_hook_active as the loop guard)
  * - PreCompact      -> pi `session_before_compact` (fire-and-forget)
- * - PostCompact     -> pi `session_compact` (fire-and-forget)
+ * - PostCompact     -> pi `session_compact` (fire-and-forget); the same event also
+ *                      fires SessionStart with source "compact", as Claude does
+ *                      when a session continues after compaction
+ * - PostModelSwitch -> pi `model_select` (after the change, matched against the new
+ *                      model id; stdout context rides the next agent start;
+ *                      PreModelSwitch stays unbridged, pi has no veto seam)
  * - PostToolUseFailure -> pi `tool_result` error branch (stderr/additionalContext
  *                      appended to the failed result; it cannot block, the tool failed)
  * - SessionEnd      -> pi `session_shutdown` (fire-and-forget)
@@ -160,6 +165,15 @@ function claudeSpelling(map: Record<string, string>, raw: string): { names: stri
   return { names: value === raw ? [raw] : [raw, value], value }
 }
 
+/** Claude: idle_prompt fires when "Claude finished responding about 60 seconds ago
+ * and you haven't typed since". */
+const IDLE_PROMPT_DELAY_MS = 60_000
+
+/** pi's model_select sources in Claude's PostModelSwitch vocabulary: an explicit
+ * set is a command-style request, cycling is the picker, and restore is the model
+ * Claude Code restores on resume. */
+const MODEL_SELECT_SOURCE: Record<string, string> = { set: 'command', cycle: 'picker', restore: 'resume' }
+
 export default function hooksExtension(pi: ExtensionAPI) {
   let config: HooksConfig = {}
   let projectDir = ''
@@ -170,6 +184,14 @@ export default function hooksExtension(pi: ExtensionAPI) {
   /** Consecutive Stop-hook blocks with no user progress between them. Reset on user input
    * and on a non-blocking Stop; at the cap the continuation is suppressed and the turn ends. */
   let stopHookBlockCount = 0
+  /** The pending idle_prompt notification: Claude fires it when the turn ended about
+   * 60 seconds ago and the user hasn't typed since, so it arms on agent_end and is
+   * canceled by input or the next turn. */
+  let idlePromptTimer: ReturnType<typeof setTimeout> | undefined
+  const cancelIdlePrompt = (): void => {
+    clearTimeout(idlePromptTimer)
+    idlePromptTimer = undefined
+  }
   let sessionCtx: ExtensionContext | undefined
   /** Claude's disableAllHooks escape hatch was set somewhere in the honored chain. */
   let hooksDisabled = false
@@ -353,6 +375,8 @@ export default function hooksExtension(pi: ExtensionAPI) {
   // over the bus from context-imports, which owns claudeMdExcludes; announcing
   // the raw contextFiles here would fire for a file the exclusion removed.
   pi.on('before_agent_start', async () => {
+    // A new turn is beginning, so the session is no longer idle.
+    cancelIdlePrompt()
     if (pendingSessionContext.length === 0) return
     const content = pendingSessionContext.join('\n')
     pendingSessionContext = []
@@ -452,6 +476,8 @@ export default function hooksExtension(pi: ExtensionAPI) {
     // Only genuine user input; extension-injected messages (plan-mode, subagent) are not
     // prompts the user submitted.
     if (event.source === 'extension') return { action: 'continue' }
+    // The user typed, so the pending idle_prompt no longer applies.
+    cancelIdlePrompt()
     // Genuine user input is progress, so it breaks a Stop-hook continuation streak: the
     // block cap counts only consecutive blocks with nothing from the user in between.
     stopHookBlockCount = 0
@@ -479,11 +505,18 @@ export default function hooksExtension(pi: ExtensionAPI) {
   // automatic retry or compaction; that is the better tradeoff.
   pi.on('agent_end', async (event, ctx) => {
     // Claude's Notification event, for the one type pi can honestly source: the
-    // agent finished and is waiting for input (idle_prompt). Observational only;
-    // exit codes and JSON output are ignored, as Claude documents for this event.
+    // agent finished and is waiting for input. Per Claude, idle_prompt fires when
+    // the turn ended about 60 seconds ago and the user hasn't typed since, so it
+    // arms here and input or the next turn cancels it. Observational only; exit
+    // codes and JSON output are ignored, as Claude documents for this event.
+    cancelIdlePrompt()
     const notifyCommands = matchingCommands(config.Notification, ['idle_prompt'])
     if (notifyCommands.length > 0) {
-      void runNotifyHooks(notifyCommands, { hook_event_name: 'Notification', notification_type: 'idle_prompt', message: 'pi is waiting for your input' }, boundRunner(ctx)).catch(() => {})
+      const runner = boundRunner(ctx)
+      idlePromptTimer = setTimeout(() => {
+        void runNotifyHooks(notifyCommands, { hook_event_name: 'Notification', notification_type: 'idle_prompt', message: 'pi is waiting for your input' }, runner).catch(() => {})
+      }, IDLE_PROMPT_DELAY_MS)
+      idlePromptTimer.unref?.()
     }
 
     // Stop has no matcher support (a stray matcher is ignored, as Claude documents)
@@ -557,6 +590,33 @@ export default function hooksExtension(pi: ExtensionAPI) {
     const trigger = claudeSpelling(PRECOMPACT_TRIGGER, event.reason)
     const results = await runNotifyHooks(matchingCommands(config.PostCompact, trigger.names), { hook_event_name: 'PostCompact', trigger: trigger.value }, boundRunner(ctx))
     surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
+    // Claude also fires SessionStart with source "compact" when the session
+    // continues after compaction; its stdout context rides the next agent start,
+    // the same as any other SessionStart context.
+    const sessionStart = matchingCommands(config.SessionStart, 'compact')
+    if (sessionStart.length > 0) {
+      const startResults = await runNotifyHooks(sessionStart, { hook_event_name: 'SessionStart', source: 'compact' }, boundRunner(ctx))
+      surfaceSystemMessages(startResults, (message) => ctx.ui.notify(message, 'warning'))
+      pendingSessionContext.push(...startResults.map((result) => promptContext(result.stdout)).filter(Boolean))
+    }
+  })
+
+  pi.on('model_select', async (event, ctx) => {
+    // Claude's PostModelSwitch: runs after the session's model changes, matched
+    // against the model switched to; it can't block. PreModelSwitch stays
+    // unbridged: pi's model_select has no veto seam, and a "Pre" hook whose block
+    // decision is silently ignored would be worse than an absent event.
+    const { model, previousModel, source } = event as { model: { id: string }; previousModel?: { id: string }; source: string }
+    if (!previousModel || previousModel.id === model.id) return
+    const commands = matchingCommands(config.PostModelSwitch, model.id)
+    if (commands.length === 0) return
+    // requested_model is null: pi does not carry the alias the request named.
+    const payload = { hook_event_name: 'PostModelSwitch', from_model: previousModel.id, to_model: model.id, requested_model: null, source: MODEL_SELECT_SOURCE[source] ?? 'command' }
+    const results = await runNotifyHooks(commands, payload, boundRunner(ctx))
+    surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
+    // Claude delivers the hook's stdout (or additionalContext) to Claude with the
+    // next request after the switch; pi's seam for that is the next agent start.
+    pendingSessionContext.push(...results.map((result) => promptContext(result.stdout)).filter(Boolean))
   })
 
   pi.on('session_shutdown', async (event, ctx) => {

--- a/extensions/hooks/matcher.ts
+++ b/extensions/hooks/matcher.ts
@@ -115,9 +115,12 @@ function collectCommands(matchers: HookMatcher[] | undefined, applies: (entry: H
     if (!applies(entry)) continue
     for (const raw of (entry.hooks ?? []).filter(isRunnableHook)) {
       const hook = withCommand(raw)
-      // Claude runs a handler defined in more than one settings file once.
-      if (seen.has(hook.command)) continue
-      seen.add(hook.command)
+      // Claude runs a handler defined in more than one settings file once; a
+      // plugin's or skill's copy of the same handler stays separate, and http
+      // handlers with the same URL but different headers are distinct.
+      const key = `${hook.origin ?? 'settings'}\n${hook.command}\n${hook.headers ? JSON.stringify(hook.headers) : ''}`
+      if (seen.has(key)) continue
+      seen.add(key)
       result.push(hook)
     }
   }

--- a/extensions/hooks/runners.ts
+++ b/extensions/hooks/runners.ts
@@ -247,12 +247,6 @@ export async function runPromptHook(hook: HookCommand, payload: unknown, model: 
   }
 }
 
-/**
- * Claude's `type: "mcp_tool"` hook: call a tool on an already-connected MCP server
- * and treat its text output like command stdout. pi reaches the server through the
- * mcp-call seam the mcp extension registers. Like http, it never fails closed: a
- * missing server, a tool error, or the deadline is non-blocking.
- */
 /** A dotted path into the hook's JSON input, or undefined when any step is missing. */
 function lookupPath(payload: unknown, dotted: string): unknown {
   let current: unknown = payload
@@ -280,6 +274,12 @@ function substituteInputPaths(value: unknown, payload: unknown): unknown {
   return value
 }
 
+/**
+ * Claude's `type: "mcp_tool"` hook: call a tool on an already-connected MCP server
+ * and treat its text output like command stdout. pi reaches the server through the
+ * mcp-call seam the mcp extension registers. Like http, it never fails closed: a
+ * missing server, a tool error, or the deadline is non-blocking.
+ */
 export async function runMcpToolHook(hook: HookCommand, payload: unknown, timeoutMs: number): Promise<HookRunResult> {
   if (!hook.server || !hook.tool) return { code: 1, stdout: '', stderr: 'mcp_tool hook needs server and tool', timedOut: false }
   // Claude: `input` is the arguments passed to the tool; without it the tool is

--- a/extensions/hooks/runners.ts
+++ b/extensions/hooks/runners.ts
@@ -253,9 +253,38 @@ export async function runPromptHook(hook: HookCommand, payload: unknown, model: 
  * mcp-call seam the mcp extension registers. Like http, it never fails closed: a
  * missing server, a tool error, or the deadline is non-blocking.
  */
+/** A dotted path into the hook's JSON input, or undefined when any step is missing. */
+function lookupPath(payload: unknown, dotted: string): unknown {
+  let current: unknown = payload
+  for (const key of dotted.split('.')) {
+    if (current === null || typeof current !== 'object') return undefined
+    current = (current as Record<string, unknown>)[key]
+  }
+  return current
+}
+
+/** Claude's ${path} substitution for mcp_tool input: string values may reference the
+ * hook's JSON input, such as ${tool_input.file_path}. Arrays and nested objects are
+ * walked; an unresolvable path stays literal; non-string looked-up values are
+ * JSON-encoded into the string. */
+function substituteInputPaths(value: unknown, payload: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replace(/\$\{([\w.]+)\}/g, (matchText, dotted: string) => {
+      const found = lookupPath(payload, dotted)
+      if (found === undefined) return matchText
+      return typeof found === 'string' ? found : JSON.stringify(found)
+    })
+  }
+  if (Array.isArray(value)) return value.map((entry) => substituteInputPaths(entry, payload))
+  if (value !== null && typeof value === 'object') return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, substituteInputPaths(entry, payload)]))
+  return value
+}
+
 export async function runMcpToolHook(hook: HookCommand, payload: unknown, timeoutMs: number): Promise<HookRunResult> {
   if (!hook.server || !hook.tool) return { code: 1, stdout: '', stderr: 'mcp_tool hook needs server and tool', timedOut: false }
-  const input = hook.input && typeof hook.input === 'object' ? hook.input : (payload as Record<string, unknown>)
+  // Claude: `input` is the arguments passed to the tool; without it the tool is
+  // called with no arguments, never handed the whole event payload.
+  const input = hook.input && typeof hook.input === 'object' ? (substituteInputPaths(hook.input, payload) as Record<string, unknown>) : {}
   let timer: ReturnType<typeof setTimeout> | undefined
   const deadline = new Promise<HookRunResult>((resolve) => {
     timer = setTimeout(() => resolve({ code: 1, stdout: '', stderr: `mcp_tool hook timed out after ${timeoutMs}ms`, timedOut: false }), timeoutMs)

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -198,6 +198,7 @@ const setupExtension = () => {
     userBash: (command: string, ctxOverride: Record<string, unknown> = {}) => handler('user_bash')({ type: 'user_bash', command, excludeFromContext: false, cwd: '/proj' }, { ...defaultCtx, ...ctxOverride }),
     input: (text: string, source = 'interactive') => handler('input')({ text, source }, defaultCtx),
     agentEnd: (messages: unknown[] = []) => handler('agent_end')({ messages }, defaultCtx),
+    modelSelect: (to: string, from?: string, source = 'set') => handler('model_select')({ model: { id: to, name: to }, previousModel: from ? { id: from, name: from } : undefined, source }, defaultCtx),
     agentSettled: () => handler('agent_settled')({}, defaultCtx),
     beforeCompact: (reason: string) => handler('session_before_compact')({ reason }, defaultCtx),
     compacted: (reason: string) => handler('session_compact')({ reason }, defaultCtx),
@@ -617,7 +618,7 @@ describe('malformed hook config', () => {
 
 describe('hooks extension registration', () => {
   it('subscribes to the lifecycle events it bridges', () => {
-    expect(setupExtension().registered).toEqual(['session_start', 'before_agent_start', 'tool_call', 'tool_result', 'user_bash', 'input', 'agent_end', 'session_before_compact', 'session_compact', 'session_shutdown'])
+    expect(setupExtension().registered).toEqual(['session_start', 'before_agent_start', 'tool_call', 'tool_result', 'user_bash', 'input', 'agent_end', 'session_before_compact', 'session_compact', 'model_select', 'session_shutdown'])
   })
 })
 
@@ -1075,8 +1076,9 @@ describe('hooks extension notify-style events', () => {
   })
 
   it('bridges Notification hooks for idle_prompt on agent end, matcher-filtered', async () => {
-    // The one notification pi can honestly source today: the agent finished and
-    // is waiting for input. Observational only, like Claude documents.
+    // Claude: idle_prompt fires when "Claude finished responding about 60 seconds
+    // ago and you haven't typed since". Observational only, like Claude documents.
+    vi.useFakeTimers()
     const ext = await withHooks({
       Notification: [
         { matcher: 'idle_prompt', hooks: [{ command: 'notify-idle' }] },
@@ -1084,12 +1086,26 @@ describe('hooks extension notify-style events', () => {
       ],
     })
     await ext.agentEnd()
+    expect(commandsRun()).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(60_000)
 
     expect(commandsRun()).toEqual(['notify-idle'])
     const stdin = JSON.parse(recordFor('notify-idle').stdin)
     expect(stdin.hook_event_name).toBe('Notification')
     expect(stdin.notification_type).toBe('idle_prompt')
     expect(typeof stdin.message).toBe('string')
+  })
+
+  it('cancels the pending idle_prompt when the user types before the 60s idle window ends', async () => {
+    vi.useFakeTimers()
+    const ext = await withHooks({ Notification: [{ matcher: 'idle_prompt', hooks: [{ command: 'notify-idle' }] }] })
+    await ext.agentEnd()
+    await vi.advanceTimersByTimeAsync(30_000)
+    await ext.input('typing now')
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    expect(commandsRun()).toEqual([])
   })
 
   it('runs Stop hooks on agent end with stop_hook_active false', async () => {
@@ -2128,5 +2144,85 @@ describe('hooks polish: interrupts, timeout defaults, prompt-hook contract', () 
     expect(result.code).toBe(0)
     expect(seenPrompt).toContain('Should this stop?')
     expect(seenPrompt).toContain('"hook_event_name":"Stop"')
+  })
+})
+
+describe('hooks extension PostModelSwitch', () => {
+  const withHooks = async (config: Record<string, unknown>) => {
+    writeSettings(hoisted.home, 'settings.json', config)
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('runs PostModelSwitch hooks after a model change, matched against the new model', async () => {
+    // Claude runs PostModelSwitch after the session's model changes; the matcher
+    // compares against the canonical name of the model switched to.
+    const ext = await withHooks({
+      PostModelSwitch: [
+        { matcher: '.*opus.*', hooks: [{ command: 'on-opus' }] },
+        { matcher: '.*haiku.*', hooks: [{ command: 'on-haiku' }] },
+      ],
+    })
+    await ext.modelSelect('claude-opus-5', 'claude-sonnet-5', 'set')
+
+    expect(commandsRun()).toEqual(['on-opus'])
+    const stdin = JSON.parse(recordFor('on-opus').stdin)
+    expect(stdin).toMatchObject({ hook_event_name: 'PostModelSwitch', from_model: 'claude-sonnet-5', to_model: 'claude-opus-5', source: 'command' })
+  })
+
+  it("maps pi's model_select sources onto Claude's vocabulary", async () => {
+    const ext = await withHooks({ PostModelSwitch: [{ hooks: [{ command: 'switched' }] }] })
+    await ext.modelSelect('claude-opus-5', 'claude-sonnet-5', 'restore')
+
+    // pi's restore (model restored on resume) is Claude's "resume".
+    expect(JSON.parse(recordFor('switched').stdin).source).toBe('resume')
+  })
+})
+
+describe('hooks extension SessionStart compact source', () => {
+  const withHooks = async (config: Record<string, unknown>) => {
+    writeSettings(hoisted.home, 'settings.json', config)
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('fires SessionStart with source compact after a compaction, alongside PostCompact', async () => {
+    // Claude fires SessionStart with source "compact" when a session continues
+    // after compaction, in addition to the PostCompact event itself.
+    const ext = await withHooks({
+      SessionStart: [{ matcher: 'compact', hooks: [{ command: 'fresh-context' }] }],
+      PostCompact: [{ hooks: [{ command: 'post-compact' }] }],
+    })
+    await ext.compacted('manual')
+
+    expect(commandsRun().sort()).toEqual(['fresh-context', 'post-compact'])
+    expect(JSON.parse(recordFor('fresh-context').stdin)).toMatchObject({ hook_event_name: 'SessionStart', source: 'compact' })
+  })
+
+  it('does not fire compact-matched SessionStart hooks on a startup begin', async () => {
+    const ext = await withHooks({ SessionStart: [{ matcher: 'compact', hooks: [{ command: 'fresh-context' }] }] })
+    await ext.agentEnd()
+    expect(commandsRun()).toEqual([])
+    void ext
+  })
+})
+
+describe('hooks extension dedup scope', () => {
+  it('keeps a plugin copy of a settings-file handler separate, running both', async () => {
+    // Claude: "If you define the same handler in more than one settings file, it
+    // runs once. A plugin's or skill's copy of the same handler stays separate."
+    const root = join(hoisted.home, '.claude', 'plugins', 'cache', 'market', 'fmt', '1.0.0')
+    mkdirSync(join(root, 'hooks'), { recursive: true })
+    writeFileSync(join(root, 'hooks', 'hooks.json'), JSON.stringify({ hooks: { PostToolUse: [{ matcher: 'Write', hooks: [{ command: 'shared-format.sh' }] }] } }))
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { fmt: true }, hooks: { PostToolUse: [{ matcher: 'Write', hooks: [{ command: 'shared-format.sh' }] }] } }))
+
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.toolResult('write', { input: { path: 'a.ts' } })
+
+    expect(commandsRun()).toEqual(['shared-format.sh', 'shared-format.sh'])
   })
 })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -162,14 +162,40 @@ describe('runMcpToolHook', () => {
     expect(seen).toEqual({ server: 'gh', tool: 'lint', input: { strict: true } })
   })
 
-  it('passes the event payload as input when the hook declares none', async () => {
+  it('calls with no arguments when the hook declares no input, per the documented field', async () => {
+    // Claude's `input` field is optional: without it the tool is called with no
+    // arguments, not handed the whole event payload.
     let seenInput: unknown
     setMcpToolCaller(async (_s, _t, input) => {
       seenInput = input
       return { text: '', isError: false }
     })
     await runMcpToolHook({ type: 'mcp_tool', command: '', server: 'gh', tool: 'lint' }, { hook_event_name: 'PreToolUse', tool_name: 'bash' }, 5000)
-    expect(seenInput).toMatchObject({ tool_name: 'bash' })
+    expect(seenInput).toEqual({})
+  })
+
+  it('substitutes ${path} references from the hook JSON input into string values', async () => {
+    // Claude: "String values support ${path} substitution from the hook's JSON
+    // input, such as ${tool_input.file_path}".
+    let seenInput: unknown
+    setMcpToolCaller(async (_s, _t, input) => {
+      seenInput = input
+      return { text: '', isError: false }
+    })
+    const payload = { hook_event_name: 'PostToolUse', tool_name: 'Edit', tool_input: { file_path: '/src/a.ts' } }
+    const input = { file_path: '${tool_input.file_path}', label: 'checked ${tool_name}', nested: { p: '${tool_input.file_path}' } }
+    await runMcpToolHook({ type: 'mcp_tool', command: '', server: 'gh', tool: 'scan', input }, payload, 5000)
+    expect(seenInput).toEqual({ file_path: '/src/a.ts', label: 'checked Edit', nested: { p: '/src/a.ts' } })
+  })
+
+  it('leaves a ${path} that resolves to nothing as literal text', async () => {
+    let seenInput: unknown
+    setMcpToolCaller(async (_s, _t, input) => {
+      seenInput = input
+      return { text: '', isError: false }
+    })
+    await runMcpToolHook({ type: 'mcp_tool', command: '', server: 'gh', tool: 'scan', input: { x: '${no.such.path}' } }, { hook_event_name: 'PreToolUse' }, 5000)
+    expect(seenInput).toEqual({ x: '${no.such.path}' })
   })
 
   it('clears its deadline timer once the call settles instead of pinning the event loop', async () => {


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #150).

## idle_prompt timing (extensions/hooks/index.ts)
- The `idle_prompt` Notification now fires when the turn ended about 60 seconds ago and the user hasn't typed since, per Claude's documented timing, instead of instantly on every agent end. User input and the next turn cancel the pending notification.

## mcp_tool input (runners.ts)
- String values in a hook's `input` support `${path}` substitution from the hook's JSON input (such as `${tool_input.file_path}`), walking nested objects and arrays; an unresolvable path stays literal; non-string looked-up values are JSON-encoded.
- A hook without `input` calls the tool with no arguments, per the documented optional field, instead of handing it the whole event payload.

## PostModelSwitch and SessionStart compact (index.ts)
- `model_select` now bridges Claude's PostModelSwitch: fired after the model changes, matched against the new model id, with `from_model`/`to_model`/`source` mapped onto Claude's vocabulary and stdout context delivered on the next turn. `requested_model` is `null` and the cost-estimate fields are absent rather than fabricated. PreModelSwitch stays unbridged (pi's event has no veto seam; a blocking hook silently ignored would be worse than an absent event), as does MessageDisplay (no display-replacement seam) — both noted in `docs/hooks.md`.
- After compaction, SessionStart also fires with source `compact` alongside PostCompact, with its stdout context riding the next agent start.

## Dedup scope (matcher.ts, config.ts)
- Identical handlers collapse across settings files only: a plugin's copy of the same handler now stays separate (entries carry their plugin origin into the dedup key), and http handlers with the same URL but different headers are distinct.

Docs: `docs/hooks.md` and the extension header updated.

All changes covered by tests that failed before the change (9 red tests), plus a mutation check on the one guard that never independently failed (unresolvable `${path}` stays literal).