### PR TITLE
Align statusline payload, child env, and managed drop-ins with Claude docs

### DIFF
--- a/docs/settings-env.md
+++ b/docs/settings-env.md
@@ -2,6 +2,6 @@
 
 Exports `env` blocks from settings into the session. Source: [`extensions/env-settings.ts`](../extensions/env-settings.ts).
 
-- Reads `managed-settings.json`, `~/.claude/settings.json`, and the project `.claude/settings.json`/`settings.local.json`, per-key with Claude's settings precedence: managed > project (with `settings.local.json` overlaying `settings.json`) > user.
+- Reads `managed-settings.json` (plus `managed-settings.d/*.json` drop-ins, merged alphabetically after the base file with Claude's rules: single values replace, lists union, nested blocks merge), `~/.claude/settings.json`, and the project `.claude/settings.json`/`settings.local.json`, per-key with Claude's settings precedence: managed > project (with `settings.local.json` overlaying `settings.json`) > user.
 - A settings value replaces a value inherited from the shell, as Claude documents, and an empty string is the documented override for an export that cannot be unset; when a later session no longer defines a key, the shell's original value is restored.
 - The project scope is approval-gated (a repo's env can redirect providers), and the keys a checked-out repository must not control (`CLAUDE_CONFIG_DIR`, `HOME`, the TMP family, `XDG_*`, content-exporting telemetry variables, start/sync variables, and pi's own `PI_CODING_AGENT_DIR`) are dropped from project and local settings with a warning; set those in the shell, user settings, or managed settings instead.

--- a/docs/statusline.md
+++ b/docs/statusline.md
@@ -2,6 +2,7 @@
 
 Runs a configured Claude `statusLine` command. Source: [`extensions/status-line.ts`](../extensions/status-line.ts).
 
-- The stdin JSON follows Claude's contract: `version`, `hook_event_name`, `session_name`, a `cost` block with wall and API durations and lines added/removed, a `context_window` token breakdown, `exceeds_200k_tokens`, and `rate_limits` carrying the `five_hour`/`seven_day` utilization and reset from the provider's rate-limit headers.
+- The stdin JSON follows Claude's contract: `version`, `hook_event_name`, `session_name`, a `cost` block with wall and API durations and lines added/removed, a `context_window` token breakdown, `exceeds_200k_tokens`, `workspace.added_dirs` (always empty: pi has no /add-dir), `effort` in Claude's vocabulary (pi's `minimal` maps to `low`, `off` omits it), and `rate_limits` carrying the `five_hour`/`seven_day` utilization with `resets_at` as Unix epoch seconds; an expired window is dropped rather than left stale. `fast_mode`, `prompt_cache`, and `spend_limit` have no pi source and stay absent.
+- Scripts run with `CLAUDECODE=1`, `CLAUDE_CODE_CHILD_SESSION=1`, and `COLUMNS`/`LINES` set to the terminal dimensions.
 - `padding` and `refreshInterval` are honored, with a 300ms debounce.
 - Without a configured command, a built-in statusline shows turn state and session cost.

--- a/extensions/hooks/runners.ts
+++ b/extensions/hooks/runners.ts
@@ -99,8 +99,14 @@ export const runHookCommand: HookCommandRunner = (command, payload, timeoutMs, p
     // the descendants too. CLAUDE_PROJECT_DIR is Claude's documented way for a hook to
     // reference project files regardless of the shell's cwd. CLAUDECODE=1 marks every
     // subprocess Claude spawns, so it is set on the child unconditionally.
-    const env: NodeJS.ProcessEnv = { ...process.env, CLAUDECODE: '1' }
+    // CLAUDE_CODE_CHILD_SESSION marks per-call children (hook and status line
+    // commands), never long-lived stdio MCP servers, as Claude documents; COLUMNS
+    // and LINES carry the terminal dimensions since the script's own width
+    // detection cannot see the captured terminal.
+    const env: NodeJS.ProcessEnv = { ...process.env, CLAUDECODE: '1', CLAUDE_CODE_CHILD_SESSION: '1' }
     if (projectDir) env.CLAUDE_PROJECT_DIR = projectDir
+    if (process.stdout.columns) env.COLUMNS = String(process.stdout.columns)
+    if (process.stdout.rows) env.LINES = String(process.stdout.rows)
     // An exec-form hook (an `args` array) spawns the executable directly with those args
     // and no shell, so shell metacharacters in the args arrive literally; $ARGUMENTS in
     // each arg is replaced with the event JSON by a replacer function (so $$/$& in the

--- a/extensions/internal/managed-settings.ts
+++ b/extensions/internal/managed-settings.ts
@@ -71,7 +71,7 @@ export function readManagedSettings(file: string = managedSettingsFileOverride ?
   } catch {
     return merged
   }
-  for (const entry of entries.filter((name) => name.endsWith('.json') && !name.startsWith('.')).sort()) {
+  for (const entry of entries.filter((name) => name.endsWith('.json') && !name.startsWith('.')).sort((a, b) => a.localeCompare(b, 'en'))) {
     merged = mergeManagedKey(merged, readOneSettingsFile(path.join(dropInDir, entry))) as Record<string, unknown>
   }
   return merged

--- a/extensions/internal/managed-settings.ts
+++ b/extensions/internal/managed-settings.ts
@@ -10,6 +10,7 @@
  */
 
 import * as fs from 'node:fs'
+import * as path from 'node:path'
 
 /** The OS managed-settings.json path Claude Code documents per platform. */
 export function managedSettingsPath(platform: NodeJS.Platform = process.platform): string {
@@ -31,8 +32,7 @@ export function managedSettingsFile(): string {
   return managedSettingsFileOverride ?? managedSettingsPath()
 }
 
-/** The parsed managed settings object, or {} when absent or malformed. */
-export function readManagedSettings(file: string = managedSettingsFileOverride ?? managedSettingsPath()): Record<string, unknown> {
+function readOneSettingsFile(file: string): Record<string, unknown> {
   try {
     const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'))
     if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as Record<string, unknown>
@@ -40,4 +40,39 @@ export function readManagedSettings(file: string = managedSettingsFileOverride ?
     // No managed policy on this machine.
   }
   return {}
+}
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/** Claude's managed-settings.d merge rules: a later single value replaces, lists
+ * combine with duplicates removed, and nested blocks merge key by key with each
+ * key following these same rules. */
+function mergeManagedKey(base: unknown, next: unknown): unknown {
+  if (Array.isArray(base) && Array.isArray(next)) return [...new Set([...base, ...next])]
+  if (isRecordValue(base) && isRecordValue(next)) {
+    const merged: Record<string, unknown> = { ...base }
+    for (const [key, value] of Object.entries(next)) merged[key] = key in merged ? mergeManagedKey(merged[key], value) : value
+    return merged
+  }
+  return next
+}
+
+/** The parsed managed settings object, or {} when absent or malformed. Claude also
+ * merges an optional managed-settings.d/ directory next to the file: every *.json
+ * in alphabetical order after the base file, hidden files and non-json ignored. */
+export function readManagedSettings(file: string = managedSettingsFileOverride ?? managedSettingsPath()): Record<string, unknown> {
+  let merged = readOneSettingsFile(file)
+  const dropInDir = path.join(path.dirname(file), 'managed-settings.d')
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(dropInDir)
+  } catch {
+    return merged
+  }
+  for (const entry of entries.filter((name) => name.endsWith('.json') && !name.startsWith('.')).sort()) {
+    merged = mergeManagedKey(merged, readOneSettingsFile(path.join(dropInDir, entry))) as Record<string, unknown>
+  }
+  return merged
 }

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -184,7 +184,9 @@ function helperEnv(name: string, config: HttpServerConfig): NodeJS.ProcessEnv {
  * env block, and Claude's path variables (CLAUDE_PROJECT_DIR, and CLAUDE_PLUGIN_ROOT
  * for a plugin's server). */
 function stdioEnv(config: StdioServerConfig, fill: (value: string) => string, session?: SessionDirs): Record<string, string> {
-  const env: Record<string, string> = { ...getDefaultEnvironment() }
+  // CLAUDECODE marks every subprocess; the long-lived server deliberately gets no
+  // CLAUDE_CODE_CHILD_SESSION, which Claude reserves for per-call children.
+  const env: Record<string, string> = { ...getDefaultEnvironment(), CLAUDECODE: '1' }
   for (const [key, value] of Object.entries(config.env ?? {})) env[key] = fill(value)
   if (session) env.CLAUDE_PROJECT_DIR = session.projectDir
   if (config.pluginRoot !== undefined) env.CLAUDE_PLUGIN_ROOT = config.pluginRoot

--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -66,7 +66,8 @@ function formatCost(cost: number): string {
 
 interface RateLimitWindow {
   used_percentage: number
-  resets_at?: string
+  /** Unix epoch seconds when the window resets, per Claude's documented field. */
+  resets_at?: number
 }
 interface RateLimitSnapshot {
   five_hour?: RateLimitWindow
@@ -109,8 +110,24 @@ function readRateLimitWindow(headers: Record<string, string>, prefix: string): R
   // the computed value negative); clamp so the payload never carries a nonsense percentage.
   const window: RateLimitWindow = { used_percentage: Math.max(0, Math.min(100, usedPercentage)) }
   const resetsAt = headers[`${base}-reset`] ?? headers[`${base}-resets-at`]
-  if (resetsAt) window.resets_at = resetsAt
+  if (resetsAt) {
+    // Claude documents resets_at as Unix epoch seconds; the header carries an ISO
+    // timestamp (or, from some providers, a bare epoch number already).
+    const epoch = /^\d+$/.test(resetsAt.trim()) ? Number(resetsAt.trim()) : Math.floor(Date.parse(resetsAt) / 1000)
+    if (Number.isFinite(epoch)) window.resets_at = epoch
+  }
   return window
+}
+
+/** The snapshot with expired windows dropped, so a window whose reset time has
+ * passed never lingers in the payload; undefined when nothing remains. */
+function liveRateLimits(snapshot: RateLimitSnapshot): RateLimitSnapshot | undefined {
+  const nowSeconds = Date.now() / 1000
+  const keep = (window?: RateLimitWindow): RateLimitWindow | undefined => (window && (window.resets_at === undefined || window.resets_at > nowSeconds) ? window : undefined)
+  const fiveHour = keep(snapshot.five_hour)
+  const sevenDay = keep(snapshot.seven_day)
+  if (!fiveHour && !sevenDay) return undefined
+  return { ...(fiveHour ? { five_hour: fiveHour } : {}), ...(sevenDay ? { seven_day: sevenDay } : {}) }
 }
 
 /** The five-hour and seven-day utilization windows Claude's statusline reports,
@@ -216,7 +233,9 @@ export default function statusLine(pi: ExtensionAPI) {
       session_id: ctx.sessionManager.getSessionId(),
       cwd: ctx.cwd,
       version: PACKAGE_VERSION,
-      workspace: { current_dir: ctx.cwd, project_dir: ctx.cwd },
+      // added_dirs is always empty: pi has no /add-dir; the field stays present
+      // because Claude documents "Empty array if none have been added".
+      workspace: { current_dir: ctx.cwd, project_dir: ctx.cwd, added_dirs: [] },
       // Both fields, per Claude's documented contract: published statusline scripts
       // read .model.display_name and render the literal "null" when it is missing.
       model: { id: model?.id ?? '', display_name: model?.name ?? model?.id ?? '' },
@@ -255,13 +274,19 @@ export default function statusLine(pi: ExtensionAPI) {
     const sessionName = ctx.sessionManager.getSessionName?.()
     if (sessionName) payload.session_name = sessionName
     if (ctx.thinkingLevel) {
-      payload.effort = { level: ctx.thinkingLevel }
+      // pi's off/minimal are outside Claude's effort vocabulary: minimal maps to
+      // low, and off omits effort entirely (thinking disabled says the rest).
       payload.thinking = { enabled: ctx.thinkingLevel !== 'off' }
+      if (ctx.thinkingLevel !== 'off') payload.effort = { level: ctx.thinkingLevel === 'minimal' ? 'low' : ctx.thinkingLevel }
     }
     if (styleName) payload.output_style = { name: styleName }
     // The current utilization of the account's rate-limit windows, when the
-    // provider reported them; omitted entirely until a response has carried them.
-    if (rateLimits) payload.rate_limits = rateLimits
+    // provider reported them; omitted until a response has carried them, and an
+    // expired window is dropped rather than left stale.
+    if (rateLimits) {
+      const live = liveRateLimits(rateLimits)
+      if (live) payload.rate_limits = live
+    }
     return payload
   }
 

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -1472,3 +1472,25 @@ describe('context file size limit', () => {
     expect(result?.systemPrompt ?? 'BASE').not.toContain('HUGE START')
   })
 })
+
+describe('managed-settings.d drop-ins', () => {
+  it('merges managed-settings.d/*.json after the base file, alphabetically, with the documented rules', async () => {
+    // Claude merges managed-settings.json first, then every *.json in the
+    // directory alphabetically: single values replace, lists union with
+    // duplicates removed, nested blocks merge key by key; hidden files and
+    // non-json files are ignored.
+    const dir = tempDir()
+    const file = join(dir, 'managed-settings.json')
+    writeFileSync(file, JSON.stringify({ model: 'sonnet', permissions: { deny: ['Bash(rm *)'] }, env: { A: '1' } }))
+    mkdirSync(join(dir, 'managed-settings.d'))
+    writeFileSync(join(dir, 'managed-settings.d', '20-later.json'), JSON.stringify({ model: 'haiku', env: { C: '3' } }))
+    writeFileSync(join(dir, 'managed-settings.d', '10-early.json'), JSON.stringify({ model: 'opus', permissions: { deny: ['Bash(rm *)', 'WebFetch'] }, env: { B: '2' } }))
+    writeFileSync(join(dir, 'managed-settings.d', '.hidden.json'), JSON.stringify({ model: 'ignored' }))
+    writeFileSync(join(dir, 'managed-settings.d', 'notes.txt'), 'not json')
+
+    const merged = readManagedSettings(file)
+    expect(merged.model).toBe('haiku')
+    expect((merged.permissions as { deny: string[] }).deny).toEqual(['Bash(rm *)', 'WebFetch'])
+    expect(merged.env).toEqual({ A: '1', B: '2', C: '3' })
+  })
+})

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -220,8 +220,12 @@ describe('runHookCommand process wiring', () => {
     expect(record.args).toEqual(['-c', 'guard.sh'])
     // `detached` is what makes the shell a process-group leader, so a timeout can kill
     // the grandchildren a compound command forks. Claude marks every subprocess it
-    // spawns with CLAUDECODE=1, so the child env inherits the parent's plus that flag.
-    expect(record.options).toEqual({ stdio: ['pipe', 'pipe', 'pipe'], detached: true, env: { ...process.env, CLAUDECODE: '1' } })
+    // spawns with CLAUDECODE=1 and per-call children with CLAUDE_CODE_CHILD_SESSION=1;
+    // COLUMNS/LINES ride along only when the parent terminal reports dimensions.
+    const expectedEnv: NodeJS.ProcessEnv = { ...process.env, CLAUDECODE: '1', CLAUDE_CODE_CHILD_SESSION: '1' }
+    if (process.stdout.columns) expectedEnv.COLUMNS = String(process.stdout.columns)
+    if (process.stdout.rows) expectedEnv.LINES = String(process.stdout.rows)
+    expect(record.options).toEqual({ stdio: ['pipe', 'pipe', 'pipe'], detached: true, env: expectedEnv })
   })
 
   it('marks the hook child with CLAUDECODE=1 even when the parent env lacks it', async () => {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -873,3 +873,23 @@ describe('hook stdout parsing rule', () => {
     expect(hookJsonError('{"note":1}\n{"note":2}')).toBeUndefined()
   })
 })
+
+describe('hook command child environment', () => {
+  it('marks hook commands with CLAUDE_CODE_CHILD_SESSION and passes terminal dimensions', async () => {
+    // Claude sets CLAUDE_CODE_CHILD_SESSION=1 in hook and status line commands
+    // (not stdio MCP servers), and COLUMNS/LINES to the terminal dimensions.
+    const savedColumns = Object.getOwnPropertyDescriptor(process.stdout, 'columns')
+    const savedRows = Object.getOwnPropertyDescriptor(process.stdout, 'rows')
+    Object.defineProperty(process.stdout, 'columns', { value: 121, configurable: true })
+    Object.defineProperty(process.stdout, 'rows', { value: 43, configurable: true })
+    try {
+      const result = await runHookCommand('echo "$CLAUDE_CODE_CHILD_SESSION:$COLUMNS:$LINES"', {}, 5000)
+      expect(result.stdout.trim()).toBe('1:121:43')
+    } finally {
+      if (savedColumns) Object.defineProperty(process.stdout, 'columns', savedColumns)
+      else delete (process.stdout as unknown as Record<string, unknown>).columns
+      if (savedRows) Object.defineProperty(process.stdout, 'rows', savedRows)
+      else delete (process.stdout as unknown as Record<string, unknown>).rows
+    }
+  })
+})

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -882,6 +882,10 @@ describe('hook command child environment', () => {
     const savedRows = Object.getOwnPropertyDescriptor(process.stdout, 'rows')
     Object.defineProperty(process.stdout, 'columns', { value: 121, configurable: true })
     Object.defineProperty(process.stdout, 'rows', { value: 43, configurable: true })
+    // Hermetic: pi-code itself may run under Claude Code, whose parent env already
+    // carries the marker; clear it to prove runHookCommand sets it.
+    const savedChild = process.env.CLAUDE_CODE_CHILD_SESSION
+    delete process.env.CLAUDE_CODE_CHILD_SESSION
     try {
       const result = await runHookCommand('echo "$CLAUDE_CODE_CHILD_SESSION:$COLUMNS:$LINES"', {}, 5000)
       expect(result.stdout.trim()).toBe('1:121:43')
@@ -890,6 +894,8 @@ describe('hook command child environment', () => {
       else delete (process.stdout as unknown as Record<string, unknown>).columns
       if (savedRows) Object.defineProperty(process.stdout, 'rows', savedRows)
       else delete (process.stdout as unknown as Record<string, unknown>).rows
+      if (savedChild === undefined) delete process.env.CLAUDE_CODE_CHILD_SESSION
+      else process.env.CLAUDE_CODE_CHILD_SESSION = savedChild
     }
   })
 })

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2248,6 +2248,10 @@ describe('mcp stdio session context', () => {
     // The harness cwd has no repo markers, so the project root falls back to cwd.
     const env = hoisted.transports[0].options.env as Record<string, string>
     expect(env.CLAUDE_PROJECT_DIR).toBe(harness.cwd)
+    // Claude sets CLAUDECODE=1 in stdio MCP server subprocesses; the long-lived
+    // server never gets CLAUDE_CODE_CHILD_SESSION, which marks per-call children.
+    expect(env.CLAUDECODE).toBe('1')
+    expect(env.CLAUDE_CODE_CHILD_SESSION).toBeUndefined()
     // A plugin-provided stdio server also gets CLAUDE_PLUGIN_ROOT, which Claude
     // exports to MCP server subprocesses.
     const pluggedEnv = hoisted.transports[1].options.env as Record<string, string>

--- a/tests/status-line-command.test.ts
+++ b/tests/status-line-command.test.ts
@@ -346,6 +346,9 @@ describe('statusLine rate limits', () => {
     hoisted.result = { code: 0, stdout: 'x', stderr: '', timedOut: false }
     const { handlers, ctx } = setup(cwd)
     vi.useFakeTimers()
+    // The header timestamps must be in the future of the (frozen) clock, or the
+    // expiry rule below would rightly drop them.
+    vi.setSystemTime(new Date('2026-08-16T00:00:00Z'))
     await handlers.get('session_start')?.({}, ctx)
     await vi.advanceTimersByTimeAsync(400)
     await handlers.get('after_provider_response')?.(
@@ -365,9 +368,10 @@ describe('statusLine rate limits', () => {
     await vi.advanceTimersByTimeAsync(400)
 
     const payload = hoisted.runs.at(-1)?.payload as Record<string, unknown>
+    // Claude documents resets_at as Unix epoch seconds, not the raw header string.
     expect(payload.rate_limits).toEqual({
-      five_hour: { used_percentage: 35.5, resets_at: '2026-08-16T12:00:00Z' },
-      seven_day: { used_percentage: 12, resets_at: '2026-08-22T00:00:00Z' },
+      five_hour: { used_percentage: 35.5, resets_at: Date.parse('2026-08-16T12:00:00Z') / 1000 },
+      seven_day: { used_percentage: 12, resets_at: Date.parse('2026-08-22T00:00:00Z') / 1000 },
     })
   })
 
@@ -562,5 +566,70 @@ describe('statusLine settings caching', () => {
     await handlers.get('turn_end')?.({}, ctx)
     await vi.advanceTimersByTimeAsync(400)
     expect(styleOf(hoisted.runs.at(-1))).toBe('Terse')
+  })
+})
+
+describe('statusLine payload and expiry conformance', () => {
+  it('drops a rate-limit window whose resets_at has passed instead of leaving it stale', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'x', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-16T11:00:00Z'))
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    await handlers.get('after_provider_response')?.(
+      {
+        type: 'after_provider_response',
+        status: 200,
+        headers: {
+          'anthropic-ratelimit-unified-5h-utilization': '35.5',
+          'anthropic-ratelimit-unified-5h-reset': '2026-08-16T12:00:00Z',
+        },
+      },
+      ctx,
+    )
+    await vi.advanceTimersByTimeAsync(400)
+
+    // Two hours later the window has reset; the next payload must not carry it.
+    vi.setSystemTime(new Date('2026-08-16T13:00:00Z'))
+    hoisted.runs.length = 0
+    await handlers.get('turn_end')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+
+    const payload = hoisted.runs.at(-1)?.payload as Record<string, unknown>
+    expect(payload.rate_limits).toBeUndefined()
+  })
+
+  it('reports workspace.added_dirs as an empty array and maps pi effort levels onto the documented vocabulary', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'x', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    ;(ctx as { thinkingLevel: string }).thinkingLevel = 'minimal'
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+
+    const payload = hoisted.runs.at(-1)?.payload as Record<string, unknown>
+    expect((payload.workspace as { added_dirs?: unknown }).added_dirs).toEqual([])
+    // pi's 'minimal' is off-contract; Claude's vocabulary starts at 'low'.
+    expect((payload.effort as { level: string }).level).toBe('low')
+  })
+
+  it('omits effort and reports thinking disabled when the level is off', async () => {
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    hoisted.result = { code: 0, stdout: 'x', stderr: '', timedOut: false }
+    const { handlers, ctx } = setup(cwd)
+    ;(ctx as { thinkingLevel: string }).thinkingLevel = 'off'
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+
+    const payload = hoisted.runs.at(-1)?.payload as Record<string, unknown>
+    expect(payload.effort).toBeUndefined()
+    expect((payload.thinking as { enabled: boolean }).enabled).toBe(false)
   })
 })


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #162); the mechanical half of the statusline/settings batch.

## Statusline payload (extensions/status-line.ts)
- `rate_limits.*.resets_at` is now Unix epoch seconds per the documented field (converted from the header's ISO timestamp; a bare epoch number passes through), and a window whose reset time has passed is dropped from the payload instead of lingering stale.
- `workspace.added_dirs` is present as the documented empty array (pi has no /add-dir).
- `effort.level` speaks Claude's vocabulary: pi's `minimal` maps to `low`, and `off` omits `effort` entirely with `thinking.enabled: false` carrying the state. `fast_mode`/`prompt_cache`/`spend_limit` have no pi source and stay absent (documented).

## Child process environment (hooks/runners.ts, mcp/transport.ts)
- Hook and statusline commands run with `CLAUDE_CODE_CHILD_SESSION=1` and `COLUMNS`/`LINES` set to the terminal dimensions, per the statusline sizing contract.
- Stdio MCP server subprocesses get `CLAUDECODE=1`; deliberately no `CLAUDE_CODE_CHILD_SESSION`, which Claude reserves for per-call children.

## Managed settings drop-ins (internal/managed-settings.ts)
- `managed-settings.d/*.json` next to the managed settings file merges after it, alphabetically, with Claude's rules: single values replace, lists union with duplicates removed, nested blocks merge key by key; hidden and non-json files are ignored. Every managed-settings consumer (hooks, MCP policy, styles, memory, env) picks this up through the shared reader.

Docs: `docs/statusline.md` and `docs/settings-env.md` updated.

All changes covered by tests that failed before the change (6 red tests), plus a mutation check on the stdio `CLAUDECODE` assertion that rode an existing green test (mutant caught).