### PR TITLE
Align hook payload fields, stdout parsing, and prompt suppression with Claude docs

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -29,7 +29,9 @@ Hook locations: settings files, managed policy settings, plugins, and skill fron
 ## Payloads and decisions
 
 - Payloads use Claude's vocabulary for pi's built-ins: `Bash`/`Edit`/`Write`/`Read`/`Grep`/`Glob` names, the documented input shapes with absolute `file_path`, and the documented Bash/Write response shapes; `updatedInput` is translated back to pi's shape (an incomplete rewrite keeps the original input).
-- Every payload carries `session_id`, `transcript_path`, `cwd`, `permission_mode`, `effort`; tool events add `tool_use_id`.
+- Every payload carries `session_id`, `transcript_path`, `cwd`, `permission_mode`, `effort`; tool events add `tool_use_id` and PostToolUse/PostToolUseFailure add `duration_ms` (excluding PreToolUse hook and confirm time). PreCompact carries `custom_instructions`, PostCompact `compact_summary`.
+- Stdout follows Claude's shape rule: only output that starts with `{` and ends with `}` is read as JSON; arrays, quoted strings, and numbers are plain text, multi-line independent JSON objects with no output field are plain text, and malformed `{..}`-shaped output surfaces a `hook error` notice instead of becoming context.
+- UserPromptSubmit honors `suppressOriginalPrompt` when context is present (the context replaces the prompt).
 - Claude matcher semantics, including `mcp__server__tool` names; Stop and UserPromptSubmit ignore a stray matcher.
 - Identical handlers collapse across settings files only; a plugin's copy of the same handler stays separate, and http handlers differing only in headers are distinct.
 - The `if` permission-rule filter (`"Bash(git *)"`, `"Edit(*.ts)"`) runs on tool events only; a hook carrying it never runs elsewhere.
@@ -40,6 +42,13 @@ Hook locations: settings files, managed policy settings, plugins, and skill fron
 ## Background hooks
 
 `async`/`asyncRewake` command hooks run in the background on every event: never blocking, no decision, no timeout enforced on `async` while `asyncRewake` keeps its own. An asyncRewake exit 2 wakes the model with the hook's stderr as a new turn; other completions deliver `systemMessage`/`additionalContext` to the model on the next turn; hooks still running at session end are killed.
+
+## Unbridged events and fields
+
+pi has no seam for these; a hook relying on them silently not working would be worse than a documented absence:
+
+- Events: PreModelSwitch (no veto seam on `model_select`), MessageDisplay (no display-replacement seam), UserPromptExpansion, PermissionRequest/PermissionDenied (pi has no permission system), Setup, FileChanged, ConfigChange, CwdChanged, DirectoryAdded, StopFailure, Elicitation events, and Notification types other than `idle_prompt`.
+- Fields: `prompt_id` and Stop's `background_tasks`/`session_crons` (no pi task registry), SessionStart's `initialUserMessage`/`watchPaths`/`sessionTitle` and UserPromptSubmit's `sessionTitle` (no session-rename or file-watch seam), and PostModelSwitch's cost-estimate fields (absent rather than fabricated).
 
 ## Divergences from Claude Code
 

--- a/extensions/hooks/decisions.ts
+++ b/extensions/hooks/decisions.ts
@@ -19,9 +19,14 @@ export interface HookDecision {
   ask?: boolean
 }
 
+/** Claude's stdout shape rule: only output that starts with `{` and ends with `}`
+ * (ignoring surrounding whitespace) is read as JSON output; a JSON array, a quoted
+ * string, or a bare number is plain text. Multi-line output whose lines each parse
+ * as JSON on their own with no output field set is plain text too (that case
+ * arrives here as a parse failure and hookJsonError sorts it from a real error). */
 export function tryParseJson(text: string):
   | {
-      hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string; additionalContext?: string; updatedInput?: unknown }
+      hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string; additionalContext?: string; updatedInput?: unknown; suppressOriginalPrompt?: boolean }
       decision?: string
       reason?: string
       continue?: boolean
@@ -32,11 +37,56 @@ export function tryParseJson(text: string):
       ok?: boolean
     }
   | undefined {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return undefined
   try {
-    return JSON.parse(text)
+    const parsed: unknown = JSON.parse(trimmed)
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) ? (parsed as ReturnType<typeof tryParseJson>) : undefined
   } catch {
     return undefined
   }
+}
+
+/** Top-level JSON output fields; a multi-line output where a line sets one of
+ * these is a parse failure rather than plain text, as Claude documents. */
+const OUTPUT_FIELDS = new Set(['decision', 'reason', 'continue', 'stopReason', 'systemMessage', 'suppressOutput', 'hookSpecificOutput', 'updatedToolOutput', 'updatedMCPToolOutput', 'ok'])
+
+/** Claude reports a `<hook> hook error` notice when {..}-shaped stdout cannot be
+ * read as JSON output, and does not treat that stdout as plain text. Returns the
+ * error message for that case; undefined for valid JSON output and for output the
+ * shape rule already reads as plain text (including the multi-line case). */
+export function hookJsonError(text: string): string | undefined {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return undefined
+  let parseError: string
+  try {
+    JSON.parse(trimmed)
+    return undefined
+  } catch (error) {
+    parseError = error instanceof Error ? error.message : String(error)
+  }
+  const lines = trimmed
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+  if (lines.length >= 2 && !multiLineSetsOutputField(lines)) return undefined
+  return `invalid JSON output: ${parseError}`
+}
+
+/** Whether every line parses as JSON and at least one sets an output field; a
+ * non-JSON line means the multi-line rule does not apply (still a parse error). */
+function multiLineSetsOutputField(lines: string[]): boolean {
+  let setsField = false
+  for (const line of lines) {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      return true // not all-JSON: the whole output is a parse failure
+    }
+    if (parsed !== null && typeof parsed === 'object' && Object.keys(parsed).some((key) => OUTPUT_FIELDS.has(key))) setsField = true
+  }
+  return setsField
 }
 
 /** The reason a JSON body's blocking decision carries, whichever spelling made it. */
@@ -94,6 +144,10 @@ function surfaceHookFailures(commands: HookCommand[], results: HookRunResult[], 
   if (!notify) return
   for (const [i, result] of results.entries()) {
     if (result.spawnFailed) notify(`Hook failed to run: ${commands[i].command}: ${result.stderr.trim() || 'unknown error'}`)
+    // Claude shows a `<hook> hook error` notice when {..}-shaped stdout cannot be
+    // read as JSON output (exit 2 still blocks and reads its own channels).
+    const jsonError = result.code === 2 ? undefined : hookJsonError(result.stdout)
+    if (jsonError !== undefined) notify(`${commands[i].command} hook error: ${jsonError}`)
   }
 }
 
@@ -196,6 +250,8 @@ export interface PromptDecision {
   block: boolean
   reason?: string
   context: string
+  /** Claude's suppressOriginalPrompt: the hook's context replaces the prompt. */
+  suppress?: boolean
 }
 
 /** Additional context a UserPromptSubmit hook contributes: an explicit
@@ -203,6 +259,8 @@ export interface PromptDecision {
 export function promptContext(stdout: string): string {
   const parsed = tryParseJson(stdout)
   if (parsed) return parsed.hookSpecificOutput?.additionalContext ?? ''
+  // Malformed JSON output is an error, not plain text: no context is added.
+  if (hookJsonError(stdout) !== undefined) return ''
   return stdout.trim()
 }
 
@@ -221,13 +279,17 @@ export async function runUserPromptSubmit(config: HooksConfig, prompt: string, r
   }
   if (onSystemMessage) surfaceSystemMessages(results, onSystemMessage)
   const contexts: string[] = []
+  let suppress = false
   for (const result of results) {
     const decision = interpretHookResult(result.code, result.stdout, result.stderr)
     if (decision.block) return { block: true, reason: decision.reason, context: '' }
+    // Claude's suppressOriginalPrompt: any hook setting it hides the original
+    // prompt, and the collected context is what reaches the model.
+    if (tryParseJson(result.stdout)?.hookSpecificOutput?.suppressOriginalPrompt === true) suppress = true
     const context = promptContext(result.stdout)
     if (context) contexts.push(context)
   }
-  return { block: false, context: contexts.join('\n') }
+  return { block: false, context: contexts.join('\n'), suppress }
 }
 
 /** The feedback lines one PostToolUse/PostToolUseFailure result appends next to the

--- a/extensions/hooks/index.ts
+++ b/extensions/hooks/index.ts
@@ -187,6 +187,9 @@ export default function hooksExtension(pi: ExtensionAPI) {
   /** Consecutive Stop-hook blocks with no user progress between them. Reset on user input
    * and on a non-blocking Stop; at the cap the continuation is suppressed and the turn ends. */
   let stopHookBlockCount = 0
+  /** Tool start times per call id, for Claude's duration_ms on PostToolUse: the
+   * clock starts after PreToolUse hooks and any confirm dialog resolve. */
+  const toolStartTimes = new Map<string, number>()
   /** The pending idle_prompt notification: Claude fires it when the turn ended about
    * 60 seconds ago and the user hasn't typed since, so it arms on agent_end and is
    * canceled by input or the next turn. */
@@ -417,13 +420,18 @@ export default function hooksExtension(pi: ExtensionAPI) {
       // additionalContext is delivered alongside the tool result, so stash it for
       // this call's tool_result to append.
       if (decision.context && decision.context.length > 0) pendingToolContext.set(event.toolCallId, decision.context)
+      // Claude's duration_ms excludes PreToolUse hook time, so the clock starts here.
+      toolStartTimes.set(event.toolCallId, Date.now())
       return undefined
     }
     // Claude's "ask": prompt the user and let the call through if they approve.
     // With no UI (headless) the block stands, which is the safe default.
     if (decision.ask && ctx.hasUI) {
       const approved = await ctx.ui.confirm(`Allow ${event.toolName}?`, decision.reason ?? 'A hook asks you to confirm this tool call.')
-      return approved ? undefined : blockedToolCall(decision.reason)
+      if (!approved) return blockedToolCall(decision.reason)
+      // Claude's duration_ms also excludes time in permission prompts.
+      toolStartTimes.set(event.toolCallId, Date.now())
+      return undefined
     }
     return blockedToolCall(decision.reason)
   })
@@ -451,7 +459,9 @@ export default function hooksExtension(pi: ExtensionAPI) {
     if (commands.length === 0 && pending.length === 0) return
     const translatedInput = alias === undefined ? claudeToolInput(event.toolName, event.input, ctx.cwd) : undefined
     const response = (alias === undefined && !event.isError ? claudeToolResponse(event.toolName, event.input, textContent(event.content), event.isError, ctx.cwd) : undefined) ?? { content: event.content, details: event.details, isError: event.isError }
-    const payload = { hook_event_name: eventName, tool_name: translatedName ?? event.toolName, tool_input: translatedInput ?? event.input, tool_response: response }
+    const startedAt = toolStartTimes.get(event.toolCallId)
+    toolStartTimes.delete(event.toolCallId)
+    const payload = { hook_event_name: eventName, tool_name: translatedName ?? event.toolName, tool_input: translatedInput ?? event.input, tool_response: response, ...(startedAt === undefined ? {} : { duration_ms: Date.now() - startedAt }) }
     const run = boundRunner(ctx, { tool_use_id: event.toolCallId })
     const results = await Promise.all(commands.map((command) => run(command, payload, timeoutMs(command))))
     surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
@@ -515,8 +525,10 @@ export default function hooksExtension(pi: ExtensionAPI) {
       return { action: 'handled' }
     }
     // Claude injects a UserPromptSubmit hook's context ahead of the prompt; transform is
-    // pi's seam for rewriting the submitted text.
-    if (decision.context) return { action: 'transform', text: `${decision.context}\n\n${event.text}` }
+    // pi's seam for rewriting the submitted text. With suppressOriginalPrompt the
+    // context replaces the prompt entirely (honored only when context exists, since
+    // an empty submission would be no turn at all).
+    if (decision.context) return { action: 'transform', text: decision.suppress ? decision.context : `${decision.context}\n\n${event.text}` }
     return { action: 'continue' }
   })
 
@@ -609,13 +621,19 @@ export default function hooksExtension(pi: ExtensionAPI) {
 
   pi.on('session_before_compact', async (event, ctx) => {
     const trigger = claudeSpelling(PRECOMPACT_TRIGGER, event.reason)
-    const results = await runNotifyHooks(matchingCommands(config.PreCompact, trigger.names), { hook_event_name: 'PreCompact', trigger: trigger.value }, boundRunner(ctx))
+    // Claude's custom_instructions: the /compact arguments on a manual run, empty
+    // on an automatic one; pi carries them on the event directly.
+    const payload = { hook_event_name: 'PreCompact', trigger: trigger.value, custom_instructions: event.customInstructions ?? '' }
+    const results = await runNotifyHooks(matchingCommands(config.PreCompact, trigger.names), payload, boundRunner(ctx))
     surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
   })
 
   pi.on('session_compact', async (event, ctx) => {
     const trigger = claudeSpelling(PRECOMPACT_TRIGGER, event.reason)
-    const results = await runNotifyHooks(matchingCommands(config.PostCompact, trigger.names), { hook_event_name: 'PostCompact', trigger: trigger.value }, boundRunner(ctx))
+    // Claude's compact_summary: the summary that replaced the compacted history.
+    const summary = (event as { compactionEntry?: { summary?: unknown } }).compactionEntry?.summary
+    const payload = { hook_event_name: 'PostCompact', trigger: trigger.value, ...(typeof summary === 'string' ? { compact_summary: summary } : {}) }
+    const results = await runNotifyHooks(matchingCommands(config.PostCompact, trigger.names), payload, boundRunner(ctx))
     surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
     // Claude also fires SessionStart with source "compact" when the session
     // continues after compaction; its stdout context rides the next agent start,

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -200,8 +200,8 @@ const setupExtension = () => {
     agentEnd: (messages: unknown[] = []) => handler('agent_end')({ messages }, defaultCtx),
     modelSelect: (to: string, from?: string, source = 'set') => handler('model_select')({ model: { id: to, name: to }, previousModel: from ? { id: from, name: from } : undefined, source }, defaultCtx),
     agentSettled: () => handler('agent_settled')({}, defaultCtx),
-    beforeCompact: (reason: string) => handler('session_before_compact')({ reason }, defaultCtx),
-    compacted: (reason: string) => handler('session_compact')({ reason }, defaultCtx),
+    beforeCompact: (reason: string, customInstructions?: string) => handler('session_before_compact')({ reason, customInstructions }, defaultCtx),
+    compacted: (reason: string, summary?: string) => handler('session_compact')({ reason, ...(summary === undefined ? {} : { compactionEntry: { summary } }) }, defaultCtx),
     shutdown: (reason: string) => handler('session_shutdown')({ reason }, defaultCtx),
     beforeAgentStart: (event: Record<string, unknown> = { systemPrompt: '' }) => handler('before_agent_start')(event),
     emitMcpTools: (entries: unknown) => busHandlers.get('pi-code:mcp-tools')?.(entries),
@@ -1285,7 +1285,7 @@ describe('hooks extension notify-style events', () => {
     const ext = await withHooks({ PreCompact: [{ matcher: 'manual', hooks: [{ command: 'pc' }] }] })
     await ext.beforeCompact('manual')
     expect(commandsRun()).toEqual(['pc'])
-    expect(JSON.parse(recordFor('pc').stdin)).toEqual({ ...COMMON, hook_event_name: 'PreCompact', trigger: 'manual' })
+    expect(JSON.parse(recordFor('pc').stdin)).toEqual({ ...COMMON, hook_event_name: 'PreCompact', trigger: 'manual', custom_instructions: '' })
   })
 
   it('does not run PreCompact hooks whose matcher misses the trigger', async () => {
@@ -1298,7 +1298,7 @@ describe('hooks extension notify-style events', () => {
     const ext = await withHooks({ PreCompact: [{ matcher: 'auto', hooks: [{ command: 'pc' }] }] })
     await ext.beforeCompact('threshold')
     expect(commandsRun()).toEqual(['pc'])
-    expect(JSON.parse(recordFor('pc').stdin)).toEqual({ ...COMMON, hook_event_name: 'PreCompact', trigger: 'auto' })
+    expect(JSON.parse(recordFor('pc').stdin)).toEqual({ ...COMMON, hook_event_name: 'PreCompact', trigger: 'auto', custom_instructions: '' })
   })
 
   it('runs PostCompact hooks after compaction with the Claude trigger', async () => {
@@ -2310,5 +2310,89 @@ describe('hooks from skill frontmatter', () => {
     await ext.toolCall('bash', {})
 
     expect(commandsRun()).toEqual(['settings-once', 'settings-once'])
+  })
+})
+
+describe('hooks compact and timing fields', () => {
+  const withHooks = async (config: Record<string, unknown>) => {
+    writeSettings(hoisted.home, 'settings.json', config)
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('passes custom_instructions from a manual /compact to PreCompact hooks', async () => {
+    const ext = await withHooks({ PreCompact: [{ hooks: [{ command: 'pre-compact' }] }] })
+    await ext.beforeCompact('manual', 'keep the failing test list')
+
+    expect(JSON.parse(recordFor('pre-compact').stdin)).toMatchObject({ hook_event_name: 'PreCompact', trigger: 'manual', custom_instructions: 'keep the failing test list' })
+  })
+
+  it('sends empty custom_instructions on an automatic compaction', async () => {
+    const ext = await withHooks({ PreCompact: [{ hooks: [{ command: 'pre-compact' }] }] })
+    await ext.beforeCompact('threshold')
+
+    expect(JSON.parse(recordFor('pre-compact').stdin).custom_instructions).toBe('')
+  })
+
+  it('passes the compaction summary to PostCompact hooks as compact_summary', async () => {
+    const ext = await withHooks({ PostCompact: [{ hooks: [{ command: 'post-compact' }] }] })
+    await ext.compacted('auto', 'what happened so far')
+
+    expect(JSON.parse(recordFor('post-compact').stdin)).toMatchObject({ hook_event_name: 'PostCompact', compact_summary: 'what happened so far' })
+  })
+
+  it('reports the tool execution time as duration_ms on PostToolUse', async () => {
+    vi.useFakeTimers()
+    const ext = await withHooks({ PostToolUse: [{ matcher: 'Bash', hooks: [{ command: 'post-timing' }] }] })
+    await ext.toolCall('bash', { command: 'sleep 2' })
+    await vi.advanceTimersByTimeAsync(1234)
+    await ext.toolResult('bash', { input: { command: 'sleep 2' } })
+    await vi.runAllTimersAsync()
+
+    expect(JSON.parse(recordFor('post-timing').stdin).duration_ms).toBe(1234)
+  })
+})
+
+describe('hooks suppressOriginalPrompt', () => {
+  const withHooks = async (config: Record<string, unknown>) => {
+    writeSettings(hoisted.home, 'settings.json', config)
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  it('replaces the prompt with the hook context when suppressOriginalPrompt is set', async () => {
+    // Claude's UserPromptSubmit suppressOriginalPrompt: the original prompt is
+    // hidden; the hook's context is what reaches the model.
+    script('suppress', { stdout: ['{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"CTX ONLY","suppressOriginalPrompt":true}}'], code: 0 })
+    const ext = await withHooks({ UserPromptSubmit: [{ hooks: [{ command: 'suppress' }] }] })
+
+    const result = (await ext.input('the original secret prompt')) as { action: string; text?: string }
+    expect(result.action).toBe('transform')
+    expect(result.text).toBe('CTX ONLY')
+  })
+
+  it('keeps the prompt when no hook suppresses it', async () => {
+    script('ctx', { stdout: ['{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"CTX"}}'], code: 0 })
+    const ext = await withHooks({ UserPromptSubmit: [{ hooks: [{ command: 'ctx' }] }] })
+
+    const result = (await ext.input('keep me')) as { action: string; text?: string }
+    expect(result.text).toBe('CTX\n\nkeep me')
+  })
+})
+
+describe('hook error notices', () => {
+  it('surfaces a hook error notice for malformed JSON output instead of using it as context', async () => {
+    // Claude: when {..}-shaped stdout cannot be parsed, the transcript shows a
+    // hook error notice and the text is not added as context.
+    script('bad-json', { stdout: ['{"decision": nope}'], code: 0 })
+    writeSettings(hoisted.home, 'settings.json', { UserPromptSubmit: [{ hooks: [{ command: 'bad-json' }] }] })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+
+    const result = (await ext.input('hello')) as { action: string; text?: string }
+    expect(result.action).toBe('continue')
+    expect(ext.notes.some((note) => note.msg.includes('hook error'))).toBe(true)
   })
 })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -835,3 +835,41 @@ describe('runPreToolUse on a timed-out hook', () => {
     expect(run).toEqual(['guard.sh', 'second.sh'])
   })
 })
+
+describe('hook stdout parsing rule', () => {
+  it('reads only {..}-shaped stdout as JSON output, per the documented rule', async () => {
+    // Claude: stdout starting with { and ending with } parses as JSON; a JSON
+    // array, a quoted string, or a bare number is plain text.
+    const { tryParseJson } = await import('../extensions/hooks/decisions.ts')
+    expect(tryParseJson('{"decision":"block","reason":"no"}')).toMatchObject({ decision: 'block' })
+    expect(tryParseJson('[1,2]')).toBeUndefined()
+    expect(tryParseJson('"just quoted text"')).toBeUndefined()
+    expect(tryParseJson('42')).toBeUndefined()
+    expect(tryParseJson('{"a":1} trailing')).toBeUndefined()
+  })
+
+  it('treats multi-line JSON objects with no output fields as plain text', async () => {
+    // Claude: two or more lines that each parse as JSON on their own, none setting
+    // an output field, are plain text.
+    const { tryParseJson } = await import('../extensions/hooks/decisions.ts')
+    expect(tryParseJson('{"note":1}\n{"note":2}')).toBeUndefined()
+  })
+
+  it('keeps a quoted-string stdout as plain-text context instead of silently dropping it', async () => {
+    const { promptContext } = await import('../extensions/hooks/decisions.ts')
+    expect(promptContext('"quoted context"')).toBe('"quoted context"')
+  })
+
+  it('reports a hook error for {..}-shaped stdout that is not valid JSON output', async () => {
+    // Claude: when stdout looks like JSON but cannot be parsed, the transcript
+    // shows a hook error notice and the output is not treated as plain text.
+    const { hookJsonError } = await import('../extensions/hooks/decisions.ts')
+    expect(hookJsonError('{"decision": broken}')).toContain('JSON')
+    expect(hookJsonError('plain text')).toBeUndefined()
+    expect(hookJsonError('{"decision":"block"}')).toBeUndefined()
+    // A multi-line output where one line sets an output field is a parse failure;
+    // with no output field set it is plain text, not an error.
+    expect(hookJsonError('{"decision":"block"}\n{"note":2}')).toContain('JSON')
+    expect(hookJsonError('{"note":1}\n{"note":2}')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #154); completes the hooks batch.

## Stdout parsing rule (extensions/hooks/decisions.ts)
- `tryParseJson` now follows Claude's shape rule: only stdout that starts with `{` and ends with `}` (ignoring whitespace) is read as JSON output. A JSON array, quoted string, or bare number is plain text (previously a quoted string silently dropped its context).
- Multi-line output whose lines each parse as JSON with no output field set is plain text; when a line does set an output field, or the output is otherwise malformed `{..}`-shaped text, the new `hookJsonError` reports it and a `<hook> hook error` notice surfaces instead of the text becoming context.

## Payload fields (index.ts)
- PreCompact carries `custom_instructions` (the manual /compact arguments, empty on automatic runs) from pi's event field.
- PostCompact carries `compact_summary` from pi's compaction entry.
- PostToolUse/PostToolUseFailure carry `duration_ms`, measured from after PreToolUse hooks and any confirm dialog resolve, per Claude's exclusion rule.

## UserPromptSubmit suppressOriginalPrompt (decisions.ts, index.ts)
- A hook setting `hookSpecificOutput.suppressOriginalPrompt` replaces the prompt with the collected context (honored when context exists, since an empty submission would be no turn at all).

## Docs (docs/hooks.md)
- New "Unbridged events and fields" section rolls up everything pi has no seam for (PreModelSwitch, MessageDisplay, UserPromptExpansion, permission events, `prompt_id`, `background_tasks`/`session_crons`, `sessionTitle`/`initialUserMessage`/`watchPaths`), closing the missing-gap-note findings.
- The header self-contradictions flagged by the audit were verified already resolved by the earlier header rework.

All changes covered by tests that failed before the change (9 red tests), plus mutation checks on the two guards that never independently failed (multi-line plain-text rule, prompt kept without suppression) — both mutants caught.