### PR TITLE
Align skills dispatch with Claude docs: fork, overrides, enterprise, carveouts

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,11 @@
 
 Bridges `.claude/skills` into pi's skill discovery. Source: [`extensions/skills.ts`](../extensions/skills.ts).
 
-- Project skills are gated on approval and load from every `.claude/skills` between the working directory and the repository root (nearest first); pi's loader reads `name`, `description`, and `disable-model-invocation` (`allowed-tools` is inert in pi's loader, a documented gap).
+- Skills load in Claude's precedence order: the enterprise directory beside the managed settings file, then personal `~/.claude/skills`, then (approval-gated) every project `.claude/skills` between the working directory and the repository root.
+- pi's loader reads `name`, `description`, and `disable-model-invocation`. Loader-side gaps, documented rather than hidden: other frontmatter fields (including `yes`/`on`/`1` boolean spellings) and the first-paragraph description fallback are pi-loader territory; a description-less skill may be dropped from the listing.
+- `context: fork` runs the skill in a subagent via the agent seam: the expanded content becomes the subagent's prompt (no conversation history), `agent:` picks a discovered agent type. Divergence: pi-code waits for the result in the invoking turn (Claude's `background: false` behavior, and what Claude itself does in `-p`/SDK runs) instead of backgrounding by default.
+- `skillOverrides`: a skill set to `"off"` refuses `/skill:name` with a notice; `"name-only"` listing visibility is pi-loader territory (noted gap).
 - Invoking `/skill:name` expands the body through the shared command pipeline, as Claude documents that commands and skills "work the same way": `` !`cmd` `` spans, `@file` references, `$ARGUMENTS`/positional substitution, and `${CLAUDE_*}` variables, with the same shell-execution gate commands use.
 - A skill with malformed frontmatter degrades to pi's plain expansion (raw body) instead of failing the invocation.
 - Plugin skill directories contribute too, though pi's loader names them without the plugin prefix.
+- Injected-span divergences: a span that exceeds the 2-minute timeout is killed and aborts the invocation (pi has no auto-background Bash set); the exit-1 carveout uses Claude's per-shell sets (bash keeps `find`/`diff`; PowerShell keeps `grep`/`git diff` but not `find`/`diff`). Stacked multi-skill messages (`/a` then `/b` in one message) expand only the first, and `@file` references outside the working directory stay literal (a deliberate hardening).

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -236,7 +236,7 @@ export async function expandCommand(runner: SpanRunner, parsed: ParsedCommand, a
           return { stdout, stderr: result.stderr, code: result.code }
         }
       : async () => ({ stdout: SHELL_DISABLED_PLACEHOLDER, stderr: '', code: 0 })
-  let expanded = await expandDynamicContent(withVars, ctx.cwd, exec)
+  let expanded = await expandDynamicContent(withVars, ctx.cwd, exec, parsed.shell === 'powershell' ? 'powershell' : 'bash')
 
   // Claude appends the raw arguments when the command never read them, so what
   // the user typed still reaches the model.

--- a/extensions/internal/agent-run.ts
+++ b/extensions/internal/agent-run.ts
@@ -16,6 +16,12 @@ export interface AgentRunRequest {
   model?: string
   /** Optional extra system prompt (Claude's experimental `systemPrompt` field). */
   systemPrompt?: string
+  /** A discovered agent to run as (Claude's `agent` field on context: fork
+   * skills); unknown names fall back per fullTools. */
+  agent?: string
+  /** Run with the full toolset instead of the read-only hook shape, for
+   * context: fork skills. */
+  fullTools?: boolean
   /** Aborts the run at the hook's deadline. */
   signal?: AbortSignal
 }

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -49,7 +49,7 @@ export interface ParsedCommand {
 }
 
 export interface DiscoveredCommand {
-  /** Claude's namespaced name: a nested file is `dir:name`, a plugin's is `plugin:name`. */
+  /** Claude names a command by its file name alone; a plugin's is `plugin:name`. */
   name: string
   filePath: string
   /** Set for plugin commands, carrying the ${CLAUDE_PLUGIN_*} and ${user_config.*} substitution sources. */
@@ -539,16 +539,21 @@ function fencedRanges(body: string): Array<[number, number]> {
 }
 
 /** Exit 1 is a normal result for Claude's documented search and comparison commands
- * (no matches, files differ); exit 2 and up fails even for these. */
+ * (no matches, files differ); exit 2 and up fails even for these. The PowerShell
+ * shell uses a different set, which "includes grep and git diff but not find or
+ * diff" (test/[ are bash builtins and do not apply there either). */
 const EXIT_ONE_OK = new Set(['grep', 'rg', 'egrep', 'fgrep', 'find', 'diff', 'test', '['])
+const EXIT_ONE_OK_POWERSHELL = new Set(['grep', 'rg', 'egrep', 'fgrep'])
 
-const isCarveoutSegment = (segment: string): boolean => {
+export type SpanShell = 'bash' | 'powershell'
+
+const isCarveoutSegment = (segment: string, shell: SpanShell): boolean => {
   const words = segment.trim().split(/\s+/)
   if (words[0] === 'git') return words[1] === 'diff' || words[1] === 'grep'
-  return EXIT_ONE_OK.has(words[0])
+  return (shell === 'powershell' ? EXIT_ONE_OK_POWERSHELL : EXIT_ONE_OK).has(words[0])
 }
 
-function benignExitOne(command: string): boolean {
+export function benignExitOne(command: string, shell: SpanShell = 'bash'): boolean {
   const segments = splitSegments(command)
   if (segments.length === 0) return false
   // A `&&`/`||` chain can short-circuit, so an earlier segment's exit 1 becomes the
@@ -557,15 +562,15 @@ function benignExitOne(command: string): boolean {
   // the exit benign whichever ran last. Without short-circuit operators the exit is
   // the last segment's (a `|` pipeline exits with its final command, `;`/newline with
   // the last statement), so the last segment decides.
-  if (/&&|\|\|/.test(command)) return segments.every(isCarveoutSegment)
-  return isCarveoutSegment(segments.at(-1) ?? '')
+  if (/&&|\|\|/.test(command)) return segments.every((segment) => isCarveoutSegment(segment, shell))
+  return isCarveoutSegment(segments.at(-1) ?? '', shell)
 }
 
 /** Run one injected span. A failure aborts the whole invocation, as Claude
  * documents: the model never sees a half-expanded body. */
-async function runSpan(exec: CommandExec, command: string, pattern: string): Promise<string> {
+async function runSpan(exec: CommandExec, command: string, pattern: string, shell: SpanShell): Promise<string> {
   const result = await exec(command)
-  if (result.code !== 0 && !(result.code === 1 && benignExitOne(command))) {
+  if (result.code !== 0 && !(result.code === 1 && benignExitOne(command, shell))) {
     throw new Error(`Shell command failed for pattern "${pattern}"\n[stderr]\n${(result.stderr || result.stdout).trim()}`)
   }
   return result.stdout.trimEnd()
@@ -608,7 +613,7 @@ interface DynamicSpan {
  * never re-scanned for further placeholders. Re-scanning was both a parity break
  * (Claude expands once) and a command-injection path: output of a `` ```! `` block
  * such as a commit message could smuggle its own `` !`cmd` `` for a later pass. */
-export async function expandDynamicContent(body: string, cwd: string, exec: CommandExec): Promise<string> {
+export async function expandDynamicContent(body: string, cwd: string, exec: CommandExec, shell: SpanShell = 'bash'): Promise<string> {
   const blocks = fenceBlocks(body)
   const protectedRanges = blocks.filter((block) => !block.exec).map((block): [number, number] => [block.start, block.end])
   const execRanges = blocks.filter((block) => block.exec).map((block): [number, number] => [block.start, block.end])
@@ -618,14 +623,14 @@ export async function expandDynamicContent(body: string, cwd: string, exec: Comm
 
   const spans: DynamicSpan[] = []
   for (const block of blocks) {
-    if (block.exec) spans.push({ start: block.start, end: block.end, run: () => runSpan(exec, block.content, '```!') })
+    if (block.exec) spans.push({ start: block.start, end: block.end, run: () => runSpan(exec, block.content, '```!', shell) })
   }
   // `!` counts only at the start of a line or after whitespace; `KEY=!`cmd`` is literal.
   const bashPattern = /(^|\s)!`([^`]+)`/g
   for (let m = bashPattern.exec(body); m !== null; m = bashPattern.exec(body)) {
     if (literal(m.index)) continue
     const [span, lead, command] = m
-    spans.push({ start: m.index, end: m.index + span.length, run: async () => lead + (await runSpan(exec, command, `!\`${command}\``)) })
+    spans.push({ start: m.index, end: m.index + span.length, run: async () => lead + (await runSpan(exec, command, `!\`${command}\``, shell)) })
   }
   const atPattern = /(^|\s)@(\S+)/g
   for (let m = atPattern.exec(body); m !== null; m = atPattern.exec(body)) {

--- a/extensions/skills.ts
+++ b/extensions/skills.ts
@@ -25,11 +25,14 @@ import * as path from 'node:path'
 import { type ExtensionAPI, type ExtensionContext, parseFrontmatter } from '@earendil-works/pi-coding-agent'
 
 import { expandCommand, shellExecutionDisabled } from './commands.js'
+import { runAgent } from './internal/agent-run.js'
 import { parseCommandFile } from './internal/command-file.js'
 import { claudeConfigDir } from './internal/config-dir.js'
+import { managedSettingsFile } from './internal/managed-settings.js'
 import { installedPlugins } from './internal/plugins.js'
 import { isProjectApprovedSilently } from './internal/project-approval.js'
 import { ancestorDirs } from './internal/project-root.js'
+import { claudeSettingsChain } from './internal/settings-chain.js'
 import { SKILL_HOOKS_CHANNEL } from './internal/skill-hooks.js'
 
 function isDirectory(target: string): boolean {
@@ -45,7 +48,10 @@ function isDirectory(target: string): boolean {
  * name and description to the model, so an untrusted repository would otherwise get
  * text into the prompt without the user ever agreeing to load its config. */
 export function skillDirs(cwd: string, home: string, trusted: boolean): string[] {
-  const candidates = [path.join(claudeConfigDir(home), 'skills')]
+  // Claude's precedence: enterprise (the skills directory beside the managed
+  // settings file) overrides personal, and personal overrides project; discovery
+  // here is first-match, so higher precedence goes first.
+  const candidates = [path.join(path.dirname(managedSettingsFile()), '.claude', 'skills'), path.join(claudeConfigDir(home), 'skills')]
   // Enabled plugins contribute their skills directories. pi's loader names a
   // skill by its directory, so a plugin skill registers without Claude's
   // /plugin: prefix; a rename-free approximation, disclosed in the README.
@@ -125,11 +131,27 @@ export default function skillsExtension(pi: ExtensionAPI) {
   })
 }
 
+/** Claude's `skillOverrides` value for one skill from the settings chain, later
+ * files winning: "off" hides the skill entirely, "name-only" trims its listing
+ * (a pi-loader surface, noted in docs). */
+function skillOverrideFor(name: string, cwd: string, trusted: boolean): string | undefined {
+  let value: string | undefined
+  for (const file of claudeSettingsChain(cwd, os.homedir(), trusted)) {
+    try {
+      const overrides = JSON.parse(fs.readFileSync(file, 'utf-8')).skillOverrides
+      if (overrides !== null && typeof overrides === 'object' && typeof overrides[name] === 'string') value = overrides[name]
+    } catch {
+      // missing or invalid file: skip
+    }
+  }
+  return value
+}
+
 /** A `/skill:name args` invocation into its expanded skill block, or undefined to
  * pass the input through to pi untouched. The expanded body is wrapped in pi's
  * skill-block format so downstream behavior (the baseDir note for relative
  * references) matches an untouched invocation. */
-async function expandSkillInvocation(pi: ExtensionAPI, rawText: string, ctx: ExtensionContext): Promise<{ action: 'transform'; text: string } | undefined> {
+async function expandSkillInvocation(pi: ExtensionAPI, rawText: string, ctx: ExtensionContext): Promise<{ action: 'transform'; text: string } | { action: 'handled' } | undefined> {
   const text = rawText.trimStart()
   if (!text.startsWith('/skill:')) return
   const space = text.indexOf(' ')
@@ -139,6 +161,11 @@ async function expandSkillInvocation(pi: ExtensionAPI, rawText: string, ctx: Ext
   const trusted = isProjectApprovedSilently(ctx)
   const found = findClaudeSkill(name, skillDirs(ctx.cwd, os.homedir(), trusted))
   if (!found) return
+  // Claude's skillOverrides: a skill set to "off" is hidden and does not run.
+  if (skillOverrideFor(name, ctx.cwd, trusted) === 'off') {
+    if (ctx.hasUI) ctx.ui.notify(`Skill "${name}" is turned off by skillOverrides in settings.`, 'info')
+    return { action: 'handled' }
+  }
   let parsed: ReturnType<typeof parseCommandFile>
   let content: string
   try {
@@ -153,10 +180,24 @@ async function expandSkillInvocation(pi: ExtensionAPI, rawText: string, ctx: Ext
   // Claude registers hooks a skill's frontmatter declares when the skill is
   // invoked, for the rest of the session; the hooks extension owns running them,
   // so the declaration is announced over the shared bus.
-  const declaredHooks = parseFrontmatter<Record<string, unknown>>(content).frontmatter.hooks
+  const frontmatter = parseFrontmatter<Record<string, unknown>>(content).frontmatter
+  const declaredHooks = frontmatter.hooks
   if (declaredHooks !== null && typeof declaredHooks === 'object' && !Array.isArray(declaredHooks)) {
     pi.events?.emit(SKILL_HOOKS_CHANNEL, { skillName: name, hooks: declaredHooks })
   }
   const expanded = await expandCommand(pi, parsed, args, { cwd: ctx.cwd }, found.filePath, undefined, { allowShell: !shellExecutionDisabled(ctx.cwd, os.homedir(), trusted) })
+  // Claude's context: fork runs the skill in a subagent; the expanded content
+  // becomes the prompt that drives it, without the conversation history.
+  // Divergence: Claude backgrounds the fork by default; pi-code waits for the
+  // result in the invoking turn (Claude's background: false behavior, which is
+  // also what Claude itself does in -p and SDK runs).
+  if (typeof frontmatter.context === 'string' && frontmatter.context.trim().toLowerCase() === 'fork') {
+    try {
+      const output = await runAgent({ prompt: expanded, fullTools: true, ...(typeof frontmatter.agent === 'string' ? { agent: frontmatter.agent.trim() } : {}) })
+      return { action: 'transform', text: `<skill name="${name}" location="${found.filePath}">\nThe skill ran in a forked subagent (no conversation history shared). Its result:\n\n${output}\n</skill>` }
+    } catch (error) {
+      return { action: 'transform', text: `<skill name="${name}">\nThe forked subagent run failed: ${error instanceof Error ? error.message : String(error)}\n</skill>` }
+    }
+  }
   return { action: 'transform', text: `<skill name="${name}" location="${found.filePath}">\nReferences are relative to ${found.baseDir}.\n\n${expanded}\n</skill>` }
 }

--- a/extensions/skills.ts
+++ b/extensions/skills.ts
@@ -147,6 +147,28 @@ function skillOverrideFor(name: string, cwd: string, trusted: boolean): string |
   return value
 }
 
+/** Claude's skillOverrides "off": the skill is hidden and does not run; the
+ * invocation is swallowed with a notice. Undefined lets the invocation proceed. */
+function refusedByOverride(name: string, ctx: ExtensionContext, trusted: boolean): { action: 'handled' } | undefined {
+  if (skillOverrideFor(name, ctx.cwd, trusted) !== 'off') return undefined
+  if (ctx.hasUI) ctx.ui.notify(`Skill "${name}" is turned off by skillOverrides in settings.`, 'info')
+  return { action: 'handled' }
+}
+
+/** Claude's context: fork run: the expanded skill content becomes the prompt that
+ * drives a subagent, without the conversation history. Divergence: Claude
+ * backgrounds the fork by default; pi-code waits for the result in the invoking
+ * turn (Claude's background: false behavior, which is also what Claude itself
+ * does in -p and SDK runs). */
+async function runForkedSkill(name: string, filePath: string, expanded: string, agentName: string | undefined): Promise<{ action: 'transform'; text: string }> {
+  try {
+    const output = await runAgent({ prompt: expanded, fullTools: true, ...(agentName ? { agent: agentName } : {}) })
+    return { action: 'transform', text: `<skill name="${name}" location="${filePath}">\nThe skill ran in a forked subagent (no conversation history shared). Its result:\n\n${output}\n</skill>` }
+  } catch (error) {
+    return { action: 'transform', text: `<skill name="${name}">\nThe forked subagent run failed: ${error instanceof Error ? error.message : String(error)}\n</skill>` }
+  }
+}
+
 /** A `/skill:name args` invocation into its expanded skill block, or undefined to
  * pass the input through to pi untouched. The expanded body is wrapped in pi's
  * skill-block format so downstream behavior (the baseDir note for relative
@@ -161,11 +183,8 @@ async function expandSkillInvocation(pi: ExtensionAPI, rawText: string, ctx: Ext
   const trusted = isProjectApprovedSilently(ctx)
   const found = findClaudeSkill(name, skillDirs(ctx.cwd, os.homedir(), trusted))
   if (!found) return
-  // Claude's skillOverrides: a skill set to "off" is hidden and does not run.
-  if (skillOverrideFor(name, ctx.cwd, trusted) === 'off') {
-    if (ctx.hasUI) ctx.ui.notify(`Skill "${name}" is turned off by skillOverrides in settings.`, 'info')
-    return { action: 'handled' }
-  }
+  const refused = refusedByOverride(name, ctx, trusted)
+  if (refused) return refused
   let parsed: ReturnType<typeof parseCommandFile>
   let content: string
   try {
@@ -186,18 +205,8 @@ async function expandSkillInvocation(pi: ExtensionAPI, rawText: string, ctx: Ext
     pi.events?.emit(SKILL_HOOKS_CHANNEL, { skillName: name, hooks: declaredHooks })
   }
   const expanded = await expandCommand(pi, parsed, args, { cwd: ctx.cwd }, found.filePath, undefined, { allowShell: !shellExecutionDisabled(ctx.cwd, os.homedir(), trusted) })
-  // Claude's context: fork runs the skill in a subagent; the expanded content
-  // becomes the prompt that drives it, without the conversation history.
-  // Divergence: Claude backgrounds the fork by default; pi-code waits for the
-  // result in the invoking turn (Claude's background: false behavior, which is
-  // also what Claude itself does in -p and SDK runs).
   if (typeof frontmatter.context === 'string' && frontmatter.context.trim().toLowerCase() === 'fork') {
-    try {
-      const output = await runAgent({ prompt: expanded, fullTools: true, ...(typeof frontmatter.agent === 'string' ? { agent: frontmatter.agent.trim() } : {}) })
-      return { action: 'transform', text: `<skill name="${name}" location="${found.filePath}">\nThe skill ran in a forked subagent (no conversation history shared). Its result:\n\n${output}\n</skill>` }
-    } catch (error) {
-      return { action: 'transform', text: `<skill name="${name}">\nThe forked subagent run failed: ${error instanceof Error ? error.message : String(error)}\n</skill>` }
-    }
+    return runForkedSkill(name, found.filePath, expanded, typeof frontmatter.agent === 'string' ? frontmatter.agent.trim() : undefined)
   }
   return { action: 'transform', text: `<skill name="${name}" location="${found.filePath}">\nReferences are relative to ${found.baseDir}.\n\n${expanded}\n</skill>` }
 }

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -650,6 +650,20 @@ export const AGENT_HOOK_SYSTEM = [
 
 /** A throwaway agent config for one agent-hook run: read-only inspection tools, the
  * hook's model (a fast default when unset), and the decision-returning system prompt. */
+/** The agent a context: fork skill runs as when it names none: full toolset, no
+ * extra system prompt (the child keeps pi's default), the skill content as the
+ * task. */
+function forkAgent(request: Pick<AgentRunRequest, 'model' | 'systemPrompt'>): AgentConfig {
+  return {
+    name: 'fork',
+    description: 'forked skill run',
+    systemPrompt: request.systemPrompt ?? '',
+    ...(request.model ? { model: request.model } : {}),
+    source: 'builtin',
+    filePath: '',
+  }
+}
+
 export function buildHookAgent(request: Pick<AgentRunRequest, 'model' | 'systemPrompt'>): AgentConfig {
   return {
     name: 'agent-hook',
@@ -1467,7 +1481,10 @@ export default function subagentExtension(pi: ExtensionAPI) {
       // A subagent session must not spawn further agents; agent hooks inside one are
       // skipped (the seam rejection is non-blocking in runAgentHook).
       if (process.env.PI_CODE_SUBAGENT) throw new Error('agent hooks do not run inside a subagent')
-      const agent = buildHookAgent(request)
+      // A context: fork skill names its agent, or runs with the full toolset;
+      // agent hooks keep the read-only hook shape.
+      const named = request.agent ? discoverAgents(hookCwd, 'both').agents.find((a) => a.name === request.agent) : undefined
+      const agent = named ?? (request.fullTools ? forkAgent(request) : buildHookAgent(request))
       const result = await runSingleAgent({
         defaultCwd: hookCwd,
         agents: [agent],

--- a/tests/command-parse.test.ts
+++ b/tests/command-parse.test.ts
@@ -568,3 +568,16 @@ describe('dollar signs stay literal', () => {
     expect(out).toBe('Example:\n```\n!`git status`\n```\nNow really: CLEAN')
   })
 })
+
+describe('powershell exit-1 carveout set', () => {
+  it('uses the PowerShell carveout set: grep and git diff yes, find and diff no', async () => {
+    // Claude: the powershell set "includes grep and git diff but not find or diff".
+    const { benignExitOne } = await import('../extensions/internal/command-file.ts')
+    expect(benignExitOne('grep foo bar', 'powershell')).toBe(true)
+    expect(benignExitOne('git diff HEAD', 'powershell')).toBe(true)
+    expect(benignExitOne('find . -name x', 'powershell')).toBe(false)
+    expect(benignExitOne('diff a b', 'powershell')).toBe(false)
+    // The default bash set keeps find and diff.
+    expect(benignExitOne('find . -name x')).toBe(true)
+  })
+})

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -221,3 +221,68 @@ describe('skill frontmatter hooks publication', () => {
     expect(emitted).toEqual([])
   })
 })
+
+describe('context: fork and skillOverrides', () => {
+  it('runs a context: fork skill through the subagent seam and returns its result', async () => {
+    // Claude: "Add context: fork ... The skill content becomes the prompt that
+    // drives the subagent"; `agent` picks the subagent type.
+    const { setAgentRunner } = await import('../extensions/internal/agent-run.ts')
+    const requests: unknown[] = []
+    setAgentRunner(async (request) => {
+      requests.push(request)
+      return 'FORK RESULT'
+    })
+    try {
+      const cwd = tempDir('cs-proj-')
+      hoisted.home = tempDir('cs-home-')
+      mkdirSync(join(hoisted.home, '.claude', 'skills', 'deploy'), { recursive: true })
+      writeFileSync(join(hoisted.home, '.claude', 'skills', 'deploy', 'SKILL.md'), '---\nname: deploy\ndescription: d\ncontext: fork\nagent: reviewer\n---\nDeploy $ARGUMENTS now.')
+      const handlers = new Map<string, (event: Record<string, unknown>, ctx: unknown) => Promise<unknown>>()
+      skillsExt({ on: (name: string, fn: never) => handlers.set(name, fn), exec: async () => ({ stdout: '', stderr: '', code: 0 }) } as never)
+      const result = (await handlers.get('input')?.({ text: '/skill:deploy prod', source: 'interactive' }, { cwd })) as { action: string; text?: string }
+
+      expect(result.action).toBe('transform')
+      expect(result.text).toContain('FORK RESULT')
+      const request = requests[0] as { prompt: string; agent?: string }
+      expect(request.prompt).toContain('Deploy prod now.')
+      expect(request.agent).toBe('reviewer')
+    } finally {
+      setAgentRunner(undefined)
+    }
+  })
+
+  it('refuses a skill set to off in skillOverrides', async () => {
+    const cwd = tempDir('cs-proj-')
+    hoisted.home = tempDir('cs-home-')
+    mkdirSync(join(hoisted.home, '.claude', 'skills', 'quiet'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'skills', 'quiet', 'SKILL.md'), '---\nname: quiet\ndescription: q\n---\nBody')
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ skillOverrides: { quiet: 'off' } }))
+    const handlers = new Map<string, (event: Record<string, unknown>, ctx: unknown) => Promise<unknown>>()
+    const notes: string[] = []
+    skillsExt({ on: (name: string, fn: never) => handlers.set(name, fn), exec: async () => ({ stdout: '', stderr: '', code: 0 }) } as never)
+    const result = (await handlers.get('input')?.({ text: '/skill:quiet', source: 'interactive' }, { cwd, hasUI: true, ui: { notify: (m: string) => notes.push(m) } })) as { action: string } | undefined
+
+    expect(result?.action).toBe('handled')
+    expect(notes.some((n) => n.includes('skillOverrides'))).toBe(true)
+  })
+
+  it('discovers enterprise skills beside the managed settings file, winning a name clash', async () => {
+    const { setManagedSettingsPath } = await import('../extensions/internal/managed-settings.ts')
+    const managedDir = tempDir('cs-managed-')
+    setManagedSettingsPath(join(managedDir, 'managed-settings.json'))
+    try {
+      const cwd = tempDir('cs-proj-')
+      hoisted.home = tempDir('cs-home-')
+      mkdirSync(join(managedDir, '.claude', 'skills', 'deploy'), { recursive: true })
+      writeFileSync(join(managedDir, '.claude', 'skills', 'deploy', 'SKILL.md'), '---\nname: deploy\ndescription: e\n---\nENTERPRISE BODY')
+      mkdirSync(join(hoisted.home, '.claude', 'skills', 'deploy'), { recursive: true })
+      writeFileSync(join(hoisted.home, '.claude', 'skills', 'deploy', 'SKILL.md'), '---\nname: deploy\ndescription: p\n---\nPERSONAL BODY')
+
+      const dirs = skillDirs(cwd, hoisted.home, true)
+      expect(dirs[0]).toBe(join(managedDir, '.claude', 'skills'))
+    } finally {
+      setManagedSettingsPath(undefined)
+    }
+  })
+})


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #170); closes the commands/skills batch.

## context: fork (skills.ts, internal/agent-run.ts, subagent/index.ts)
- A `context: fork` skill now runs in a subagent through the agent-run seam: the expanded content becomes the subagent's prompt (no conversation history), and `agent:` picks a discovered agent type; without one, a full-toolset fork agent runs (the read-only hook shape stays for agent hooks). Divergence, documented: pi-code waits for the result in the invoking turn (Claude's `background: false` behavior, and what Claude itself does in `-p`/SDK runs) instead of backgrounding by default.

## skillOverrides and enterprise skills (skills.ts)
- A skill set to `"off"` in `skillOverrides` refuses `/skill:name` with a notice; `"name-only"` remains a pi-loader listing concern (noted).
- Enterprise skills load from the `.claude/skills` directory beside the managed settings file with top precedence.

## PowerShell exit-1 carveout (internal/command-file.ts, commands.ts)
- The injected-span exit-1 carveout now uses Claude's per-shell sets: bash keeps `find`/`diff`/`test`; PowerShell keeps `grep`/`git diff` but not `find` or `diff`. The shell threads through span expansion.

## Documented divergences (docs/skills.md)
- pi-loader gaps (frontmatter fields beyond the basics, boolean spellings, first-paragraph description fallback), the timeout kill without auto-backgrounding, single-skill expansion per message, and literal out-of-cwd `@refs` (a deliberate hardening) are now all disclosed.

All changes covered by tests that failed before the change (4 red tests).