### PR TITLE
Load hooks from managed settings and skill frontmatter

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -2,6 +2,8 @@
 
 Runs Claude Code's `.claude/settings.json` hooks on pi's lifecycle events. Source: [`extensions/hooks/`](../extensions/hooks) (the module header in `index.ts` is the authoritative contract).
 
+Hook locations: settings files, managed policy settings, plugins, and skill frontmatter (registered at invocation for the rest of the session, with `once` removing a hook after its first successful run). Agent-frontmatter hooks are not yet loaded (tracked with the subagent work).
+
 ## Events
 
 - **PreToolUse**: blocks tools, rewrites input via `updatedInput`, injects `additionalContext` beside the eventual tool result.
@@ -43,4 +45,4 @@ Runs Claude Code's `.claude/settings.json` hooks on pi's lifecycle events. Sourc
 
 - A timed-out PreToolUse/UserPromptSubmit hook fails closed at a 60s default (Claude: 600s for PreToolUse, 30s for UserPromptSubmit, both non-blocking), since pi has no permission prompt to fall back on. Prompt hooks default to Claude's 30s and agent hooks to 60s; SessionEnd hooks share Claude's 1.5-second budget, raised by a declared per-hook `timeout` up to 60 seconds, so a slow hook cannot stall session exit.
 - Prompt hooks honor the `model` override (resolved against the models this user can run) and append the input JSON to the prompt when `$ARGUMENTS` is absent, as documented.
-- `disableAllHooks` in any scope turns the system off; `/hooks` prints the resolved configuration.
+- `disableAllHooks` is tiered per Claude: the managed level turns everything off; a settings-file value disables non-managed hooks while managed policy hooks keep running. `/hooks` prints the resolved configuration.

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -44,6 +44,11 @@ export interface HookCommand {
   /** Dedup scope: unset for settings files (identical handlers collapse across
    * them); a plugin's or skill's copy carries its origin and stays separate. */
   origin?: string
+  /** Claude's `once`: remove after the first successful run. Honored only for
+   * skill-frontmatter hooks; ignored in settings files and agent frontmatter. */
+  once?: boolean
+  /** Set after a once-hook's first successful run; collection skips spent hooks. */
+  spent?: boolean
 }
 export interface HookMatcher {
   matcher?: string
@@ -76,7 +81,13 @@ export function hookFiles(cwd: string, home: string, trusted: boolean): string[]
  * disabled in their own settings would defeat the escape hatch. The chain itself
  * already gates project files on trust (see hookFiles). */
 export function readDisableAllHooks(files: string[], managed: Record<string, unknown> = readManagedSettings()): boolean {
-  if (managed.disableAllHooks === true) return true
+  return managed.disableAllHooks === true || readSettingsDisableAllHooks(files)
+}
+
+/** The settings-chain half of disableAllHooks alone. Claude: user/project/local
+ * disableAllHooks cannot disable hooks configured through managed policy settings,
+ * so the caller keeps managed hooks running when only this half is set. */
+export function readSettingsDisableAllHooks(files: string[]): boolean {
   for (const file of files) {
     try {
       const parsed: unknown = JSON.parse(fs.readFileSync(file, 'utf-8'))
@@ -86,6 +97,22 @@ export function readDisableAllHooks(files: string[], managed: Record<string, unk
     }
   }
   return false
+}
+
+/** Hooks from managed policy settings, one of Claude's hook locations. They run
+ * even when user/project/local disableAllHooks is set; only the managed level's
+ * own disableAllHooks turns them off (the caller checks that tier). */
+export function loadManagedHooks(sources?: Map<HookMatcher, string>, managed: Record<string, unknown> = readManagedSettings()): HooksConfig {
+  const config: HooksConfig = {}
+  if (isRecord(managed.hooks)) mergeHooksJson(config, JSON.stringify({ hooks: managed.hooks }), 'managed settings', sources)
+  return config
+}
+
+/** Hooks a skill's frontmatter declares, registered when the skill is invoked and
+ * kept for the rest of the session, as Claude documents. They carry a skill origin
+ * so dedup keeps them separate from settings copies and `once` is honored. */
+export function mergeSkillHooks(config: HooksConfig, skillName: string, hooks: unknown, sources?: Map<HookMatcher, string>): void {
+  mergeHooksJson(config, JSON.stringify({ hooks }), `${skillName} (skill)`, sources, `skill:${skillName}`)
 }
 
 /** Claude's `allowedHttpHookUrls` setting: URL patterns http hooks may target, with

--- a/extensions/hooks/index.ts
+++ b/extensions/hooks/index.ts
@@ -73,12 +73,13 @@
  * `{"hookSpecificOutput": {"permissionDecision": "deny", ...}}` (or the older
  * `{"decision": "block"}`).
  *
- * Config is merged from ~/.claude/settings.json (always) plus the project's
- * .claude/settings.json and settings.local.json (only when the project is
- * trusted, since hooks execute arbitrary shell). Claude's `disableAllHooks`
- * setting (managed settings or any honored file in that chain) short-circuits
- * the load entirely, so no event fires any hook; /hooks prints the resolved
- * chain per event with each entry's source settings file. Matchers follow Claude's rule:
+ * Config is merged from managed policy settings, ~/.claude/settings.json (always),
+ * the project's .claude/settings.json and settings.local.json (only when the
+ * project is trusted, since hooks execute arbitrary shell), plugins, and invoked
+ * skills' frontmatter. Claude's `disableAllHooks` is tiered: at the managed level
+ * it turns everything off; in any honored settings file it disables the
+ * non-managed hooks while managed policy hooks keep running. /hooks prints the
+ * resolved chain per event with each entry's source. Matchers follow Claude's rule:
  * `*`/empty match all, plain names are exact (with `|`/`,` list separators), and
  * anything with other regex characters is an unanchored regex. Claude matchers
  * are PascalCase (`Bash`); pi tool names are lowercase (`bash`), so comparison
@@ -90,14 +91,16 @@
 import * as os from 'node:os'
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent'
 import { INSTRUCTIONS_CHANNEL, isInstructionLoadEvent } from '../internal/instruction-events.js'
+import { readManagedSettings } from '../internal/managed-settings.js'
 import { isMcpToolAliases, MCP_TOOLS_CHANNEL } from '../internal/mcp-alias.js'
 import { isPlanModeState, PLAN_MODE_CHANNEL } from '../internal/plan-mode-state.js'
 import { installedPlugins } from '../internal/plugins.js'
 import { isProjectApproved } from '../internal/project-approval.js'
 import { repoRoot } from '../internal/project-root.js'
+import { isSkillHooksEvent, SKILL_HOOKS_CHANNEL } from '../internal/skill-hooks.js'
 import { isSubagentPhaseEvent, SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
 import { claudeToolInput, claudeToolName, claudeToolResponse, piToolOutput } from './claude-tools.js'
-import { formatHooksSummary, type HookCommand, type HookMatcher, type HooksConfig, hookFiles, isBackgroundHook, loadHooks, loadPluginHooks, readAllowedHttpHookUrls, readDisableAllHooks } from './config.js'
+import { formatHooksSummary, type HookCommand, type HookMatcher, type HooksConfig, hookFiles, isBackgroundHook, loadHooks, loadManagedHooks, loadPluginHooks, mergeSkillHooks, readAllowedHttpHookUrls, readDisableAllHooks, readSettingsDisableAllHooks } from './config.js'
 import { blockedToolCall, jsonBlockVerdict, postToolFeedback, promptContext, runPreToolUse, runUserPromptSubmit, surfaceSystemMessages, tryParseJson } from './decisions.js'
 import { allCommands, matchingCommands, passesIfFilter } from './matcher.js'
 import { type HookRunner, type HookRunResult, runAgentHook, runHookCommand, runHttpHook, runMcpToolHook, runPromptHook, sessionEndTimeoutMs, timeoutMs } from './runners.js'
@@ -257,7 +260,14 @@ export default function hooksExtension(pi: ExtensionAPI) {
         if (hook.type === 'mcp_tool') return runMcpToolHook(hook, merged, ms)
         return runHookCommand(hook.command, merged, ms, projectDir, hook.args, onChild)
       }
-      if (!isBackgroundHook(hook)) return dispatch()
+      // Claude's `once` (skill-frontmatter hooks only): removed after the first
+      // successful run; a failure, block, or timeout leaves it in place.
+      const markOnce = async (run: Promise<HookRunResult>): Promise<HookRunResult> => {
+        const result = await run
+        if (hook.once === true && hook.origin?.startsWith('skill:') === true && result.code === 0 && !result.timedOut) hook.spent = true
+        return result
+      }
+      if (!isBackgroundHook(hook)) return markOnce(dispatch())
       let kill: (() => void) | undefined
       void dispatch((registered) => {
         kill = registered
@@ -274,6 +284,15 @@ export default function hooksExtension(pi: ExtensionAPI) {
         })
       return Promise.resolve({ code: 0, stdout: '', stderr: '', timedOut: false })
     }
+  // Hooks a skill's frontmatter declares arrive over the shared bus when the skill
+  // is invoked (see skills.ts) and stay registered for the rest of the session, as
+  // Claude documents; a session restart reloads config and drops them.
+  pi.events.on(SKILL_HOOKS_CHANNEL, (data) => {
+    if (!isSkillHooksEvent(data)) return
+    if (hooksDisabled) return
+    mergeSkillHooks(config, data.skillName, data.hooks, hookSources)
+  })
+
   // Claude matchers name MCP tools mcp__<server>__<tool>; pi-code registers them as
   // <server>_<tool>. The mcp extension publishes the mapping on pi's shared bus.
   const mcpAliases = new Map<string, string>()
@@ -345,15 +364,23 @@ export default function hooksExtension(pi: ExtensionAPI) {
     const files = hookFiles(ctx.cwd, os.homedir(), trusted)
     hookSources.clear()
     allowedHttpHookUrls = readAllowedHttpHookUrls(files)
-    // The disableAllHooks escape hatch, checked before any config loads: with no
-    // config resolved, no event, plugin hooks included, can fire a hook.
-    hooksDisabled = readDisableAllHooks(files)
-    if (hooksDisabled) {
+    // The disableAllHooks escape hatch, checked before any config loads. The tiers
+    // differ, as Claude documents: managed-level disableAllHooks turns everything
+    // off, while a settings-level one cannot disable the hooks an administrator
+    // configured through managed policy settings.
+    const managedSettings = readManagedSettings()
+    hooksDisabled = readDisableAllHooks(files, managedSettings)
+    if (managedSettings.disableAllHooks === true) {
       config = {}
       pendingSessionContext = []
       return
     }
-    config = loadHooks(files, hookSources)
+    config = loadManagedHooks(hookSources, managedSettings)
+    if (readSettingsDisableAllHooks(files)) {
+      pendingSessionContext = []
+      return
+    }
+    for (const [event, matchers] of Object.entries(loadHooks(files, hookSources))) config[event] = [...(config[event] ?? []), ...matchers]
     // Plugins are user-installed and enabled by user settings (see installedPlugins),
     // so a checked-out repo cannot toggle which code-bearing plugin hooks run.
     loadPluginHooks(config, installedPlugins(os.homedir()), hookSources)
@@ -639,7 +666,9 @@ export default function hooksExtension(pi: ExtensionAPI) {
   pi.registerCommand('hooks', {
     description: 'Show the hook configuration resolved from settings',
     handler: async (_args, ctx) => {
-      if (hooksDisabled) {
+      // With a settings-level disable, managed policy hooks stay active and the
+      // viewer still shows them; only a fully empty config reports disabled.
+      if (hooksDisabled && Object.keys(config).length === 0) {
         ctx.ui.notify('All hooks are disabled by the disableAllHooks setting.', 'info')
         return
       }

--- a/extensions/hooks/matcher.ts
+++ b/extensions/hooks/matcher.ts
@@ -104,8 +104,14 @@ function syntheticCommand(hook: HookCommand): string | undefined {
 /** A matched entry with its `command` filled in: mirroring the synthetic identity into
  * `command` keeps dedup, timeout messages and display working for non-shell hooks. */
 function withCommand(raw: HookCommand): HookCommand {
-  const identity = syntheticCommand(raw)
-  return identity !== undefined && typeof raw.command !== 'string' ? { ...raw, command: identity } : raw
+  // Fill the identity onto the config entry itself rather than a clone: the runner
+  // must receive the same object collection reads, so a once-hook marked spent
+  // after a successful run is the object the next collection filters out.
+  if (typeof raw.command !== 'string') {
+    const identity = syntheticCommand(raw)
+    if (identity !== undefined) raw.command = identity
+  }
+  return raw
 }
 
 function collectCommands(matchers: HookMatcher[] | undefined, applies: (entry: HookMatcher) => boolean): HookCommand[] {
@@ -114,6 +120,8 @@ function collectCommands(matchers: HookMatcher[] | undefined, applies: (entry: H
   for (const entry of matchers ?? []) {
     if (!applies(entry)) continue
     for (const raw of (entry.hooks ?? []).filter(isRunnableHook)) {
+      // A once-hook that already ran successfully is removed, as Claude documents.
+      if (raw.spent === true) continue
       const hook = withCommand(raw)
       // Claude runs a handler defined in more than one settings file once; a
       // plugin's or skill's copy of the same handler stays separate, and http

--- a/extensions/internal/skill-hooks.ts
+++ b/extensions/internal/skill-hooks.ts
@@ -1,0 +1,19 @@
+/**
+ * The bus channel skills.ts publishes frontmatter hooks on. Claude registers a
+ * skill's hooks when the skill is invoked and keeps them for the rest of the
+ * session; the hooks extension owns running them, so the skill side only
+ * announces the declaration.
+ */
+
+export const SKILL_HOOKS_CHANNEL = 'pi-code:skill-hooks'
+
+export interface SkillHooksEvent {
+  skillName: string
+  hooks: Record<string, unknown>
+}
+
+export function isSkillHooksEvent(data: unknown): data is SkillHooksEvent {
+  if (typeof data !== 'object' || data === null) return false
+  const event = data as { skillName?: unknown; hooks?: unknown }
+  return typeof event.skillName === 'string' && typeof event.hooks === 'object' && event.hooks !== null && !Array.isArray(event.hooks)
+}

--- a/extensions/skills.ts
+++ b/extensions/skills.ts
@@ -30,6 +30,7 @@ import { claudeConfigDir } from './internal/config-dir.js'
 import { installedPlugins } from './internal/plugins.js'
 import { isProjectApprovedSilently } from './internal/project-approval.js'
 import { ancestorDirs } from './internal/project-root.js'
+import { SKILL_HOOKS_CHANNEL } from './internal/skill-hooks.js'
 
 function isDirectory(target: string): boolean {
   try {
@@ -139,13 +140,22 @@ async function expandSkillInvocation(pi: ExtensionAPI, rawText: string, ctx: Ext
   const found = findClaudeSkill(name, skillDirs(ctx.cwd, os.homedir(), trusted))
   if (!found) return
   let parsed: ReturnType<typeof parseCommandFile>
+  let content: string
   try {
-    parsed = parseCommandFile(fs.readFileSync(found.filePath, 'utf-8'))
+    content = fs.readFileSync(found.filePath, 'utf-8')
+    parsed = parseCommandFile(content)
   } catch {
     // Unreadable, or malformed frontmatter: pass through to pi's plain expansion
     // (the loader registered the skill and delivers the raw body), rather than
     // failing the invocation over the dynamic features it cannot have.
     return
+  }
+  // Claude registers hooks a skill's frontmatter declares when the skill is
+  // invoked, for the rest of the session; the hooks extension owns running them,
+  // so the declaration is announced over the shared bus.
+  const declaredHooks = parseFrontmatter<Record<string, unknown>>(content).frontmatter.hooks
+  if (declaredHooks !== null && typeof declaredHooks === 'object' && !Array.isArray(declaredHooks)) {
+    pi.events?.emit(SKILL_HOOKS_CHANNEL, { skillName: name, hooks: declaredHooks })
   }
   const expanded = await expandCommand(pi, parsed, args, { cwd: ctx.cwd }, found.filePath, undefined, { allowShell: !shellExecutionDisabled(ctx.cwd, os.homedir(), trusted) })
   return { action: 'transform', text: `<skill name="${name}" location="${found.filePath}">\nReferences are relative to ${found.baseDir}.\n\n${expanded}\n</skill>` }

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -205,6 +205,7 @@ const setupExtension = () => {
     shutdown: (reason: string) => handler('session_shutdown')({ reason }, defaultCtx),
     beforeAgentStart: (event: Record<string, unknown> = { systemPrompt: '' }) => handler('before_agent_start')(event),
     emitMcpTools: (entries: unknown) => busHandlers.get('pi-code:mcp-tools')?.(entries),
+    emitSkillHooks: (event: unknown) => busHandlers.get('pi-code:skill-hooks')?.(event),
     emitPlanMode: (state: unknown) => busHandlers.get('pi-code:plan-mode')?.(state),
     emitSubagent: (event: unknown) => busHandlers.get('pi-code:subagent')?.(event),
     emitInstruction: (event: unknown) => busHandlers.get('pi-code:instructions')?.(event),
@@ -2224,5 +2225,90 @@ describe('hooks extension dedup scope', () => {
     await ext.toolResult('write', { input: { path: 'a.ts' } })
 
     expect(commandsRun()).toEqual(['shared-format.sh', 'shared-format.sh'])
+  })
+})
+
+describe('hooks from managed policy settings', () => {
+  it('runs hooks declared in managed settings', async () => {
+    // Claude's hook locations include managed policy settings.
+    writeFileSync(join(hoisted.home, 'managed-settings.json'), JSON.stringify({ hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'managed-guard' }] }] } }))
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.toolCall('bash', {})
+
+    expect(commandsRun()).toEqual(['managed-guard'])
+  })
+
+  it('keeps managed hooks running when settings-level disableAllHooks is set', async () => {
+    // Claude: disableAllHooks in user/project/local settings cannot disable hooks
+    // an administrator configured through managed policy settings.
+    writeFileSync(join(hoisted.home, 'managed-settings.json'), JSON.stringify({ hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'managed-guard' }] }] } }))
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ disableAllHooks: true, hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'user-guard' }] }] } }))
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.toolCall('bash', {})
+
+    expect(commandsRun()).toEqual(['managed-guard'])
+  })
+
+  it('turns managed hooks off only via managed-level disableAllHooks', async () => {
+    writeFileSync(join(hoisted.home, 'managed-settings.json'), JSON.stringify({ disableAllHooks: true, hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'managed-guard' }] }] } }))
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.toolCall('bash', {})
+
+    expect(commandsRun()).toEqual([])
+  })
+})
+
+describe('hooks from skill frontmatter', () => {
+  const invokeSkill = (ext: ReturnType<typeof setupExtension>, hooks: unknown, skillName = 'secure-ops') => {
+    ext.emitSkillHooks({ skillName, hooks })
+  }
+
+  it('registers skill hooks at invocation and keeps them for the rest of the session', async () => {
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    invokeSkill(ext, { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'skill-guard' }] }] })
+    await ext.toolCall('bash', {})
+    await ext.toolCall('bash', {})
+
+    expect(commandsRun()).toEqual(['skill-guard', 'skill-guard'])
+  })
+
+  it('removes a once hook after its first successful run', async () => {
+    // Claude: once removes the hook after its first successful run; honored only
+    // for skill-frontmatter hooks.
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    invokeSkill(ext, { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'skill-once', once: true }] }] })
+    await ext.toolCall('bash', {})
+    await ext.toolCall('bash', {})
+
+    expect(commandsRun()).toEqual(['skill-once'])
+  })
+
+  it('keeps a once hook in place after a failing run', async () => {
+    // Claude: a run that fails, blocks with exit code 2, or times out leaves the
+    // hook in place, so it runs again on the next matching event.
+    script('skill-once', { code: 1 })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    invokeSkill(ext, { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'skill-once', once: true }] }] })
+    await ext.toolCall('bash', {})
+    await ext.toolCall('bash', {})
+
+    expect(commandsRun()).toEqual(['skill-once', 'skill-once'])
+  })
+
+  it('ignores once on a settings-file hook', async () => {
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'settings-once', once: true }] }] })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.toolCall('bash', {})
+    await ext.toolCall('bash', {})
+
+    expect(commandsRun()).toEqual(['settings-once', 'settings-once'])
   })
 })

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -179,3 +179,45 @@ describe('Claude skill lookup edge cases', () => {
     await expect(handlers.get('input')?.({ text: '/skill:rough', source: 'interactive' }, { cwd })).resolves.toBeUndefined()
   })
 })
+
+describe('skill frontmatter hooks publication', () => {
+  const setupWithBus = (cwd: string) => {
+    const handlers = new Map<string, (event: Record<string, unknown>, ctx: unknown) => Promise<unknown>>()
+    const emitted: Array<{ channel: string; data: unknown }> = []
+    const api = {
+      on: (name: string, fn: (event: Record<string, unknown>, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn),
+      exec: async () => ({ stdout: '', stderr: '', code: 0 }),
+      events: { emit: (channel: string, data: unknown) => emitted.push({ channel, data }), on: () => () => {} },
+    }
+    skillsExt(api as never)
+    return { input: (text: string) => handlers.get('input')?.({ text, source: 'interactive' }, { cwd }), emitted }
+  }
+
+  it('publishes frontmatter hooks on the shared bus when a skill is invoked', async () => {
+    // Claude registers hooks from skill frontmatter when the skill is invoked and
+    // keeps them for the rest of the session; the hooks extension owns the running,
+    // so the skill side publishes them over the shared bus.
+    const cwd = tempDir('cs-proj-')
+    hoisted.home = tempDir('cs-home-')
+    mkdirSync(join(hoisted.home, '.claude', 'skills', 'secure-ops'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'skills', 'secure-ops', 'SKILL.md'), '---\nname: secure-ops\ndescription: guarded\nhooks:\n  PreToolUse:\n    - matcher: Bash\n      hooks:\n        - type: command\n          command: ./scripts/check.sh\n---\nBody')
+    const { input, emitted } = setupWithBus(cwd)
+    await input('/skill:secure-ops')
+
+    expect(emitted).toContainEqual({
+      channel: 'pi-code:skill-hooks',
+      data: { skillName: 'secure-ops', hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: './scripts/check.sh' }] }] } },
+    })
+  })
+
+  it('publishes nothing for a skill without frontmatter hooks', async () => {
+    const cwd = tempDir('cs-proj-')
+    hoisted.home = tempDir('cs-home-')
+    mkdirSync(join(hoisted.home, '.claude', 'skills', 'plain'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'skills', 'plain', 'SKILL.md'), '---\nname: plain\ndescription: p\n---\nBody')
+    const { input, emitted } = setupWithBus(cwd)
+    await input('/skill:plain')
+
+    expect(emitted).toEqual([])
+  })
+})


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #152).

## Managed policy settings hooks (extensions/hooks/config.ts, index.ts)
- Hooks declared in `managed-settings.json` now load alongside the settings chain.
- `disableAllHooks` is tiered per Claude: managed-level turns everything off; a settings-file value disables non-managed hooks while managed policy hooks keep running. `/hooks` still shows the active managed set in that state.

## Skill frontmatter hooks (internal/skill-hooks.ts, skills.ts, config.ts, index.ts, matcher.ts)
- Invoking a skill whose frontmatter declares `hooks` registers them for the rest of the session: the skills extension publishes the declaration on a shared bus channel and the hooks extension merges it with a `skill:<name>` origin (so dedup keeps it separate from settings copies, per #152's scope rule).
- `once: true` removes a skill hook after its first successful run; a failure, block, or timeout leaves it in place. The field is ignored on settings-file hooks, as Claude documents.
- `withCommand` now fills the synthesized identity onto the config entry itself instead of a clone, so the object the runner marks spent is the object collection filters.

Agent-frontmatter hooks are deferred to the subagent chunk (they need the subagent spawn path) and noted in `docs/hooks.md`.

Docs: `docs/hooks.md` hook-locations section added; the extension header's disableAllHooks paragraph corrected.

All changes covered by tests that failed before the change (6 red tests), plus mutation checks on the three guards that never independently failed (settings-file `once` ignored, managed-level disable, no publish without frontmatter hooks) — all three mutants caught.