### PR TITLE
Load agent-frontmatter hooks and align subagent discovery with Claude docs

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -2,7 +2,7 @@
 
 Runs Claude Code's `.claude/settings.json` hooks on pi's lifecycle events. Source: [`extensions/hooks/`](../extensions/hooks) (the module header in `index.ts` is the authoritative contract).
 
-Hook locations: settings files, managed policy settings, plugins, and skill frontmatter (registered at invocation for the rest of the session, with `once` removing a hook after its first successful run). Agent-frontmatter hooks are not yet loaded (tracked with the subagent work).
+Hook locations: settings files, managed policy settings, plugins, skill frontmatter (registered at invocation for the rest of the session, with `once` removing a hook after its first successful run), and agent frontmatter (passed to the subagent child via env, running only while it runs, with `Stop` converted to `SubagentStop`).
 
 ## Events
 
@@ -12,7 +12,7 @@ Hook locations: settings files, managed policy settings, plugins, and skill fron
 - **SessionStart**: context injection before the first prompt.
 - **UserPromptSubmit**: blocks the prompt or injects context ahead of it.
 - **Stop**: a block (or `additionalContext`) feeds back as a new turn, with `stop_hook_active` as the loop guard and a consecutive-block cap of 8 (`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`; `0` disables the cap). Does not run when the turn ended on a user interrupt, as Claude documents.
-- **SubagentStart / SubagentStop**: notify-only (a child has already exited by SubagentStop).
+- **SubagentStart / SubagentStop**: SubagentStart runs pre-spawn so its `additionalContext` reaches the child before its first prompt (it cannot block the spawn); SubagentStop is notify-only (the child has already exited) and carries `last_assistant_message`.
 - **PreCompact / PostCompact / SessionEnd / Notification** (`idle_prompt`, the one type pi can source): notify-only. `idle_prompt` fires when the turn ended about 60 seconds ago and the user hasn't typed since, per Claude's timing; input or the next turn cancels it. After compaction, **SessionStart** also fires with source `compact`.
 - **PostModelSwitch**: fires after the session's model changes, matched against the new model id; stdout/`additionalContext` reaches the model on the next turn. `requested_model` is `null` (pi does not carry the requested alias) and the cost-estimate fields are absent rather than fabricated. PreModelSwitch stays unbridged: pi's `model_select` event has no veto seam, and a blocking hook whose decision is silently ignored would be worse than an absent event. MessageDisplay is likewise unbridged (pi has no display-replacement seam).
 - **InstructionsLoaded**: observational; fires per loaded context file at session start, plus `path_glob_match` on a scoped-rule attach and `include` per resolved `@import`, deduped per session. `nested_traversal`/`compact` reasons never fire (pi does not lazily load nested CLAUDE.md or reload after compaction).

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -3,7 +3,9 @@
 Claude-style subagents with parallel, chain, and background modes. Source: [`extensions/subagent/`](../extensions/subagent) (see also its [README](../extensions/subagent/README.md)).
 
 - Built-in Explore/Plan/general-purpose agents, plus `~/.claude/agents`, `~/.pi/agent/agents`, and project `.claude/agents`/`.pi/agents` (scanned recursively into subfolders), merged once the project is trusted; project wins a name clash. Every `.claude/agents` between the working directory and the repository root is scanned, the definition closest to the working directory winning a same-name clash, as Claude documents.
-- Frontmatter: `tools`/`disallowedTools`, `model` (sonnet/opus/haiku/fable tier aliases or a concrete id), `effort`, `skills` preload, `permissionMode: plan`, `maxTurns`, `memory`, `isolation: worktree`.
+- Frontmatter: `tools`/`disallowedTools`, `model` (sonnet/opus/haiku/fable tier aliases or a concrete id), `effort`, `skills` preload, `permissionMode: plan`, `maxTurns`, `memory`, `isolation: worktree`, `hooks` (scoped to the run, `Stop` converted to `SubagentStop` at the child's own end), `background: true` (stays in the background even on a foreground ask).
+- Plugin agents register under Claude's scoped id `plugin:name` (filename fallback for a missing name); `:` in a non-plugin agent name rejects the file. Explore and Plan spawn with `--no-context-files`, the only agents that skip CLAUDE.md, per Claude.
+- SubagentStart hooks run pre-spawn through a seam so their `additionalContext` lands before the child's first prompt; they cannot block the spawn.
 - The agent body is the child's system prompt (replacing pi's default, as Claude replaces its own). Model order per Claude: frontmatter model, then `CLAUDE_CODE_SUBAGENT_MODEL`, then pi's default.
 - A `maxTurns`-capped run returns its output marked as partial; a capped background run's completion notes it can be resumed by id. A `tools` list where no entry resolves to a tool fails the launch naming the entries instead of running tool-less.
 - SubagentStop hooks receive `last_assistant_message`; `agent_transcript_path` stays absent (a `--no-session` child writes no transcript).

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -115,6 +115,25 @@ export function mergeSkillHooks(config: HooksConfig, skillName: string, hooks: u
   mergeHooksJson(config, JSON.stringify({ hooks }), `${skillName} (skill)`, sources, `skill:${skillName}`)
 }
 
+/** Claude's agent-frontmatter hooks, inside the subagent child: the parent passes
+ * them via PI_CODE_AGENT_HOOKS (Stop already converted to SubagentStop), and they
+ * run only while this child runs because they die with the process. Returns the
+ * agent identity for the child's SubagentStop firing, or undefined outside a
+ * subagent or with no hooks passed. */
+export function mergeAgentEnvHooks(config: HooksConfig, sources?: Map<HookMatcher, string>): { agent: string; id?: string } | undefined {
+  if (process.env.PI_CODE_SUBAGENT !== '1') return undefined
+  const raw = process.env.PI_CODE_AGENT_HOOKS
+  if (!raw) return undefined
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!isRecord(parsed) || typeof parsed.agent !== 'string' || !isRecord(parsed.hooks)) return undefined
+    mergeHooksJson(config, JSON.stringify({ hooks: parsed.hooks }), `${parsed.agent} (agent)`, sources, `agent:${parsed.agent}`)
+    return { agent: parsed.agent, ...(typeof parsed.id === 'string' ? { id: parsed.id } : {}) }
+  } catch {
+    return undefined
+  }
+}
+
 /** Claude's `allowedHttpHookUrls` setting: URL patterns http hooks may target, with
  * `*` as a wildcard. Per Claude's documentation: undefined (no source sets the key)
  * means no restrictions, an empty array blocks every http hook, and arrays merge

--- a/extensions/hooks/index.ts
+++ b/extensions/hooks/index.ts
@@ -64,9 +64,13 @@
  * (asyncRewake keeps its own), and hooks still running at session end are killed,
  * as Claude does at teardown.
  *
- * SubagentStart/SubagentStop ride pi-code's own subagent extension, which publishes
- * child-run lifecycle on the shared bus (notify-style: a child has already exited by
- * the time SubagentStop fires, so its exit-2 block semantics cannot be honored).
+ * SubagentStart runs through the pre-spawn seam (internal/subagent-hooks) so its
+ * additionalContext reaches the child before its first prompt; it cannot block a
+ * spawn, as Claude documents. SubagentStop rides the subagent extension's bus stop
+ * event (notify-style: the child has already exited, so exit-2 block semantics
+ * cannot be honored) and carries last_assistant_message. Inside a subagent child,
+ * agent-frontmatter hooks arrive via PI_CODE_AGENT_HOOKS (Stop pre-converted to
+ * SubagentStop, fired at the child's own agent end) and die with the process.
  *
  * Hook commands run via `sh -c` with the event JSON on stdin. A PreToolUse
  * hook blocks the tool by exiting 2 (stderr becomes the reason) or by printing
@@ -99,8 +103,9 @@ import { isProjectApproved } from '../internal/project-approval.js'
 import { repoRoot } from '../internal/project-root.js'
 import { isSkillHooksEvent, SKILL_HOOKS_CHANNEL } from '../internal/skill-hooks.js'
 import { isSubagentPhaseEvent, SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
+import { setSubagentStartHookRunner } from '../internal/subagent-hooks.js'
 import { claudeToolInput, claudeToolName, claudeToolResponse, piToolOutput } from './claude-tools.js'
-import { formatHooksSummary, type HookCommand, type HookMatcher, type HooksConfig, hookFiles, isBackgroundHook, loadHooks, loadManagedHooks, loadPluginHooks, mergeSkillHooks, readAllowedHttpHookUrls, readDisableAllHooks, readSettingsDisableAllHooks } from './config.js'
+import { formatHooksSummary, type HookCommand, type HookMatcher, type HooksConfig, hookFiles, isBackgroundHook, loadHooks, loadManagedHooks, loadPluginHooks, mergeAgentEnvHooks, mergeSkillHooks, readAllowedHttpHookUrls, readDisableAllHooks, readSettingsDisableAllHooks } from './config.js'
 import { blockedToolCall, jsonBlockVerdict, postToolFeedback, promptContext, runPreToolUse, runUserPromptSubmit, surfaceSystemMessages, tryParseJson } from './decisions.js'
 import { allCommands, matchingCommands, passesIfFilter } from './matcher.js'
 import { type HookRunner, type HookRunResult, runAgentHook, runHookCommand, runHttpHook, runMcpToolHook, runPromptHook, sessionEndTimeoutMs, timeoutMs } from './runners.js'
@@ -199,6 +204,9 @@ export default function hooksExtension(pi: ExtensionAPI) {
     idlePromptTimer = undefined
   }
   let sessionCtx: ExtensionContext | undefined
+  /** Set inside a subagent child that carries agent-frontmatter hooks: the child's
+   * own agent end fires their SubagentStop, per Claude's Stop conversion. */
+  let agentIdentity: { agent: string; id?: string } | undefined
   /** Claude's disableAllHooks escape hatch was set somewhere in the honored chain. */
   let hooksDisabled = false
   /** Which settings file each resolved entry came from, for the /hooks viewer. */
@@ -337,20 +345,35 @@ export default function hooksExtension(pi: ExtensionAPI) {
   // Subagent lifecycle arrives over the bus without a pi context; the session context
   // captured at session_start supplies the common payload fields.
   pi.events.on(SUBAGENT_CHANNEL, async (data) => {
-    if (!isSubagentPhaseEvent(data) || !sessionCtx) return
+    // SubagentStart runs through the pre-spawn seam below (so its context can
+    // reach the child before its first prompt); the bus start event would
+    // double-run it, so only the stop phase is handled here.
+    if (!isSubagentPhaseEvent(data) || data.phase !== 'stop' || !sessionCtx) return
     const ctx = sessionCtx
-    const eventName = data.phase === 'start' ? 'SubagentStart' : 'SubagentStop'
     // Claude's SubagentStop carries the subagent's final text; agent_transcript_path
     // stays absent (a --no-session child writes no transcript, see docs/hooks.md).
-    const payload = { hook_event_name: eventName, agent_type: data.agentType, agent_id: data.agentId, ...(data.phase === 'stop' && data.lastAssistantMessage !== undefined ? { last_assistant_message: data.lastAssistantMessage } : {}) }
+    const payload = { hook_event_name: 'SubagentStop', agent_type: data.agentType, agent_id: data.agentId, ...(data.lastAssistantMessage !== undefined ? { last_assistant_message: data.lastAssistantMessage } : {}) }
     try {
-      const results = await runNotifyHooks(matchingCommands(config[eventName], data.agentType), payload, boundRunner(ctx))
+      const results = await runNotifyHooks(matchingCommands(config.SubagentStop, data.agentType), payload, boundRunner(ctx))
       surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
     } catch {
       // The bus outlives the session: an event landing between /new disposing this
       // ctx and the next session_start hits disposed getters, and nothing awaits a
       // bus listener, so a throw here would escape as an unhandled rejection.
     }
+  })
+
+  // Claude's SubagentStart hooks inject additionalContext into the subagent before
+  // its first prompt, so they must run before the spawn: the subagent extension
+  // calls this seam pre-spawn and prepends the returned context to the child's task.
+  setSubagentStartHookRunner(async (agentType, agentId) => {
+    if (!sessionCtx) return []
+    const ctx = sessionCtx
+    const commands = matchingCommands(config.SubagentStart, agentType)
+    if (commands.length === 0) return []
+    const results = await runNotifyHooks(commands, { hook_event_name: 'SubagentStart', agent_type: agentType, agent_id: agentId }, boundRunner(ctx))
+    surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
+    return results.map((result) => promptContext(result.stdout)).filter(Boolean)
   })
 
   pi.on('session_start', async (event, ctx) => {
@@ -389,6 +412,10 @@ export default function hooksExtension(pi: ExtensionAPI) {
     // Plugins are user-installed and enabled by user settings (see installedPlugins),
     // so a checked-out repo cannot toggle which code-bearing plugin hooks run.
     loadPluginHooks(config, installedPlugins(os.homedir()), hookSources)
+    // Inside a subagent child, the parent passes the agent's frontmatter hooks via
+    // env (Stop already converted to SubagentStop, per Claude); they run only for
+    // this child process.
+    agentIdentity = mergeAgentEnvHooks(config, hookSources)
     // "reload" re-fires in-process with the same conversation and would double-run hooks;
     // a fork is a genuine session begin, which Claude reports as source "fork".
     if (event.reason === 'reload') return
@@ -558,6 +585,18 @@ export default function hooksExtension(pi: ExtensionAPI) {
         void runNotifyHooks(notifyCommands, { hook_event_name: 'Notification', notification_type: 'idle_prompt', message: 'pi is waiting for your input' }, runner).catch(() => {})
       }, IDLE_PROMPT_DELAY_MS)
       idlePromptTimer.unref?.()
+    }
+
+    // In a subagent child, the agent-frontmatter Stop hooks were converted to
+    // SubagentStop and fire here, at the child's own end, notify-style; before the
+    // Stop early-returns, which do not apply to them.
+    if (agentIdentity) {
+      const subStop = matchingCommands(config.SubagentStop, agentIdentity.agent)
+      if (subStop.length > 0) {
+        const subText = lastAssistantText((event as { messages?: Array<{ role: string; content: unknown }> }).messages ?? [])
+        const subPayload = { hook_event_name: 'SubagentStop', agent_type: agentIdentity.agent, ...(agentIdentity.id ? { agent_id: agentIdentity.id } : {}), stop_hook_active: false, ...(subText ? { last_assistant_message: subText } : {}) }
+        await runNotifyHooks(subStop, subPayload, boundRunner(ctx)).catch(() => {})
+      }
     }
 
     // Stop has no matcher support (a stray matcher is ignored, as Claude documents)

--- a/extensions/internal/subagent-hooks.ts
+++ b/extensions/internal/subagent-hooks.ts
@@ -1,0 +1,26 @@
+/**
+ * Pre-spawn seam for Claude's SubagentStart hooks. The hooks extension registers
+ * the runner; the subagent extension calls it before spawning a child, so the
+ * hooks' additionalContext can be injected before the child's first prompt,
+ * which the after-the-fact bus event structurally cannot do. Same module-seam
+ * pattern as mcp-call.
+ */
+
+export type SubagentStartHookRunner = (agentType: string, agentId: string) => Promise<string[]>
+
+let runner: SubagentStartHookRunner | undefined
+
+export function setSubagentStartHookRunner(fn: SubagentStartHookRunner | undefined): void {
+  runner = fn
+}
+
+/** Context strings SubagentStart hooks contribute; empty when no runner is
+ * registered or the runner fails (hooks must never block a spawn). */
+export async function runSubagentStartHooks(agentType: string, agentId: string): Promise<string[]> {
+  if (!runner) return []
+  try {
+    return await runner(agentType, agentId)
+  } catch {
+    return []
+  }
+}

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -157,8 +157,23 @@ function readSkillBody(name: string, skillDirs: string[]): string | undefined {
  * the intent into a read-only toolset unless the file pins tools itself. */
 const READ_ONLY_TOOLS = ['read', 'grep', 'find', 'ls']
 
+/** The agent's name per Claude's naming rules: a plugin agent registers under the
+ * scoped id `<plugin>:<name>` with the filename standing in for a missing name;
+ * elsewhere the frontmatter name is required and `:` is reserved for plugin ids,
+ * so a file carrying one is not loaded. */
+function agentName(frontmatter: Record<string, unknown>, filePath: string, pluginName?: string): string | null {
+  const declared = typeof frontmatter.name === 'string' ? frontmatter.name.trim() : ''
+  if (pluginName !== undefined) return `${pluginName}:${declared || path.basename(filePath, '.md')}`
+  if (!declared) return null
+  if (declared.includes(':')) {
+    console.warn(`pi-code-subagent: ignoring agent ${filePath}: names cannot contain ":", which is reserved for plugin-scoped identifiers`)
+    return null
+  }
+  return declared
+}
+
 /** Parse one agent markdown file; null when it is not a usable agent definition. */
-function parseAgentFile(content: string, source: AgentSource, filePath: string): AgentConfig | null {
+function parseAgentFile(content: string, source: AgentSource, filePath: string, pluginName?: string): AgentConfig | null {
   let parsed: { frontmatter: Record<string, unknown>; body: string }
   try {
     parsed = parseFrontmatter<Record<string, unknown>>(content)
@@ -166,7 +181,7 @@ function parseAgentFile(content: string, source: AgentSource, filePath: string):
     return null // malformed YAML must not abort discovery for the whole directory
   }
   const { frontmatter, body } = parsed
-  const name = typeof frontmatter.name === 'string' ? frontmatter.name : ''
+  const name = agentName(frontmatter, filePath, pluginName)
   const description = typeof frontmatter.description === 'string' ? frontmatter.description : ''
   if (!name || !description) return null
   const tools = parseToolsField(frontmatter.tools, true)
@@ -198,6 +213,8 @@ function parseAgentFile(content: string, source: AgentSource, filePath: string):
     memory: parseMemoryField(frontmatter.memory),
     maxTurns: parseMaxTurns(frontmatter.maxTurns),
     isolation,
+    hooks: frontmatter.hooks !== null && typeof frontmatter.hooks === 'object' && !Array.isArray(frontmatter.hooks) ? (frontmatter.hooks as Record<string, unknown>) : undefined,
+    background: frontmatter.background === true ? true : undefined,
     systemPrompt: body,
     source,
     filePath,
@@ -262,6 +279,12 @@ export interface AgentConfig {
   maxTurns?: number
   /** Claude's `isolation: worktree`: run the child in a temporary git worktree. */
   isolation?: 'worktree'
+  /** Claude's frontmatter `hooks`, scoped to this subagent: passed to the child
+   * via env, with Stop converted to SubagentStop (see agentHooksEnv). */
+  hooks?: Record<string, unknown>
+  /** Claude's `background: true`: keep this agent in the background even when
+   * asked to run it in the foreground. */
+  background?: boolean
   systemPrompt: string
   source: AgentSource
   filePath: string
@@ -274,7 +297,7 @@ export interface AgentDiscoveryResult {
 
 /** Claude scans .claude/agents recursively so agents can be organized into
  * subfolders (agents/review/, agents/research/); the walk mirrors that. */
-function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
+function loadAgentsFromDir(dir: string, source: AgentSource, pluginName?: string): AgentConfig[] {
   const agents: AgentConfig[] = []
 
   let entries: fs.Dirent[]
@@ -287,7 +310,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
   for (const entry of entries) {
     const filePath = path.join(dir, entry.name)
     if (entry.isDirectory()) {
-      agents.push(...loadAgentsFromDir(filePath, source))
+      agents.push(...loadAgentsFromDir(filePath, source, pluginName))
       continue
     }
     if (!entry.name.endsWith('.md')) continue
@@ -300,7 +323,7 @@ function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
       continue
     }
 
-    const agent = parseAgentFile(content, source, filePath)
+    const agent = parseAgentFile(content, source, filePath, pluginName)
     if (agent) agents.push(agent)
   }
 
@@ -323,13 +346,14 @@ export type AgentSource = 'user' | 'project' | 'builtin' | 'plugin'
 /** Bundled default agents (Explore, Plan, general-purpose), lowest precedence. */
 const BUILTIN_AGENTS_DIR = path.join(import.meta.dirname, 'agents')
 
-/** Agent directories of every enabled plugin: `agents/` unless the manifest
+/** Agent directories of every enabled plugin, each with its plugin name (Claude
+ * scopes plugin agent ids as `<plugin>:<name>`): `agents/` unless the manifest
  * points elsewhere. Plugins are user-installed, so user scope only decides. */
-function pluginAgentDirs(home: string): string[] {
+function pluginAgentDirs(home: string): Array<{ dir: string; pluginName: string }> {
   return installedPlugins(home).flatMap((plugin) => {
     const declared = plugin.manifest.agents
     const dirs = Array.isArray(declared) ? declared : [typeof declared === 'string' ? declared : 'agents']
-    return dirs.map((dir) => path.resolve(plugin.root, String(dir)))
+    return dirs.map((dir) => ({ dir: path.resolve(plugin.root, String(dir)), pluginName: plugin.name }))
   })
 }
 
@@ -344,7 +368,7 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 
   // Plugins load after builtins and before the user's own dirs, so a user agent
   // wins a name clash with a plugin's, and ~/.pi/agent/agents wins over ~/.claude.
-  const userAgents = scope === 'project' ? [] : [...loadAgentsFromDir(BUILTIN_AGENTS_DIR, 'builtin'), ...pluginAgentDirs(os.homedir()).flatMap((dir) => loadAgentsFromDir(dir, 'plugin')), ...loadAgentsFromDir(claudeUserDir, 'user'), ...loadAgentsFromDir(userDir, 'user')]
+  const userAgents = scope === 'project' ? [] : [...loadAgentsFromDir(BUILTIN_AGENTS_DIR, 'builtin'), ...pluginAgentDirs(os.homedir()).flatMap((entry) => loadAgentsFromDir(entry.dir, 'plugin', entry.pluginName)), ...loadAgentsFromDir(claudeUserDir, 'user'), ...loadAgentsFromDir(userDir, 'user')]
   // project .claude/agents loads first so project .pi/agents wins on name conflicts
   const projectAgents = scope === 'user' ? [] : [...projectClaudeDirs.flatMap((dir) => loadAgentsFromDir(dir, 'project')), ...(projectPiDir ? loadAgentsFromDir(projectPiDir, 'project') : [])]
 

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -43,6 +43,8 @@ export interface BackgroundSpawn {
   command: string
   args: string[]
   cwd: string
+  /** Extra child environment (agent-frontmatter hooks ride here). */
+  env?: Record<string, string>
   /** The --system-prompt body, kept so a resume can rebuild the file the
    * completing run deleted. Without it the resumed child is handed a path that no
    * longer exists, and pi falls back to using that path as the prompt text. */
@@ -213,12 +215,14 @@ function withRebuiltPrompt(spawnSpec: BackgroundSpawn): string[] {
   }
 }
 
-export function startBackgroundRun(agent: string, task: string, invocation: BackgroundSpawn, onComplete: (run: BackgroundRun) => void): string | null {
+export function startBackgroundRun(agent: string, task: string, invocation: BackgroundSpawn, onComplete: (run: BackgroundRun) => void, presetId?: string): string | null {
   // Checked here, synchronously with registration: callers await temp-file writes
   // between any check of their own and this call, so a parallel tool-call batch
   // could otherwise all pass that earlier check and overshoot the cap.
   if (activeBackgroundRuns() >= MAX_BACKGROUND_RUNS) return null
-  const id = `bg-${randomUUID().slice(0, 8)}`
+  // A preset id lets the caller run SubagentStart hooks pre-spawn with the same
+  // id the run will carry.
+  const id = presetId ?? `bg-${randomUUID().slice(0, 8)}`
   // A stable session id per run: the child persists its session, so a follow-up can
   // resume it instead of starting cold.
   const sessionId = `pi-code-${id}-${randomUUID().slice(0, 8)}`
@@ -240,7 +244,7 @@ function driveRun(run: BackgroundRun, invocation: BackgroundSpawn, onComplete: (
     // Its own group, so cancelling reaches any grandchild the agent spawned.
     detached: true,
     // The marker lets the child's subagent tool refuse to nest further.
-    env: { ...process.env, PI_CODE_SUBAGENT: '1' },
+    env: { ...process.env, PI_CODE_SUBAGENT: '1', ...invocation.env },
   })
   run.live = true
   const killGroup = (signal: NodeJS.Signals): void => {

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -791,6 +791,14 @@ function agentHooksEnv(agent: AgentConfig, agentId: string): Record<string, stri
   return { PI_CODE_AGENT_HOOKS: JSON.stringify({ agent: agent.name, id: agentId, hooks }) }
 }
 
+/** Whether a run belongs in the background: the caller asked, or Claude's
+ * `background: true` frontmatter keeps the agent there even on a foreground ask
+ * (single mode). */
+function wantsBackground(params: { background?: boolean; agent?: string }, agents: AgentConfig[]): boolean {
+  if (params.background) return true
+  return params.agent !== undefined && agents.find((a) => a.name === params.agent)?.background === true
+}
+
 /** The task argument with any SubagentStart hook context ahead of it, per Claude:
  * "added to the subagent's context at the start of its conversation, before its
  * first prompt". */
@@ -1595,10 +1603,7 @@ export default function subagentExtension(pi: ExtensionAPI) {
       // unavailable tier still falls back to the session model.
       const availableModels = ctx.modelRegistry?.getAvailable?.() ?? []
 
-      // Claude's `background: true` frontmatter keeps the agent in the background
-      // even when the caller asked to run it in the foreground (single mode).
-      const backgroundAgent = params.agent !== undefined && agents.find((a) => a.name === params.agent)?.background === true
-      if (params.background || backgroundAgent) return runBackgroundMode(params, { agents, defaultCwd: ctx.cwd, pi, makeDetails, skillRoots, availableModels, projectApproved }, (id) => rememberBackgroundRun(id))
+      if (wantsBackground(params, agents)) return runBackgroundMode(params, { agents, defaultCwd: ctx.cwd, pi, makeDetails, skillRoots, availableModels, projectApproved }, (id) => rememberBackgroundRun(id))
 
       const mode: ModeContext = {
         agents,

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -30,6 +30,7 @@ import { capForContext } from '../internal/output-guard.js'
 import { isProjectApproved, isProjectApprovedSilently } from '../internal/project-approval.js'
 import { repoRoot } from '../internal/project-root.js'
 import { SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
+import { runSubagentStartHooks } from '../internal/subagent-hooks.js'
 import { autoMemoryEnabled, capIndexForPrompt, INDEX_MAX_BYTES, INDEX_MAX_LINES, memorySettingsFiles, readMemorySettings } from '../memory.js'
 import { skillDirs } from '../skills.js'
 import { type AgentConfig, type AgentMemoryScope, type AgentScope, type AgentSource, discoverAgents, expandMcpToolPatterns, resolveModelAlias, withPreloadedSkills } from './agents.js'
@@ -151,6 +152,10 @@ interface RunAgentOptions {
   onUpdate?: OnUpdateCallback
   makeDetails: (results: SingleResult[]) => SubagentDetails
   onPhase?: SubagentPhaseSink
+  /** The child's run id, set by the wrapper so the spawn env can carry it. */
+  agentId?: string
+  /** SubagentStart hook context, injected ahead of the child's first prompt. */
+  startContexts?: string[]
   /** Skill directories to preload from, resolved where project trust is known. */
   skillRoots?: string[]
   /** Models this user can actually run, for resolving a tier alias. */
@@ -208,10 +213,13 @@ async function runSingleAgent(options: RunAgentOptions): Promise<SingleResult> {
     }
   }
   const agentId = `fg-${randomUUID().slice(0, 8)}`
+  // SubagentStart hooks run pre-spawn through the seam so their additionalContext
+  // reaches the child before its first prompt.
+  const startContexts = await runSubagentStartHooks(agent.name, agentId)
   options.onPhase?.('start', agent.name, agentId)
   let result: SingleResult | undefined
   try {
-    result = await runSingleAgentInner(options)
+    result = await runSingleAgentInner({ ...options, agentId, startContexts })
     return result
   } finally {
     options.onPhase?.('stop', agent.name, agentId, result ? getFinalOutput(result.messages) || undefined : undefined)
@@ -302,7 +310,7 @@ async function runSingleAgentInner(options: RunAgentOptions): Promise<SingleResu
       args.push('--system-prompt', tmpPromptPath)
     }
 
-    args.push(`Task: ${task}`)
+    args.push(taskWithStartContext(task, options.startContexts ?? []))
     let wasAborted = false
 
     const exitCode = await new Promise<number>((resolve) => {
@@ -315,7 +323,7 @@ async function runSingleAgentInner(options: RunAgentOptions): Promise<SingleResu
         // direct child orphans a build or dev server the agent started.
         detached: true,
         // The marker lets the child's subagent tool refuse to nest further.
-        env: { ...process.env, PI_CODE_SUBAGENT: '1' },
+        env: { ...process.env, PI_CODE_SUBAGENT: '1', ...agentHooksEnv(agent, options.agentId ?? '') },
       })
       let buffer = ''
       let assistantTurns = 0
@@ -764,7 +772,31 @@ function agentInvocationArgs(agent: AgentConfig, aliasModel?: string): string[] 
   // grant granted nothing.
   if (agent.tools && agent.tools.length > 0) args.push('--tools', expandMcpToolPatterns(agent.tools, knownMcpAliases).join(','))
   if (agent.disallowedTools && agent.disallowedTools.length > 0) args.push('--exclude-tools', expandMcpToolPatterns(agent.disallowedTools, knownMcpAliases).join(','))
+  // Claude: "Explore and Plan are the only subagents that omit CLAUDE.md" (and no
+  // field or setting changes which agents skip them), to keep research fast.
+  if (agent.source === 'builtin' && (agent.name === 'Explore' || agent.name === 'Plan')) args.push('--no-context-files')
   return args
+}
+
+/** Claude's agent-frontmatter hooks ride to the child as env; the child's hooks
+ * extension merges them for the run only (they die with the process, matching
+ * "only while that subagent is running"). Stop converts to SubagentStop, the
+ * event the child fires when it completes, as Claude documents. */
+function agentHooksEnv(agent: AgentConfig, agentId: string): Record<string, string> {
+  if (!agent.hooks) return {}
+  const hooks: Record<string, unknown> = { ...agent.hooks }
+  const stop = hooks.Stop
+  delete hooks.Stop
+  if (Array.isArray(stop)) hooks.SubagentStop = [...(Array.isArray(hooks.SubagentStop) ? (hooks.SubagentStop as unknown[]) : []), ...stop]
+  return { PI_CODE_AGENT_HOOKS: JSON.stringify({ agent: agent.name, id: agentId, hooks }) }
+}
+
+/** The task argument with any SubagentStart hook context ahead of it, per Claude:
+ * "added to the subagent's context at the start of its conversation, before its
+ * first prompt". */
+function taskWithStartContext(task: string, contexts: string[]): string {
+  const context = contexts.filter(Boolean).join('\n')
+  return context ? `${context}\n\nTask: ${task}` : `Task: ${task}`
 }
 
 function backgroundCapResult(makeDetails: MakeDetails): ToolResult {
@@ -853,35 +885,45 @@ async function runBackgroundMode(params: SubagentParamsStatic, context: Backgrou
     // foreground path).
     args.push('--system-prompt', tmpPrompt.filePath)
   }
-  args.push(`Task: ${task}`)
+  // The id is preset so SubagentStart hooks run pre-spawn with the id the run
+  // will actually carry, and their context lands before the child's first prompt.
+  const presetId = `bg-${randomUUID().slice(0, 8)}`
+  const startContexts = await runSubagentStartHooks(agent.name, presetId)
+  args.push(taskWithStartContext(task, startContexts))
   const invocation = getPiInvocation(args)
-  const id = startBackgroundRun(agent.name, task, { command: invocation.command, args: invocation.args, cwd: worktree?.dir ?? runCwd, promptBody: tmpPrompt ? promptBody : undefined, maxTurns: agent.maxTurns }, (run) => {
-    removeTmpPrompt(tmpPrompt)
-    const finish = (): void => {
-      // Both calls throw once the session that started the run is disposed. driveRun's
-      // catch covers the synchronous path, but the worktree branch reaches here from an
-      // async continuation outside it, so the guard must live in finish itself.
-      try {
-        pi.events.emit(SUBAGENT_CHANNEL, { phase: 'stop', agentType: run.agent, agentId: run.id, ...(run.output?.trim() ? { lastAssistantMessage: run.output.trim() } : {}) })
-        pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
-      } catch {
-        // Session disposed after the run outlived it; nothing to notify.
+  const id = startBackgroundRun(
+    agent.name,
+    task,
+    { command: invocation.command, args: invocation.args, cwd: worktree?.dir ?? runCwd, env: agentHooksEnv(agent, presetId), promptBody: tmpPrompt ? promptBody : undefined, maxTurns: agent.maxTurns },
+    (run) => {
+      removeTmpPrompt(tmpPrompt)
+      const finish = (): void => {
+        // Both calls throw once the session that started the run is disposed. driveRun's
+        // catch covers the synchronous path, but the worktree branch reaches here from an
+        // async continuation outside it, so the guard must live in finish itself.
+        try {
+          pi.events.emit(SUBAGENT_CHANNEL, { phase: 'stop', agentType: run.agent, agentId: run.id, ...(run.output?.trim() ? { lastAssistantMessage: run.output.trim() } : {}) })
+          pi.sendMessage({ customType: 'subagent-background', content: backgroundCompletionText(run), display: true }, { triggerTurn: true })
+        } catch {
+          // Session disposed after the run outlived it; nothing to notify.
+        }
       }
-    }
-    if (!worktree) {
-      finish()
-      return
-    }
-    // Cleanup only removes a pristine worktree; a kept one is reported in the
-    // completion text so the parent knows where the changes live.
-    const keptWorktree = worktree
-    void cleanupAgentWorktree(runCwd, keptWorktree)
-      .then((outcome) => {
-        if (outcome === 'kept') run.output = `${run.output ?? ''}\n[isolation: worktree kept at ${keptWorktree.dir} (branch ${keptWorktree.branch}); the agent's changes live there]`.trim()
-      })
-      .catch(() => {})
-      .finally(finish)
-  })
+      if (!worktree) {
+        finish()
+        return
+      }
+      // Cleanup only removes a pristine worktree; a kept one is reported in the
+      // completion text so the parent knows where the changes live.
+      const keptWorktree = worktree
+      void cleanupAgentWorktree(runCwd, keptWorktree)
+        .then((outcome) => {
+          if (outcome === 'kept') run.output = `${run.output ?? ''}\n[isolation: worktree kept at ${keptWorktree.dir} (branch ${keptWorktree.branch}); the agent's changes live there]`.trim()
+        })
+        .catch(() => {})
+        .finally(finish)
+    },
+    presetId,
+  )
   if (id === null) {
     // Lost the cap race to a parallel batch: the atomic check inside startBackgroundRun refused.
     removeTmpPrompt(tmpPrompt)
@@ -1553,7 +1595,10 @@ export default function subagentExtension(pi: ExtensionAPI) {
       // unavailable tier still falls back to the session model.
       const availableModels = ctx.modelRegistry?.getAvailable?.() ?? []
 
-      if (params.background) return runBackgroundMode(params, { agents, defaultCwd: ctx.cwd, pi, makeDetails, skillRoots, availableModels, projectApproved }, (id) => rememberBackgroundRun(id))
+      // Claude's `background: true` frontmatter keeps the agent in the background
+      // even when the caller asked to run it in the foreground (single mode).
+      const backgroundAgent = params.agent !== undefined && agents.find((a) => a.name === params.agent)?.background === true
+      if (params.background || backgroundAgent) return runBackgroundMode(params, { agents, defaultCwd: ctx.cwd, pi, makeDetails, skillRoots, availableModels, projectApproved }, (id) => rememberBackgroundRun(id))
 
       const mode: ModeContext = {
         agents,

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { discoverAgents } from '../extensions/subagent/agents.ts'
+import { discoverAgents, withPreloadedSkills } from '../extensions/subagent/agents.ts'
 
 // The 'both' scope also scans the user's agent dirs; point them at throwaway dirs so
 // an agent in the developer's real ~/.claude/agents or ~/.pi/agent/agents cannot
@@ -256,5 +256,18 @@ describe('plugin-scoped agent ids and frontmatter fields', () => {
     mkdirSync(join(cwd, '.claude', 'agents'), { recursive: true })
     writeFileSync(join(cwd, '.claude', 'agents', 'bg.md'), '---\nname: bg\ndescription: b\nbackground: true\n---\nwork')
     expect(discoverAgents(cwd, 'both').agents.find((a) => a.name === 'bg')?.background).toBe(true)
+  })
+})
+
+describe('skill preloading and model invocation', () => {
+  it('preloads a skill even when its frontmatter sets disable-model-invocation', () => {
+    // Claude: disable-model-invocation removes a skill from the model-facing list,
+    // but the agent `skills` field can still preload it in full.
+    const root = mkdtempSync(join(tmpdir(), 'skills-'))
+    mkdirSync(join(root, 'quiet-skill'), { recursive: true })
+    writeFileSync(join(root, 'quiet-skill', 'SKILL.md'), '---\nname: quiet-skill\ndescription: q\ndisable-model-invocation: true\n---\nThe quiet body')
+
+    const prompt = withPreloadedSkills('base prompt', ['quiet-skill'], [root])
+    expect(prompt).toContain('The quiet body')
   })
 })

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -128,11 +128,12 @@ describe('plugin agents', () => {
     writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { toolkit: true } }))
 
     const cwd = mkdtempSync(join(tmpdir(), 'agents-'))
-    const found = discoverAgents(cwd, 'user').agents.find((a) => a.name === 'auditor')
+    // Plugin agents register under Claude's plugin-scoped id, not the bare name.
+    const found = discoverAgents(cwd, 'user').agents.find((a) => a.name === 'toolkit:auditor')
     expect(found?.source).toBe('plugin')
   })
 
-  it('lets a user agent of the same name win over a plugin agent', () => {
+  it('keeps a plugin agent and a same-named user agent as distinct scoped entries', () => {
     const root = join(hoisted.home, '.claude', 'plugins', 'cache', 'market', 'toolkit', '2.0.0')
     mkdirSync(join(root, 'agents'), { recursive: true })
     writeFileSync(join(root, 'agents', 'auditor.md'), agentFile('auditor', 'PLUGIN'))
@@ -141,9 +142,10 @@ describe('plugin agents', () => {
     writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { toolkit: true } }))
 
     const cwd = mkdtempSync(join(tmpdir(), 'agents-'))
-    const found = discoverAgents(cwd, 'user').agents.filter((a) => a.name === 'auditor')
-    expect(found).toHaveLength(1)
-    expect(found[0].systemPrompt.trim()).toBe('USER')
+    // Scoped ids mean a plugin's auditor never clashes with the user's: both exist.
+    const agents = discoverAgents(cwd, 'user').agents
+    expect(agents.find((a) => a.name === 'auditor')?.systemPrompt.trim()).toBe('USER')
+    expect(agents.find((a) => a.name === 'toolkit:auditor')?.systemPrompt.trim()).toBe('PLUGIN')
   })
 })
 
@@ -213,5 +215,46 @@ describe('monorepo agent discovery', () => {
     const agents = discoverAgents(cwd, 'project').agents
     expect(agents.find((a) => a.name === 'deployer')?.description).toBe('root deployer')
     expect(agents.find((a) => a.name === 'shared')?.description).toBe('near shared')
+  })
+})
+
+describe('plugin-scoped agent ids and frontmatter fields', () => {
+  it('names plugin agents with the plugin-scoped identifier, filename as fallback', () => {
+    // Claude: a plugin subagent's agent type is the scoped id such as
+    // my-plugin:reviewer, not the bare frontmatter name.
+    const root = join(hoisted.home, '.claude', 'plugins', 'cache', 'market', 'toolkit', '2.0.0')
+    mkdirSync(join(root, 'agents'), { recursive: true })
+    writeFileSync(join(root, 'agents', 'reviewer.md'), '---\nname: reviewer\ndescription: reviews\n---\nreview things')
+    writeFileSync(join(root, 'agents', 'anon.md'), '---\ndescription: nameless\n---\nwork')
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { toolkit: true } }))
+
+    const cwd = mkdtempSync(join(tmpdir(), 'agents-'))
+    const names = discoverAgents(cwd, 'user').agents.map((a) => a.name)
+    expect(names).toContain('toolkit:reviewer')
+    expect(names).toContain('toolkit:anon')
+    expect(names).not.toContain('reviewer')
+  })
+
+  it('rejects a non-plugin agent whose name contains a colon, reserved for plugin ids', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'agents-'))
+    mkdirSync(join(cwd, '.claude', 'agents'), { recursive: true })
+    writeFileSync(join(cwd, '.claude', 'agents', 'bad.md'), '---\nname: my:agent\ndescription: colon\n---\nwork')
+    expect(discoverAgents(cwd, 'both').agents.find((a) => a.name === 'my:agent')).toBeUndefined()
+  })
+
+  it('parses frontmatter hooks into the agent config', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'agents-'))
+    mkdirSync(join(cwd, '.claude', 'agents'), { recursive: true })
+    writeFileSync(join(cwd, '.claude', 'agents', 'guarded.md'), '---\nname: guarded\ndescription: g\nhooks:\n  PreToolUse:\n    - matcher: Bash\n      hooks:\n        - type: command\n          command: ./check.sh\n---\nwork')
+    const agent = discoverAgents(cwd, 'both').agents.find((a) => a.name === 'guarded')
+    expect(agent?.hooks).toEqual({ PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: './check.sh' }] }] })
+  })
+
+  it('parses background: true into the agent config', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'agents-'))
+    mkdirSync(join(cwd, '.claude', 'agents'), { recursive: true })
+    writeFileSync(join(cwd, '.claude', 'agents', 'bg.md'), '---\nname: bg\ndescription: b\nbackground: true\n---\nwork')
+    expect(discoverAgents(cwd, 'both').agents.find((a) => a.name === 'bg')?.background).toBe(true)
   })
 })

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -1483,9 +1483,12 @@ describe('hooks subagent lifecycle', () => {
     return { ext, proj }
   }
 
-  it('runs SubagentStart hooks matching the agent type', async () => {
-    const { ext, proj } = await withHooks({ SubagentStart: [{ matcher: 'scout', hooks: [{ command: 'sub-start' }] }] })
-    await ext.emitSubagent({ phase: 'start', agentType: 'scout', agentId: 'fg-abc' })
+  it('runs SubagentStart hooks matching the agent type through the pre-spawn seam', async () => {
+    // SubagentStart moved off the bus start event onto the pre-spawn seam so its
+    // context can reach the child before its first prompt.
+    const { runSubagentStartHooks } = await import('../extensions/internal/subagent-hooks.ts')
+    const { proj } = await withHooks({ SubagentStart: [{ matcher: 'scout', hooks: [{ command: 'sub-start' }] }] })
+    await runSubagentStartHooks('scout', 'fg-abc')
     expect(commandsRun()).toEqual(['sub-start'])
     expect(JSON.parse(recordFor('sub-start').stdin)).toEqual({ ...COMMON, cwd: proj, hook_event_name: 'SubagentStart', agent_type: 'scout', agent_id: 'fg-abc' })
   })
@@ -2402,5 +2405,64 @@ describe('hook error notices', () => {
     const result = (await ext.input('hello')) as { action: string; text?: string }
     expect(result.action).toBe('continue')
     expect(ext.notes.some((note) => note.msg.includes('hook error'))).toBe(true)
+  })
+})
+
+describe('hooks SubagentStart context seam', () => {
+  it('serves SubagentStart hooks through the pre-spawn runner, returning their context', async () => {
+    // Claude: SubagentStart hooks inject additionalContext into the subagent
+    // before its first prompt, so they must run before the child spawns; the
+    // subagent extension calls this seam pre-spawn.
+    const { runSubagentStartHooks } = await import('../extensions/internal/subagent-hooks.ts')
+    script('sub-start', { stdout: ['{"hookSpecificOutput":{"hookEventName":"SubagentStart","additionalContext":"security rules"}}'], code: 0 })
+    writeSettings(hoisted.home, 'settings.json', { SubagentStart: [{ matcher: 'scout', hooks: [{ command: 'sub-start' }] }] })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+
+    const contexts = await runSubagentStartHooks('scout', 'fg-1')
+    expect(commandsRun()).toEqual(['sub-start'])
+    expect(contexts).toEqual(['security rules'])
+    expect(JSON.parse(recordFor('sub-start').stdin)).toMatchObject({ hook_event_name: 'SubagentStart', agent_type: 'scout', agent_id: 'fg-1' })
+  })
+
+  it('no longer double-runs SubagentStart from the bus start event', async () => {
+    writeSettings(hoisted.home, 'settings.json', { SubagentStart: [{ hooks: [{ command: 'sub-start' }] }] })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+
+    await ext.emitSubagent({ phase: 'start', agentType: 'scout', agentId: 'fg-1' })
+    expect(commandsRun()).toEqual([])
+  })
+})
+
+describe('hooks from agent frontmatter in the child', () => {
+  const withAgentHooks = async (hooks: unknown) => {
+    process.env.PI_CODE_SUBAGENT = '1'
+    process.env.PI_CODE_AGENT_HOOKS = JSON.stringify({ agent: 'scout', id: 'fg-9', hooks })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    return ext
+  }
+
+  afterEach(() => {
+    delete process.env.PI_CODE_SUBAGENT
+    delete process.env.PI_CODE_AGENT_HOOKS
+  })
+
+  it('runs agent-frontmatter hooks inside the subagent child', async () => {
+    const ext = await withAgentHooks({ PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'agent-guard' }] }] })
+    await ext.toolCall('bash', {})
+
+    expect(commandsRun()).toEqual(['agent-guard'])
+  })
+
+  it('fires the converted Stop hook as SubagentStop when the child finishes', async () => {
+    // Claude converts a Stop hook in agent frontmatter to SubagentStop, the event
+    // fired when the subagent completes; in the child that is its own agent end.
+    const ext = await withAgentHooks({ SubagentStop: [{ hooks: [{ command: 'agent-done' }] }] })
+    await ext.agentEnd()
+
+    expect(commandsRun()).toEqual(['agent-done'])
+    expect(JSON.parse(recordFor('agent-done').stdin)).toMatchObject({ hook_event_name: 'SubagentStop', agent_type: 'scout', agent_id: 'fg-9' })
   })
 })

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -1888,3 +1888,74 @@ describe('subagent run semantics conformance', () => {
     expect((stop.data as { lastAssistantMessage?: string }).lastAssistantMessage).toBe('the findings')
   })
 })
+
+describe('subagent context and hooks conformance', () => {
+  it('spawns Explore and Plan with --no-context-files, per Claude context skipping', async () => {
+    // Claude: "Explore and Plan are the only subagents that omit CLAUDE.md"; no
+    // field or setting changes which agents skip them.
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ name: 'Explore', source: 'builtin' })], projectAgentsDir: null })
+    script('inspect', { stdout: [say('found')] })
+    await execute('c1', { agent: 'Explore', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(spawnCalls[0].args).toContain('--no-context-files')
+  })
+
+  it('does not skip context files for other agents', async () => {
+    script('inspect', { stdout: [say('found')] })
+    await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(spawnCalls[0].args).not.toContain('--no-context-files')
+  })
+
+  it('keeps a background: true agent in the background even on a foreground ask', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [{ ...agentConfig(), background: true }], projectAgentsDir: null })
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(startBackgroundRunMock).toHaveBeenCalled()
+    expect(text(result)).toContain('background run')
+    expect(spawnCalls).toHaveLength(0)
+  })
+
+  it('injects SubagentStart hook context before the child first prompt', async () => {
+    // Claude: SubagentStart additionalContext is "added to the subagent's context
+    // at the start of its conversation, before its first prompt".
+    const { setSubagentStartHookRunner } = await import('../extensions/internal/subagent-hooks.ts')
+    setSubagentStartHookRunner(async () => ['Follow security guidelines'])
+    try {
+      script('inspect', { stdout: [say('ok')] })
+      await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+      const taskArg = spawnCalls[0].args.at(-1)
+      expect(taskArg).toContain('Follow security guidelines')
+      expect(taskArg).toContain('Task: inspect')
+      expect(taskArg?.indexOf('Follow security guidelines')).toBeLessThan(taskArg?.indexOf('Task: inspect') ?? -1)
+    } finally {
+      setSubagentStartHookRunner(undefined)
+    }
+  })
+
+  it('passes agent frontmatter hooks to the child with Stop converted to SubagentStop', async () => {
+    // Claude: subagent-frontmatter hooks run only while that subagent runs, and a
+    // Stop hook there converts to SubagentStop.
+    discoverAgentsMock.mockReturnValue({
+      agents: [{ ...agentConfig(), hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: './c.sh' }] }], Stop: [{ hooks: [{ command: './done.sh' }] }] } }],
+      projectAgentsDir: null,
+    })
+    script('inspect', { stdout: [say('ok')] })
+    await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    const env = (spawnCalls[0].options as { env?: Record<string, string> }).env ?? {}
+    const passed = JSON.parse(env.PI_CODE_AGENT_HOOKS ?? '{}')
+    expect(passed.agent).toBe('scout')
+    expect(passed.hooks.PreToolUse).toBeDefined()
+    expect(passed.hooks.SubagentStop).toEqual([{ hooks: [{ command: './done.sh' }] }])
+    expect(passed.hooks.Stop).toBeUndefined()
+  })
+
+  it('passes no hooks env for an agent without frontmatter hooks', async () => {
+    script('inspect', { stdout: [say('ok')] })
+    await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    const env = (spawnCalls[0].options as { env?: Record<string, string> }).env ?? {}
+    expect(env.PI_CODE_AGENT_HOOKS).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #158); closes the subagent batch.

## Agent-frontmatter hooks (agents.ts, index.ts, background.ts, hooks/config.ts, hooks/index.ts)
- `hooks` in agent frontmatter now parse into the agent config and ride to the child via `PI_CODE_AGENT_HOOKS`, with `Stop` converted to `SubagentStop` per Claude. The child's hooks extension merges them for the run only (they die with the process, matching "only while that subagent is running") and fires the converted hooks at its own agent end with a SubagentStop payload carrying `last_assistant_message`.

## SubagentStart context injection (internal/subagent-hooks.ts, hooks/index.ts, subagent/index.ts)
- SubagentStart hooks now run through a pre-spawn seam (mcp-call pattern): the subagent extension calls it before spawning, and the returned `additionalContext` is prepended to the child's first prompt, per "added to the subagent's context at the start of its conversation". The bus start event no longer fires SubagentStart (it would double-run and its context could never reach the child). Background runs pre-generate their id so the hooks see the id the run actually carries.

## Discovery and dispatch (agents.ts, index.ts)
- Plugin agents register under Claude's plugin-scoped id (`toolkit:reviewer`), with the filename standing in for a missing frontmatter name; a same-named user agent no longer clashes. A `:` in a non-plugin agent name rejects the file, as Claude reserves it.
- `background: true` frontmatter keeps the agent in the background even on a foreground ask.
- Explore and Plan spawn with `--no-context-files`, the only agents that skip CLAUDE.md, matching Claude's non-configurable rule.

Docs: `docs/subagents.md` and `docs/hooks.md` updated; the hooks header's subagent paragraph rewritten.

All changes covered by tests that failed before the change (12 red tests), plus mutation checks on the two guards that never independently failed (context files kept for other agents, no hooks env without frontmatter hooks) — both caught.