### PR TITLE
Compare settings content instead of stats in the watcher

### DIFF
--- a/extensions/internal/settings-watch.ts
+++ b/extensions/internal/settings-watch.ts
@@ -7,20 +7,38 @@
 
 import * as fs from 'node:fs'
 
+// Captured at module load: the poll must run on real time even under a test's
+// fake timers (the stat watcher it replaced lived in libuv and was immune too);
+// otherwise fake-timer advances spin the poll and freeze real detection.
+const realSetInterval = globalThis.setInterval
+const realClearInterval = globalThis.clearInterval
+
+/** One file's content, or undefined when absent or unreadable. */
+function snapshot(file: string): string | undefined {
+  try {
+    return fs.readFileSync(file, 'utf-8')
+  } catch {
+    return undefined
+  }
+}
+
 /** Watch the given settings files, calling `reload` when any of them changes.
- * Returns a dispose function. The poll interval is env-tunable for tests. */
+ * Returns a dispose function. The poll compares content, not stats: a same-size
+ * rewrite within one timestamp tick is invisible to an mtime comparison on a
+ * coarse-granularity filesystem, which made detection flaky. Settings files are
+ * small, so re-reading them on the poll is negligible. The interval is
+ * env-tunable for tests. */
 export function watchSettingsFiles(files: string[], reload: () => void): () => void {
   const interval = Number(process.env.PI_CODE_SETTINGS_WATCH_INTERVAL_MS) || 2000
-  const listeners: Array<[string, (curr: fs.Stats, prev: fs.Stats) => void]> = []
-  for (const file of files) {
-    const listener = (curr: fs.Stats, prev: fs.Stats): void => {
-      if (curr.mtimeMs !== prev.mtimeMs || curr.size !== prev.size) reload()
+  let last = files.map(snapshot)
+  const timer = realSetInterval(() => {
+    const next = files.map(snapshot)
+    if (next.some((content, index) => content !== last[index])) {
+      last = next
+      reload()
     }
-    // persistent: false, so a watcher alone never keeps a one-shot run alive.
-    fs.watchFile(file, { interval, persistent: false }, listener)
-    listeners.push([file, listener])
-  }
-  return () => {
-    for (const [file, listener] of listeners) fs.unwatchFile(file, listener)
-  }
+  }, interval)
+  // A watcher alone must never keep a one-shot run alive.
+  timer.unref?.()
+  return () => realClearInterval(timer)
 }


### PR DESCRIPTION
The settings watcher compared mtime and size between polls. A rewrite that keeps the file size is invisible on a filesystem with coarse timestamp granularity, which made detection flaky in CI (the 1.0.37 release gate caught it on the bump PR).

The poll now compares file content directly: settings files are small, so re-reading them at the poll interval is negligible, and detection no longer depends on filesystem timestamp resolution. The poll runs on real timers captured at module load, like the libuv stat watcher it replaces, so fake-timer tests neither spin nor freeze it.