### PR TITLE
Align output styles, memory, and context limits with Claude docs

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -4,6 +4,6 @@ Per-repository memories with a session-injected index. Source: [`extensions/memo
 
 - Memories live under `~/.pi/agent/memory`, keyed on the repository root, so subdirectory sessions share one store (as Claude does; this is pi's own store, separate from Claude's).
 - The index is injected each session within Claude's 200-line/25KB bound; YAML frontmatter and block HTML comments are stripped before it counts or loads.
-- A save that would overflow the index reports why; a memory written with frontmatter gets a `modified:` ISO timestamp.
-- Honors `autoMemoryEnabled` (settings) and `CLAUDE_CODE_DISABLE_AUTO_MEMORY` (env) to turn it off, and `autoMemoryDirectory` (absolute or `~/`) to relocate the store.
-- `/memory` prints the store and index locations.
+- A save landing near the index read limit reminds Claude to shorten it; over the limit the write still succeeds and an error tells Claude to rewrite the index, per Claude's contract. A memory written with frontmatter gets a `modified:` ISO timestamp; the tool asks for Claude's documented `type` vocabulary (user/feedback/project/reference).
+- Honors `autoMemoryEnabled` (settings) and `CLAUDE_CODE_DISABLE_AUTO_MEMORY` (env) to turn it off, and `autoMemoryDirectory` (absolute or `~/`) to relocate the store; managed policy settings win over the file chain.
+- `/memory` prints the store, index, and every documented memory-file location (user and project CLAUDE.md, CLAUDE.local.md, the `.claude/CLAUDE.md` alternate), including files that do not exist yet.

--- a/docs/output-styles.md
+++ b/docs/output-styles.md
@@ -3,6 +3,6 @@
 Claude output styles with replace semantics. Source: [`extensions/output-styles.ts`](../extensions/output-styles.ts).
 
 - Reads every `.claude/output-styles` between the working directory and the repository root (the style closest to the working directory winning a name clash) plus the active `outputStyle` setting, and styles shipped by enabled plugins (manifest `outputStyles`, default `output-styles/`, ranked below the user's and project's own).
-- Claude replace semantics with `keep-coding-instructions`.
-- Bundles the Explanatory, Learning, and Proactive built-ins.
+- Claude replace semantics with `keep-coding-instructions`; `force-for-plugin` on a plugin style applies it automatically over the `outputStyle` setting (first loaded wins); a managed-settings `outputStyle` wins over every file.
+- Bundles the Concise, Explanatory, Learning, and Proactive built-ins.
 - `/output-style [name]` switches styles.

--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -81,6 +81,21 @@ import { fenceMarker, stripBlockComments } from './internal/strip-comments.js'
 
 /** Claude documents "a maximum depth of four hops" for recursive imports. */
 const MAX_IMPORT_DEPTH = 4
+
+/** Claude loads a context file (CLAUDE.md and friends) of up to 4 MiB in full and
+ * skips a larger one. */
+const CONTEXT_FILE_MAX_BYTES = 4 * 1024 * 1024
+
+/** One context file's content, or undefined when it is absent, unreadable, or over
+ * the 4 MiB limit Claude documents. */
+function readContextFile(filePath: string): string | undefined {
+  try {
+    if (fs.statSync(filePath).size > CONTEXT_FILE_MAX_BYTES) return undefined
+    return fs.readFileSync(filePath, 'utf-8')
+  } catch {
+    return undefined
+  }
+}
 export const MAX_IMPORT_FILES = 50
 export const MAX_IMPORT_BYTES = 256 * 1024
 
@@ -292,11 +307,8 @@ export function additionalDirContextFiles(dir: string, includeLocal: boolean): A
   if (includeLocal) candidates.push(path.join(dir, 'CLAUDE.local.md'))
   const files: Array<{ path: string; content: string }> = []
   for (const candidate of candidates) {
-    try {
-      files.push({ path: candidate, content: fs.readFileSync(candidate, 'utf-8') })
-    } catch {
-      // absent or unreadable: treat as not there
-    }
+    const content = readContextFile(candidate)
+    if (content !== undefined) files.push({ path: candidate, content })
   }
   return files
 }
@@ -717,12 +729,9 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
 
     // ~/.claude/CLAUDE.md, Claude's user-scope memory. The user's own file, so no
     // project approval is required; a missing file simply leaves it unset.
-    try {
-      const userClaudeMd = path.join(claudeConfigDir(os.homedir()), 'CLAUDE.md')
-      userContext = { path: userClaudeMd, content: fs.readFileSync(userClaudeMd, 'utf-8') }
-    } catch {
-      // no user CLAUDE.md
-    }
+    const userClaudeMd = path.join(claudeConfigDir(os.homedir()), 'CLAUDE.md')
+    const userContent = readContextFile(userClaudeMd)
+    if (userContent !== undefined) userContext = { path: userClaudeMd, content: userContent }
 
     // CLAUDE.local.md is Claude Code's personal sidecar of CLAUDE.md; pi's own loader
     // skips it. A cloned repo can ship one, so it is gated like other project config.
@@ -735,18 +744,12 @@ export default function contextImportsExtension(pi: ExtensionAPI) {
     const dotClaudeMd = findNearestFile(ctx.cwd, path.join('.claude', 'CLAUDE.md'))
     if ((candidates.length > 0 || dotClaudeMd !== null) && (await isProjectApproved(ctx))) {
       for (const candidate of candidates) {
-        try {
-          localContexts.push({ path: candidate, content: fs.readFileSync(candidate, 'utf-8') })
-        } catch {
-          // unreadable: treat as absent
-        }
+        const content = readContextFile(candidate)
+        if (content !== undefined) localContexts.push({ path: candidate, content })
       }
       if (dotClaudeMd !== null) {
-        try {
-          projectDotClaude = { path: dotClaudeMd, content: fs.readFileSync(dotClaudeMd, 'utf-8') }
-        } catch {
-          // unreadable: treat as absent
-        }
+        const content = readContextFile(dotClaudeMd)
+        if (content !== undefined) projectDotClaude = { path: dotClaudeMd, content }
       }
     }
     // Read after the local-context flow so an approval it just recorded is honored.

--- a/extensions/internal/builtin-styles/concise.md
+++ b/extensions/internal/builtin-styles/concise.md
@@ -1,0 +1,13 @@
+---
+name: Concise
+description: Leads with the result and keeps responses short by default, without cutting the engineering work
+keep-coding-instructions: true
+---
+
+Lead with the result. Skip preamble, narration, and restating the request; answer first, support after.
+
+Keep responses short by default while doing the engineering work as thoroughly as ever: brevity applies to the writing, never to the analysis, testing, or care taken.
+
+When the user asks for an explanation or more detail, answer in full.
+
+Always keep the complete content of error reports, security warnings, and confirmations for destructive actions; never shorten those.

--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -198,9 +198,14 @@ export function globCompileStats(): { compiled: number; evaluated: number } {
 /** Rule `paths:` globs compiled once for repeated matching, with claude-rules'
  * pathMatchesGlobs semantics: `./` and leading `/` anchors are stripped, a trailing
  * slash scopes to the directory's contents, and blank entries drop out. */
+/** Claude's shared list budget: rule patterns past ~1000 compiled entries are
+ * ignored rather than compiled without bound. */
+const LIST_PATTERN_BUDGET = 1000
+
 export function compileGlobs(globs: string[]): CompiledGlob[] {
   const compiled: CompiledGlob[] = []
   for (const raw of globs) {
+    if (compiled.length >= LIST_PATTERN_BUDGET) break
     let glob = raw.trim()
     if (!glob) continue
     if (glob.startsWith('./')) glob = glob.slice(2)

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -15,6 +15,7 @@ import { StringEnum } from '@earendil-works/pi-ai'
 import { type ExtensionAPI, withFileMutationQueue } from '@earendil-works/pi-coding-agent'
 import { Type } from 'typebox'
 import { claudeConfigDir } from './internal/config-dir.js'
+import { readManagedSettings } from './internal/managed-settings.js'
 import { capForContext } from './internal/output-guard.js'
 import { isProjectApprovedSilently } from './internal/project-approval.js'
 import { repoRoot } from './internal/project-root.js'
@@ -141,6 +142,18 @@ export function indexWouldOverflow(index: string, name: string, description: str
   return next.split('\n').length > INDEX_MAX_LINES || Buffer.byteLength(next, 'utf-8') > INDEX_MAX_BYTES
 }
 
+/** Where the index stands against the read limits, measured on the loaded content
+ * (frontmatter and comments stripped): 'over' past either bound, 'near' within
+ * 10% of one, else 'ok'. Claude reminds near a limit and errors over it. */
+export function indexReadState(index: string): 'ok' | 'near' | 'over' {
+  const loaded = stripNonLoaded(index)
+  const lines = loaded.split('\n').length
+  const bytes = Buffer.byteLength(loaded, 'utf-8')
+  if (lines > INDEX_MAX_LINES || bytes > INDEX_MAX_BYTES) return 'over'
+  if (lines > INDEX_MAX_LINES * 0.9 || bytes > INDEX_MAX_BYTES * 0.9) return 'near'
+  return 'ok'
+}
+
 type MemoryToolResult = { content: Array<{ type: 'text'; text: string }>; details: Record<string, never> }
 
 /** Write a memory and its index line, or say why it cannot be written. The whole
@@ -156,18 +169,29 @@ async function saveMemory(dir: string, indexPath: string, name: string | undefin
   }
   return withFileMutationQueue(indexPath, async (): Promise<MemoryToolResult> => {
     const index = readIndex(dir)
-    // Claude reports an explicit error rather than writing a memory the next session
-    // would never load, and says what to do about it.
-    if (indexWouldOverflow(index, name, description)) {
-      return {
-        content: [{ type: 'text', text: `Memory index is full (${INDEX_MAX_LINES} entries or ${INDEX_MAX_BYTES} bytes). Delete or consolidate memories before saving ${name}.` }],
-        details: {},
-      }
-    }
     fs.mkdirSync(dir, { recursive: true })
     // A memory with frontmatter records its write time; one without is left as-is.
     fs.writeFileSync(path.join(dir, `${name}.md`), stampModified(content, now))
-    writeIndex(indexPath, upsertIndexLine(index, name, description))
+    const nextIndex = upsertIndexLine(index, name, description)
+    writeIndex(indexPath, nextIndex)
+    // Claude measures the index after the write: over a read limit the write still
+    // succeeds, but an error tells Claude to rewrite the index (everything past
+    // the limit is dropped on the next load); near a limit, a reminder to shorten.
+    const state = indexReadState(nextIndex)
+    if (state === 'over') {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Saved memory ${name}, but the memory index is over its read limit (${INDEX_MAX_LINES} lines / ${INDEX_MAX_BYTES} bytes): rewrite MEMORY.md now. Keep one line per entry, move detail into topic files, and merge or drop stale entries; everything past the limit is dropped on the next load.`,
+          },
+        ],
+        details: {},
+      }
+    }
+    if (state === 'near') {
+      return { content: [{ type: 'text', text: `Saved memory ${name}. The memory index is near its read limit; shorten it: keep one line per entry, move detail into topic files, and merge or drop stale entries.` }], details: {} }
+    }
     return { content: [{ type: 'text', text: `Saved memory ${name}.` }], details: {} }
   })
 }
@@ -294,8 +318,9 @@ export function memorySettingsFiles(cwd: string, home: string, approved: boolean
   return claudeSettingsChain(cwd, home, approved)
 }
 
-/** Merge the two memory settings across the chain, later files winning per key. */
-export function readMemorySettings(files: string[]): { autoMemoryEnabled?: unknown; autoMemoryDirectory?: unknown } {
+/** Merge the two memory settings across the chain, later files winning per key;
+ * managed policy settings win over every file, per Claude's settings precedence. */
+export function readMemorySettings(files: string[], managed: Record<string, unknown> = readManagedSettings()): { autoMemoryEnabled?: unknown; autoMemoryDirectory?: unknown } {
   const merged: { autoMemoryEnabled?: unknown; autoMemoryDirectory?: unknown } = {}
   for (const file of files) {
     try {
@@ -307,6 +332,8 @@ export function readMemorySettings(files: string[]): { autoMemoryEnabled?: unkno
       // missing or invalid settings file: skip
     }
   }
+  if ('autoMemoryEnabled' in managed) merged.autoMemoryEnabled = managed.autoMemoryEnabled
+  if ('autoMemoryDirectory' in managed) merged.autoMemoryDirectory = managed.autoMemoryDirectory
   return merged
 }
 
@@ -405,7 +432,8 @@ export default function memoryExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: 'memory',
     label: 'Memory',
-    description: 'Persistent memory across sessions. Save durable facts, user preferences, corrections, and project decisions that are not derivable from the code. Actions: save (name + description + content), read (name), delete (name), list.',
+    description:
+      'Persistent memory across sessions. Save durable facts, user preferences, corrections, and project decisions that are not derivable from the code. Give each saved memory `type` frontmatter from the documented vocabulary: user (who the user is), feedback (guidance on how to work), project (ongoing work and constraints), or reference (pointers to external resources). Actions: save (name + description + content), read (name), delete (name), list.',
     parameters: MemoryParams,
     async execute(_id, params) {
       if (inSubagent()) {
@@ -492,6 +520,10 @@ export default function memoryExtension(pi: ExtensionAPI) {
         `  Index:       ${path.join(store, INDEX_FILE)}`,
         `  User memory (CLAUDE.md):    ${path.join(home, '.claude', 'CLAUDE.md')}`,
         `  Project memory (CLAUDE.md): ${path.join(ctx.cwd, 'CLAUDE.md')}`,
+        // Claude's /memory lists every documented location, including files that
+        // do not exist yet.
+        `  Project memory (CLAUDE.local.md): ${path.join(ctx.cwd, 'CLAUDE.local.md')}`,
+        `  Project memory (alternate):       ${path.join(ctx.cwd, '.claude', 'CLAUDE.md')}`,
         'Toggle with /memory on or /memory off.',
       ]
       ctx.ui.notify(lines.join('\n'), 'info')

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -25,6 +25,7 @@ import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
 import { claudeConfigDir } from './internal/config-dir.js'
+import { readManagedSettings } from './internal/managed-settings.js'
 import { installedPlugins } from './internal/plugins.js'
 import { isProjectApproved } from './internal/project-approval.js'
 import { ancestorDirs, findNearestDir, findNearestFile } from './internal/project-root.js'
@@ -35,6 +36,8 @@ export interface OutputStyle {
   description: string
   body: string
   keepCodingInstructions: boolean
+  /** Claude's `force-for-plugin`: a plugin style applying automatically. */
+  forceForPlugin: boolean
 }
 
 function field(frontmatter: string, key: string): string {
@@ -47,7 +50,20 @@ export function parseStyle(content: string, fallbackName: string): OutputStyle {
   const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)
   const frontmatter = match ? match[1] : ''
   const body = match ? content.slice(match[0].length) : content
-  return { name: field(frontmatter, 'name') || fallbackName, description: field(frontmatter, 'description'), body: body.trim(), keepCodingInstructions: field(frontmatter, 'keep-coding-instructions') === 'true' }
+  return {
+    name: field(frontmatter, 'name') || fallbackName,
+    description: field(frontmatter, 'description'),
+    body: body.trim(),
+    keepCodingInstructions: field(frontmatter, 'keep-coding-instructions') === 'true',
+    forceForPlugin: field(frontmatter, 'force-for-plugin') === 'true',
+  }
+}
+
+/** Claude's `force-for-plugin` (plugin output styles only): the first loaded style
+ * carrying it applies automatically, overriding the outputStyle setting. The
+ * caller passes only plugin-loaded styles. */
+export function forcedPluginStyle(styles: OutputStyle[]): OutputStyle | undefined {
+  return styles.find((style) => style.forceForPlugin)
 }
 
 /** Equivalents of Claude's built-in styles, shipped with pi-code as the
@@ -137,8 +153,10 @@ export function settingsFiles(cwd: string, home: string, trusted: boolean): stri
   return claudeSettingsChain(cwd, home, trusted)
 }
 
-/** The `outputStyle` recorded in settings, last file winning. */
-export function readActiveStyleName(files: string[]): string | undefined {
+/** The `outputStyle` recorded in settings, last file winning; a managed policy
+ * value wins over every file, per Claude's settings precedence. */
+export function readActiveStyleName(files: string[], managed: Record<string, unknown> = readManagedSettings()): string | undefined {
+  if (typeof managed.outputStyle === 'string') return managed.outputStyle
   let name: string | undefined
   for (const file of files) {
     try {
@@ -186,7 +204,10 @@ export default function outputStylesExtension(pi: ExtensionAPI) {
     const nearestLocal = findNearestFile(ctx.cwd, path.join('.claude', 'settings.local.json'))
     const claudeDir = findNearestDir(ctx.cwd, '.claude') ?? path.join(ctx.cwd, '.claude')
     localSettingsPath = nearestLocal ?? path.join(claudeDir, 'settings.local.json')
-    activeName = readActiveStyleName(settingsFiles(ctx.cwd, home, trusted))
+    // Claude's force-for-plugin: the first loaded forced plugin style applies
+    // automatically, overriding the outputStyle setting.
+    const forced = forcedPluginStyle(loadStyles(pluginStyleDirs(home)))
+    activeName = forced?.name ?? readActiveStyleName(settingsFiles(ctx.cwd, home, trusted))
     const active = styleForName(styles, activeName)
     if (active) ctx.ui.notify(`Output style: ${active.name}`, 'info')
   })

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -1456,3 +1456,19 @@ describe('managed CLAUDE.md file', () => {
     expect(await wireWithBus().fire(tempDir())).toBe('BASE')
   })
 })
+
+describe('context file size limit', () => {
+  it('skips a CLAUDE.local.md larger than 4 MiB instead of loading it', async () => {
+    // Claude: "Claude Code loads a CLAUDE.md file of up to 4 MiB in full and
+    // skips a larger file."
+    const cwd = tempDir()
+    writeFileSync(join(cwd, 'CLAUDE.local.md'), `HUGE START\n${'x'.repeat(4 * 1024 * 1024)}`)
+
+    const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>()
+    contextImports({ on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn) } as never)
+    await handlers.get('session_start')?.({}, { cwd, isProjectTrusted: () => true, hasUI: true, ui: { notify: () => {}, confirm: async () => true } })
+    const result = (await handlers.get('before_agent_start')?.({ systemPrompt: 'BASE', systemPromptOptions: { cwd, contextFiles: [] } }, {})) as { systemPrompt: string } | undefined
+
+    expect(result?.systemPrompt ?? 'BASE').not.toContain('HUGE START')
+  })
+})

--- a/tests/memory-actions.test.ts
+++ b/tests/memory-actions.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -189,5 +189,63 @@ describe('memory index robustness', () => {
     expect(result).not.toContain('Deleted')
     expect(existsSync(join(dir, 'keep.md'))).toBe(true)
     expect(readFileSync(indexPath, 'utf-8')).toContain('- [keep](keep.md):')
+  })
+})
+
+describe('memory index overflow, per the documented write-and-error rule', () => {
+  const origHome2 = process.env.HOME
+  afterEach(() => {
+    if (origHome2 === undefined) delete process.env.HOME
+    else process.env.HOME = origHome2
+  })
+
+  function setup() {
+    process.env.HOME = mkdtempSync(join(tmpdir(), 'mem-home-'))
+    const cwd = mkdtempSync(join(tmpdir(), 'mem-proj-'))
+    const handlers = new Map<string, Handler>()
+    let tool: Tool | undefined
+    memoryExtension({
+      on: (name: string, fn: Handler) => handlers.set(name, fn),
+      registerTool: (t: Tool) => {
+        tool = t
+      },
+      registerCommand: () => {},
+    } as never)
+    if (!tool) throw new Error('memory tool not registered')
+    return { handlers, tool, cwd, dir: memoryDir(cwd) }
+  }
+
+  const start = async (handlers: Map<string, Handler>, cwd: string) => handlers.get('session_start')?.({}, { cwd, ui: { notify: () => {} } })
+
+  it('still writes the memory when the index is over its limit, and errors telling Claude to rewrite the index', async () => {
+    // Claude: "If the file is over a limit, the write still succeeds, but Claude
+    // Code returns an error telling Claude to rewrite the index."
+    const { handlers, tool, cwd, dir } = setup()
+    await start(handlers, cwd)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'MEMORY.md'), Array.from({ length: 201 }, (_, i) => `- [m${i}](m${i}.md) — x`).join('\n'))
+
+    const result = await tool.execute('1', { action: 'save', name: 'overflow-mem', description: 'd', content: 'the fact' })
+
+    expect(existsSync(join(dir, 'overflow-mem.md'))).toBe(true)
+    expect(result.content[0].text.toLowerCase()).toContain('rewrite')
+  })
+
+  it('reminds Claude to shorten the index when a write lands near a limit', async () => {
+    const { handlers, tool, cwd, dir } = setup()
+    await start(handlers, cwd)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'MEMORY.md'), Array.from({ length: 185 }, (_, i) => `- [m${i}](m${i}.md) — x`).join('\n'))
+
+    const result = await tool.execute('1', { action: 'save', name: 'near-mem', description: 'd', content: 'the fact' })
+
+    expect(result.content[0].text.toLowerCase()).toContain('shorten')
+  })
+
+  it('names the documented type vocabulary in the tool description', () => {
+    const { tool } = setup()
+    const description = (tool as { description?: string }).description ?? ''
+    expect(description).toContain('feedback')
+    expect(description).toContain('reference')
   })
 })

--- a/tests/memory-command.test.ts
+++ b/tests/memory-command.test.ts
@@ -139,3 +139,25 @@ describe('memory command', () => {
     }
   })
 })
+
+describe('memory location listing, per the documented /memory contract', () => {
+  const wire = () => {
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>()
+    memoryExtension({ on: () => {}, registerTool: () => {}, registerCommand: (name: string, spec: { handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, spec) } as never)
+    return commands
+  }
+
+  it('lists CLAUDE.local.md and the project .claude/CLAUDE.md alternate', async () => {
+    // Claude: "/memory lists your CLAUDE.md, CLAUDE.local.md, and other memory
+    // file locations across user and project scopes, including entries for files
+    // that don't exist yet."
+    const cwd = mkdtempSync(join(tmpdir(), 'memcmd-'))
+    const notify = vi.fn()
+    await wire()
+      .get('memory')
+      ?.handler('', { cwd, isProjectTrusted: () => false, hasUI: false, ui: { notify } })
+    const text = notify.mock.calls[0][0] as string
+    expect(text).toContain('CLAUDE.local.md')
+    expect(text).toContain(join('.claude', 'CLAUDE.md'))
+  })
+})

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -28,7 +28,24 @@ vi.mock('node:fs', async (importOriginal) => {
   return { ...actual, readFileSync, renameSync }
 })
 
-import memoryExtension, { autoMemoryEnabled, capIndexForPrompt, INDEX_MAX_BYTES, INDEX_MAX_LINES, indexWouldOverflow, memoryDir, migrateLegacyStore, projectSlug, removeIndexLine, resolveMemoryDir, setAutoMemoryEnabledSetting, slugifyName, stampModified, stripNonLoaded, upsertIndexLine } from '../extensions/memory.ts'
+import memoryExtension, {
+  autoMemoryEnabled,
+  capIndexForPrompt,
+  INDEX_MAX_BYTES,
+  INDEX_MAX_LINES,
+  indexWouldOverflow,
+  memoryDir,
+  migrateLegacyStore,
+  projectSlug,
+  readMemorySettings,
+  removeIndexLine,
+  resolveMemoryDir,
+  setAutoMemoryEnabledSetting,
+  slugifyName,
+  stampModified,
+  stripNonLoaded,
+  upsertIndexLine,
+} from '../extensions/memory.ts'
 
 describe('memory helpers', () => {
   it('slugs project paths into directory names', () => {
@@ -451,5 +468,18 @@ describe('migrateLegacyStore', () => {
     rmSync(home, { recursive: true, force: true })
     rmSync(repo, { recursive: true, force: true })
     hoisted.home = ''
+  })
+})
+
+describe('managed autoMemory settings', () => {
+  it('lets managed policy settings override the settings-chain autoMemory values', () => {
+    // Claude's settings precedence: managed policy settings win over user and
+    // project files.
+    const dir = mkdtempSync(join(tmpdir(), 'mem-managed-'))
+    const user = join(dir, 'settings.json')
+    writeFileSync(user, JSON.stringify({ autoMemoryEnabled: true }))
+    const merged = readMemorySettings([user], { autoMemoryEnabled: false, autoMemoryDirectory: '/managed/dir' })
+    expect(merged.autoMemoryEnabled).toBe(false)
+    expect(merged.autoMemoryDirectory).toBe('/managed/dir')
   })
 })

--- a/tests/output-styles.test.ts
+++ b/tests/output-styles.test.ts
@@ -19,11 +19,11 @@ const tempDir = (): string => mkdtempSync(join(tmpdir(), 'os-'))
 describe('parseStyle', () => {
   it('reads name and description from frontmatter and trims the body', () => {
     const md = '---\nname: Explanatory\ndescription: Teach while you work\n---\nExplain your reasoning.\n'
-    expect(parseStyle(md, 'fallback')).toEqual({ name: 'Explanatory', description: 'Teach while you work', body: 'Explain your reasoning.', keepCodingInstructions: false })
+    expect(parseStyle(md, 'fallback')).toEqual({ name: 'Explanatory', description: 'Teach while you work', body: 'Explain your reasoning.', keepCodingInstructions: false, forceForPlugin: false })
   })
 
   it('falls back to the filename when name is absent and keeps the whole body', () => {
-    expect(parseStyle('Just a persona.', 'concise')).toEqual({ name: 'concise', description: '', body: 'Just a persona.', keepCodingInstructions: false })
+    expect(parseStyle('Just a persona.', 'concise')).toEqual({ name: 'concise', description: '', body: 'Just a persona.', keepCodingInstructions: false, forceForPlugin: false })
   })
 
   it('reads keep-coding-instructions true from frontmatter', () => {
@@ -33,13 +33,13 @@ describe('parseStyle', () => {
 
   it('parses CRLF frontmatter (Windows-authored files)', () => {
     const md = '---\r\nname: Terse\r\ndescription: Few words\r\n---\r\nBe terse.\r\n'
-    expect(parseStyle(md, 'fallback')).toEqual({ name: 'Terse', description: 'Few words', body: 'Be terse.', keepCodingInstructions: false })
+    expect(parseStyle(md, 'fallback')).toEqual({ name: 'Terse', description: 'Few words', body: 'Be terse.', keepCodingInstructions: false, forceForPlugin: false })
   })
 })
 
 describe('applyStyle', () => {
   const prompt = `You are a coding agent.\nGuidelines here.\n${CODING_BASE_MARKER}\n\n<project_context>CLAUDE.md content</project_context>\n\nCurrent working directory: /p\n\n## Global Rules\nrules here`
-  const style = { name: 'Writer', description: '', body: 'You are a writing assistant.', keepCodingInstructions: false }
+  const style = { name: 'Writer', description: '', body: 'You are a writing assistant.', keepCodingInstructions: false, forceForPlugin: false }
 
   it('replaces the coding instructions and keeps everything after the marker', () => {
     const applied = applyStyle(prompt, style)
@@ -51,7 +51,7 @@ describe('applyStyle', () => {
   })
 
   it('appends instead when the style keeps the coding instructions', () => {
-    const applied = applyStyle(prompt, { ...style, keepCodingInstructions: true })
+    const applied = applyStyle(prompt, { ...style, keepCodingInstructions: true, forceForPlugin: false })
     expect(applied).toContain('You are a coding agent.')
     expect(applied.endsWith('## Output Style: Writer\n\nYou are a writing assistant.')).toBe(true)
   })
@@ -144,7 +144,8 @@ describe('builtin styles', () => {
   it('ships Explanatory, Learning and Proactive as lowest-precedence styles', () => {
     const styles = loadStyles([BUILTIN_STYLES_DIR])
     const names = styles.map((style) => style.name).sort()
-    expect(names).toEqual(['Explanatory', 'Learning', 'Proactive'])
+    // Claude's built-ins include Concise (v2.1.237+).
+    expect(names).toEqual(['Concise', 'Explanatory', 'Learning', 'Proactive'])
     // Claude's built-ins are coding styles: they keep the software engineering instructions.
     expect(styles.every((style) => style.keepCodingInstructions)).toBe(true)
   })
@@ -178,8 +179,8 @@ describe('readActiveStyleName', () => {
 
 describe('styleForName', () => {
   const styles = [
-    { name: 'a', description: '', body: 'A', keepCodingInstructions: false },
-    { name: 'b', description: '', body: 'B', keepCodingInstructions: false },
+    { name: 'a', description: '', body: 'A', keepCodingInstructions: false, forceForPlugin: false },
+    { name: 'b', description: '', body: 'B', keepCodingInstructions: false, forceForPlugin: false },
   ]
 
   it('finds the matching style, or nothing for an unknown/undefined name', () => {
@@ -336,5 +337,28 @@ describe('extension wiring', () => {
     const cwd = projectWithStyle('Evil', 'Injected instructions.')
     const result = await wireSession({ cwd, hasUI: true, isProjectTrusted: () => true, ui: { notify: () => {}, confirm: async () => false } })
     expect(result).toBeUndefined()
+  })
+})
+
+describe('force-for-plugin and managed outputStyle', () => {
+  it('parses force-for-plugin frontmatter', () => {
+    const style = parseStyle('---\nname: Corp\ndescription: c\nforce-for-plugin: true\n---\nBody', 'x')
+    expect(style.forceForPlugin).toBe(true)
+  })
+
+  it('applies the first loaded forced plugin style over the outputStyle setting', async () => {
+    // Claude: "apply this style automatically whenever the plugin is enabled...
+    // Overrides the user's outputStyle setting. If multiple enabled plugins set
+    // this, Claude Code uses the first one loaded."
+    const { forcedPluginStyle } = await import('../extensions/output-styles.ts')
+    const styles = [parseStyle('---\nname: Normal\ndescription: n\n---\nBody', 'n'), parseStyle('---\nname: First\ndescription: f\nforce-for-plugin: true\n---\nBody', 'f'), parseStyle('---\nname: Second\ndescription: s\nforce-for-plugin: true\n---\nBody', 's')]
+    expect(forcedPluginStyle(styles)?.name).toBe('First')
+  })
+
+  it('lets a managed-settings outputStyle win over every settings file', () => {
+    const dir = tempDir()
+    const user = join(dir, 'user.json')
+    writeFileSync(user, JSON.stringify({ outputStyle: 'Explanatory' }))
+    expect(readActiveStyleName([user], { outputStyle: 'Learning' })).toBe('Learning')
   })
 })

--- a/tests/path-rules.test.ts
+++ b/tests/path-rules.test.ts
@@ -137,3 +137,12 @@ describe('bracket expressions', () => {
     expect(pathMatchesGlobs('photos [2024/x.png', ['photos \\[2024/**'])).toBe(true)
   })
 })
+
+describe('rule list budget', () => {
+  it('stops compiling past the shared 1000-pattern list budget', () => {
+    // Claude's rules share a list-level budget (~1000 patterns); entries past it
+    // are ignored rather than compiled without bound.
+    const globs = Array.from({ length: 1005 }, (_, i) => `dir${i}/*.ts`)
+    expect(compileGlobs(globs)).toHaveLength(1000)
+  })
+})


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #160); closes the styles/memory batch.

## Output styles (extensions/output-styles.ts, internal/builtin-styles/concise.md)
- The Concise built-in style ships (leads with the result, short by default, full detail on request, never shortens errors/security warnings/destructive-action confirmations), so `outputStyle: "Concise"` is no longer a silent no-op.
- `force-for-plugin` frontmatter parses and applies: the first loaded forced plugin style overrides the `outputStyle` setting.
- A managed-settings `outputStyle` wins over every settings file, per settings precedence.

## Memory (extensions/memory.ts)
- Index overflow follows the documented rule: a save landing near the read limit (within 10%) reminds Claude to shorten the index; over the limit the write still succeeds and an error tells Claude to rewrite MEMORY.md (previously the save was refused).
- Managed policy settings win over the chain for `autoMemoryEnabled`/`autoMemoryDirectory`.
- The memory tool's description names Claude's documented `type` vocabulary (user/feedback/project/reference).
- `/memory` lists every documented location including `CLAUDE.local.md` and the `.claude/CLAUDE.md` alternate, for files that do not exist yet too.

## Limits (internal/path-rules.ts, context-imports.ts)
- Rule pattern lists share Claude's ~1000-pattern budget; entries past it are ignored rather than compiled without bound.
- Context files (user CLAUDE.md, CLAUDE.local.md, the project alternate) over 4 MiB are skipped instead of loaded, per "loads a CLAUDE.md file of up to 4 MiB in full and skips a larger file".

Docs: `docs/memory.md` and `docs/output-styles.md` updated (including the stale overflow sentence).

Every change is covered by a test that failed before it (11 red tests).