### PR TITLE
Align command precedence, naming, and listing with Claude docs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,8 +4,8 @@ Registers `.claude/commands/**/*.md` as slash commands with Claude's command con
 
 ## Naming and arguments
 
-- Commands load from every `.claude/commands` between the working directory and the repository root, the nearest winning a name clash. Subdirectory commands register as `/dir:name` (`frontend/build.md` is `/frontend:build`); current Claude docs name a command by file name alone, so the qualified form is a pi-code divergence.
-- `$ARGUMENTS` (with the `ARGUMENTS:` append when unused), 0-based `$ARGUMENTS[N]`/`$N`, named `arguments:` frontmatter.
+- Commands load from every project `.claude/commands` between the working directory and the repository root, then the personal `~/.claude/commands`, then the enterprise directory beside the managed settings file; per Claude, enterprise overrides personal and personal overrides project. A command is named by its file name alone (subdirectories only organize the files).
+- `$ARGUMENTS` (the `ARGUMENTS:` append fires only when no placeholder received an argument), 0-based `$ARGUMENTS[N]`/`$N`, named `arguments:` frontmatter. The model-facing listing always keeps every command name; over budget only descriptions are shed.
 - `${CLAUDE_SESSION_ID}`, `${CLAUDE_EFFORT}`, `${CLAUDE_SKILL_DIR}`, `${CLAUDE_PROJECT_DIR}` in bodies and `allowed-tools` rules.
 
 ## Dynamic content

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -5,8 +5,8 @@
  * handing `.claude/commands` to pi's prompt-template loader. Owning registration
  * is what makes the rest of Claude's command contract reachable: `$ARGUMENTS` and
  * positional substitution, `` !`cmd` `` bash output, `@file` inlining, subdirectory
- * commands (registered as `/frontend:build`; current Claude docs name a command by
- * file name alone, so the qualified form is a pi-code divergence), and the
+ * commands (named by file name alone, as Claude documents; subdirectories only
+ * organize the files), and the
  * `allowed-tools`, `argument-hint` and `model` frontmatter (`model` switches the
  * session model for the command's run via `pi.setModel`, restored on agent_end).
  * `shell: powershell` runs a command's injected spans through PowerShell when a
@@ -47,7 +47,7 @@ import { Type } from 'typebox'
 import { matchesBashRules } from './internal/bash-rules.js'
 import { type CommandExec, type DiscoveredCommand, discoverCommandFiles, expandDynamicContent, type ParsedCommand, parseCommandFile, resolvePowershellBinary, spanExec, substituteArgsDetailed, substituteVars } from './internal/command-file.js'
 import { claudeConfigDir } from './internal/config-dir.js'
-import { readManagedSettings } from './internal/managed-settings.js'
+import { managedSettingsFile, readManagedSettings } from './internal/managed-settings.js'
 import { capForContext } from './internal/output-guard.js'
 import { matchesPathRules } from './internal/path-rules.js'
 import { type InstalledPlugin, installedPlugins } from './internal/plugins.js'
@@ -115,15 +115,18 @@ function isDirectory(target: string): boolean {
   }
 }
 
-/** Existing `.claude/commands` directories, user first then project. The project
- * directory is the nearest at or above cwd (bounded at the repository root, matching
- * the approval walk) and is included only for approved projects. */
+/** Existing `.claude/commands` directories in Claude's precedence order (later
+ * directories win in collectCommands): project first, then personal, then the
+ * enterprise directory beside the managed settings file, per "enterprise
+ * overrides personal, and personal overrides project". The project directories
+ * are included only for approved projects. */
 export function commandDirs(cwd: string, home: string, trusted: boolean): string[] {
-  const candidates = [path.join(claudeConfigDir(home), 'commands')]
+  const candidates: string[] = []
   // Claude scans every .claude/commands between cwd and the repository root, the
-  // nearest winning a name clash: collectCommands lets later directories win, so
-  // the project list goes root-first with the nearest last.
+  // nearest winning an intra-project name clash: root-first with the nearest last.
   if (trusted) candidates.push(...ancestorDirs(cwd, path.join('.claude', 'commands')).reverse())
+  candidates.push(path.join(claudeConfigDir(home), 'commands'))
+  candidates.push(path.join(path.dirname(managedSettingsFile()), '.claude', 'commands'))
   const dirs: string[] = []
   for (const dir of candidates) {
     if (!dirs.includes(dir) && isDirectory(dir)) dirs.push(dir)
@@ -270,23 +273,22 @@ export function slashCommandBudget(contextWindow: number | undefined, env: Recor
 /** The slash_command tool description: usage framing plus the budgeted command
  * list, each entry `/name - description (argument-hint)`. */
 export function slashCommandToolDescription(commands: SlashCommandEntry[], budget: number): string {
-  const lines: string[] = []
-  let used = 0
-  let omitted = 0
-  for (const command of commands) {
+  // Claude: "The listing always contains every skill name"; the budget shortens
+  // descriptions (later entries lose theirs first), never drops a name, so an
+  // omitted-but-invocable command can no longer contradict the listing.
+  const lines = commands.map((command) => `/${command.name}`)
+  let used = lines.reduce((total, line) => total + line.length + 1, 0)
+  for (const [index, command] of commands.entries()) {
     const hintSuffix = command.argumentHint ? ` (${command.argumentHint})` : ''
     // when_to_use is model-facing trigger text, appended after the description and before
     // the argument hint; it shares the per-entry cap and never reaches the user surface.
     const whenSuffix = command.whenToUse ? ` ${command.whenToUse}` : ''
     const entry = `/${command.name} - ${command.description}${whenSuffix}${hintSuffix}`.slice(0, ENTRY_CHAR_CAP)
-    if (used + entry.length + 1 > budget) {
-      omitted++
-      continue // a shorter later entry may still fit the remaining budget
-    }
-    used += entry.length + 1
-    lines.push(entry)
+    const growth = entry.length - lines[index].length
+    if (used + growth > budget) continue
+    used += growth
+    lines[index] = entry
   }
-  if (omitted > 0) lines.push(`(${omitted} more ${omitted === 1 ? 'command was' : 'commands were'} omitted: raise SLASH_COMMAND_TOOL_CHAR_BUDGET to list them)`)
   return ["Execute a custom slash command on the user's behalf. The command expands to instructions for you to follow in this conversation.", '', 'Available commands:', ...lines].join('\n')
 }
 

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -125,8 +125,7 @@ export function commandDirs(cwd: string, home: string, trusted: boolean): string
   // Claude scans every .claude/commands between cwd and the repository root, the
   // nearest winning an intra-project name clash: root-first with the nearest last.
   if (trusted) candidates.push(...ancestorDirs(cwd, path.join('.claude', 'commands')).reverse())
-  candidates.push(path.join(claudeConfigDir(home), 'commands'))
-  candidates.push(path.join(path.dirname(managedSettingsFile()), '.claude', 'commands'))
+  candidates.push(path.join(claudeConfigDir(home), 'commands'), path.join(path.dirname(managedSettingsFile()), '.claude', 'commands'))
   const dirs: string[] = []
   for (const dir of candidates) {
     if (!dirs.includes(dir) && isDirectory(dir)) dirs.push(dir)

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -394,9 +394,11 @@ export function substituteVars(text: string, vars: Record<string, string | undef
   return text.replaceAll(/\$\{(CLAUDE_[A-Z0-9_]+)\}/g, (token, name: string) => vars[name] ?? token)
 }
 
-/** `a/b/c.md` becomes Claude's `a:b:c`. */
+/** Claude: "You invoke a command file by its file name"; subdirectories organize
+ * files without namespacing, so `a/b/c.md` is `/c`. A same-name file in another
+ * subdirectory takes the name over (scan order decides), as with Claude. */
 export function commandNameFor(relativePath: string): string {
-  return relativePath.replace(/\.md$/, '').split(path.sep).join(':')
+  return path.basename(relativePath, '.md')
 }
 
 /** Every `*.md` under a commands directory, including nested ones. */

--- a/tests/command-parse.test.ts
+++ b/tests/command-parse.test.ts
@@ -388,7 +388,9 @@ describe('resolvePowershellBinary', () => {
 })
 
 describe('discoverCommandFiles', () => {
-  it('walks subdirectories and names them with Claude namespacing', () => {
+  it('walks subdirectories, naming each command by its file name alone', () => {
+    // Claude: "You invoke a command file by its file name"; subdirectories only
+    // organize the files.
     const root = tempDir()
     mkdirSync(join(root, 'frontend'), { recursive: true })
     writeFileSync(join(root, 'hello.md'), 'hi')
@@ -396,7 +398,7 @@ describe('discoverCommandFiles', () => {
 
     const found = discoverCommandFiles(root)
     const names = found.map((f) => f.name).sort()
-    expect(names).toEqual(['frontend:build', 'hello'])
+    expect(names).toEqual(['build', 'hello'])
   })
 
   it('returns nothing for a missing directory', () => {
@@ -406,7 +408,9 @@ describe('discoverCommandFiles', () => {
 
 describe('commandNameFor', () => {
   it('joins nested segments with colons and drops the extension', () => {
-    expect(commandNameFor('a/b/c.md')).toBe('a:b:c')
+    // Claude: "You invoke a command file by its file name"; subdirectories
+    // organize files without namespacing the name.
+    expect(commandNameFor('a/b/c.md')).toBe('c')
     expect(commandNameFor('top.md')).toBe('top')
   })
 })

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -83,13 +83,14 @@ describe('commandDirs', () => {
 })
 
 describe('collectCommands', () => {
-  it('lets a project command override a user command of the same name', () => {
+  it('lets a personal command win a name clash with a project command', () => {
+    // Claude: "personal overrides project".
     const cwd = tempDir()
     writeCommand(hoisted.home, 'ship.md', 'user version')
     writeCommand(cwd, 'ship.md', 'project version')
     const found = collectCommands(commandDirs(cwd, hoisted.home, true))
     expect(found).toHaveLength(1)
-    expect(found[0].filePath).toContain(cwd)
+    expect(found[0].filePath).toContain(hoisted.home)
   })
 })
 
@@ -183,16 +184,16 @@ const setup = (cwd: string, trusted = true) => {
 }
 
 describe('commands extension', () => {
-  it('registers a nested command under its namespaced name and drives a turn with substituted args', async () => {
+  it('registers a nested command under its file name and drives a turn with substituted args', async () => {
     const cwd = tempDir()
     writeCommand(cwd, join('frontend', 'build.md'), '---\ndescription: Build it\nargument-hint: [target]\n---\nBuild $0 now.')
     const s = setup(cwd)
     await s.handlers.get('session_start')?.({}, s.ctx)
 
-    expect([...s.commands.keys()]).toEqual(['frontend:build'])
-    expect(s.commands.get('frontend:build')?.description).toBe('Build it [target]')
+    expect([...s.commands.keys()]).toEqual(['build'])
+    expect(s.commands.get('build')?.description).toBe('Build it [target]')
 
-    await s.commands.get('frontend:build')?.handler('web', s.ctx)
+    await s.commands.get('build')?.handler('web', s.ctx)
     expect(s.sent).toEqual(['Build web now.'])
   })
 
@@ -978,15 +979,15 @@ describe('slashCommandToolDescription', () => {
     expect(entry).toHaveLength(1536)
   })
 
-  it('drops entries past the overall budget and says so', () => {
+  it('keeps the name of an over-budget entry, shedding only its description', () => {
     const commands = [
       { name: 'a', description: 'first command' },
       { name: 'b', description: 'x'.repeat(300) },
     ]
     const text = slashCommandToolDescription(commands, 60)
     expect(text).toContain('/a - first command')
-    expect(text).not.toContain('/b')
-    expect(text).toContain('omitted')
+    expect(text.split('\n')).toContain('/b')
+    expect(text).not.toContain('omitted')
   })
 })
 
@@ -1183,5 +1184,68 @@ describe('disableSkillShellExecution', () => {
 
     expect(s.execCalls).toEqual([])
     expect(s.sent[0]).toBe(`status: ${SHELL_DISABLED_PLACEHOLDER}\n${SHELL_DISABLED_PLACEHOLDER}`)
+  })
+})
+
+describe('command precedence and naming conformance', () => {
+  it('lets a personal command override a project command of the same name', () => {
+    // Claude: across levels, enterprise overrides personal, and personal
+    // overrides project.
+    const cwd = tempDir()
+    mkdirSync(join(cwd, '.claude', 'commands'), { recursive: true })
+    writeFileSync(join(cwd, '.claude', 'commands', 'deploy.md'), 'PROJECT BODY')
+    mkdirSync(join(hoisted.home, '.claude', 'commands'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'commands', 'deploy.md'), 'PERSONAL BODY')
+
+    const commands = collectCommands(commandDirs(cwd, hoisted.home, true))
+    const deploy = commands.find((c) => c.name === 'deploy')
+    expect(deploy && readFileSync(deploy.filePath, 'utf-8')).toBe('PERSONAL BODY')
+  })
+
+  it('loads enterprise commands from the managed settings directory with top precedence', async () => {
+    const { setManagedSettingsPath } = await import('../extensions/internal/managed-settings.ts')
+    const managedDir = tempDir()
+    setManagedSettingsPath(join(managedDir, 'managed-settings.json'))
+    try {
+      mkdirSync(join(managedDir, '.claude', 'commands'), { recursive: true })
+      writeFileSync(join(managedDir, '.claude', 'commands', 'deploy.md'), 'ENTERPRISE BODY')
+      mkdirSync(join(hoisted.home, '.claude', 'commands'), { recursive: true })
+      writeFileSync(join(hoisted.home, '.claude', 'commands', 'deploy.md'), 'PERSONAL BODY')
+
+      const commands = collectCommands(commandDirs(tempDir(), hoisted.home, true))
+      const deploy = commands.find((c) => c.name === 'deploy')
+      expect(deploy && readFileSync(deploy.filePath, 'utf-8')).toBe('ENTERPRISE BODY')
+    } finally {
+      setManagedSettingsPath(undefined)
+    }
+  })
+
+  it('keeps every command name in the tool listing, shortening descriptions when over budget', () => {
+    // Claude: "The listing always contains every skill name"; the budget shortens
+    // descriptions, never drops names.
+    const commands = Array.from({ length: 20 }, (_, i) => ({ name: `cmd-${i}`, description: 'd'.repeat(200) }))
+    const text = slashCommandToolDescription(commands, 800)
+    for (let i = 0; i < 20; i++) expect(text).toContain(`/cmd-${i}`)
+    expect(text).not.toContain('omitted')
+  })
+})
+
+describe('ARGUMENTS append rule', () => {
+  it('appends the arguments only when no placeholder received one, per the documented rule', async () => {
+    // Claude: "When no placeholder receives an argument, Claude Code appends
+    // them as ARGUMENTS: <value>."
+    const cwd = tempDir()
+    writeCommand(cwd, 'named.md', '---\narguments: [issue]\n---\nFix $issue please.')
+    writeCommand(cwd, 'blind.md', 'Just do the thing.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    // A named placeholder consumed the argument: no append.
+    await s.commands.get('named')?.handler('123', s.ctx)
+    expect(s.sent.at(-1)).toBe('Fix 123 please.')
+
+    // Nothing consumed the argument: the append carries it.
+    await s.commands.get('blind')?.handler('456', s.ctx)
+    expect(s.sent.at(-1)).toBe('Just do the thing.\n\nARGUMENTS: 456')
   })
 })


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #166); the command half of the commands/skills batch.

## Precedence (extensions/commands.ts)
- Personal commands now override project commands of the same name, and enterprise commands (the `.claude/commands` directory beside the managed settings file) override personal, per "enterprise overrides personal, and personal overrides project". Previously project won.

## Naming (internal/command-file.ts)
- A command is named by its file name alone; subdirectories only organize files (`frontend/build.md` is `/build`, no longer `/frontend:build`). The header's claim that the qualified form was Claude's contract is corrected.

## Listing (commands.ts)
- The slash_command tool listing always keeps every command name; over budget only descriptions are shed (later entries lose theirs first), so an omitted-but-invocable command can no longer contradict the listing.

## Verified conforming
- The `ARGUMENTS:` append already follows "when no placeholder receives an argument" through the consumed-tracking added earlier; both sides are now pinned by a test (B6-F14 closes as verified).

Docs: `docs/commands.md` updated.

All changes covered by tests that failed before the change (4 red tests, plus the stale pins updated to the documented contracts).