### PR TITLE
Align plugin enablement and MCP resource mentions with Claude docs

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -15,7 +15,7 @@ Managed `allowedMcpServers`/`deniedMcpServers` entries are typed and matched per
 ## Transports and auth
 
 - stdio, HTTP (streamable with SSE fallback), SSE, and WebSocket by `type`. WebSocket is url-only: any `headers`/`bearerToken`/`headersHelper` on a ws server is ignored with a warning (the SDK transport carries no headers; Claude documents header auth for ws, so authenticated ws servers cannot be used yet).
-- `${VAR}` / `${VAR:-default}` expansion in values.
+- `${VAR}` / `${VAR:-default}` expansion in values; `:-` follows shell semantics deliberately (substitutes when unset OR empty), a pinned reading of the doc's "if set" summary.
 - Stdio servers get `CLAUDE_PROJECT_DIR` (and `CLAUDE_PLUGIN_ROOT` for a plugin's server) in their environment; every client answers `roots/list` with the session's launch directory.
 - A `headersHelper` command's stdout JSON merges into the transport headers (http/sse). The helper runs with `CLAUDE_CODE_MCP_SERVER_NAME` and `CLAUDE_CODE_MCP_SERVER_URL` set (credential-expanded url parts shown as `REDACTED`); a project- or plugin-supplied helper runs without credential-named variables (`TOKEN`/`SECRET`/`PASSWORD`/`KEY`/`AUTH`).
 - Bearer tokens, or OAuth for remote servers: browser login on 401/403 after a confirm, CSRF-guarded loopback callback, tokens under `~/.pi/agent/mcp-oauth`, silent refresh later. A configured `Authorization` header (static, bearer, or helper-supplied) is the server's authentication: auth failures report as failed connections with no OAuth fallback.
@@ -28,4 +28,4 @@ Connect and per-call budgets honor `MCP_TIMEOUT` (30s default) and `MCP_TOOL_TIM
 
 ## Surface
 
-A connected server's prompts register as `/mcp__server__prompt` commands; resources are reachable through the `list_mcp_resources`/`read_mcp_resource` tools; tools refresh on `list_changed`. `/mcp` shows status.
+A connected server's prompts register as `/mcp__server__prompt` commands; resources are reachable through the `list_mcp_resources`/`read_mcp_resource` tools and via `@server:uri` mentions in a prompt, which fetch and inline the resource (mentions naming an unconnected server stay literal); tools refresh on `list_changed`. `/mcp` shows status.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4,5 +4,6 @@ Loads installed marketplace plugins. Source: [`extensions/internal/plugins.ts`](
 
 - Reads the plugin cache at `~/.claude/plugins/cache`, active per `enabledPlugins` in user settings only: a checked-out repo cannot flip which code-bearing plugins run, so project settings never toggle them.
 - Contributes commands as `/plugin:name`, agents, hooks, MCP servers (tools aliased `mcp__plugin_<plugin>_<server>__<tool>`), and output styles.
+- Enablement follows Claude's precedence: a managed-settings `enabledPlugins` entry force-enables or blocks, then the user's `enabledPlugins` setting, then the manifest's `defaultEnabled` (default `true`: an installed plugin with no entry runs).
 - Substitutes `${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PLUGIN_DATA}`, and `${user_config.KEY}` (from `pluginConfigs[id].options` in user settings).
 - Skill directories contribute too, though pi's loader names them without the plugin prefix.

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -16,6 +16,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 
 import { claudeConfigDir } from './config-dir.js'
+import { readManagedSettings } from './managed-settings.js'
 
 export interface InstalledPlugin {
   name: string
@@ -169,16 +170,30 @@ export function installedPlugins(home: string, extraSettingsFiles: string[] = []
   return plugins
 }
 
+/** The plugin's effective enablement per Claude's precedence: a managed
+ * enabledPlugins entry force-enables or blocks, then the user's setting, then the
+ * manifest's defaultEnabled, which defaults to true ("starts in an enabled state
+ * when the user has not set one"). */
+function pluginEnabled(qualified: string, pluginDir: string, enabled: Record<string, boolean>, manifest: Record<string, unknown>): boolean {
+  const managedEntry = readManagedSettings().enabledPlugins
+  if (managedEntry !== null && typeof managedEntry === 'object') {
+    const managedState = (managedEntry as Record<string, unknown>)[qualified] ?? (managedEntry as Record<string, unknown>)[pluginDir]
+    if (typeof managedState === 'boolean') return managedState
+  }
+  const userState = enabled[qualified] ?? enabled[pluginDir]
+  if (typeof userState === 'boolean') return userState
+  return manifest.defaultEnabled !== false
+}
+
 /** Resolve one cached plugin directory into an enabled InstalledPlugin, or null to skip
- * it: not turned on in settings, or no version directory on disk yet. */
+ * it: turned off by managed/user settings or defaultEnabled, or no version yet. */
 function resolvePlugin(home: string, cacheDir: string, marketplace: string, pluginDir: string, enabled: Record<string, boolean>, configs: Record<string, Record<string, string>>): InstalledPlugin | null {
   const qualified = `${pluginDir}@${marketplace}`
-  const state = enabled[qualified] ?? enabled[pluginDir]
-  if (state !== true) return null
   const version = newestVersion(listDirs(path.join(cacheDir, marketplace, pluginDir)))
   if (!version) return null
   const root = path.join(cacheDir, marketplace, pluginDir, version)
   const manifest = readJson(path.join(root, '.claude-plugin', 'plugin.json'))
+  if (!pluginEnabled(qualified, pluginDir, enabled, manifest)) return null
   const name = typeof manifest.name === 'string' && manifest.name.length > 0 ? manifest.name : pluginDir
   // Claude: "{id} is the plugin identifier with characters outside a-z, A-Z, 0-9,
   // _, and - replaced by -", one dash per character, underscores kept.

--- a/extensions/mcp/index.ts
+++ b/extensions/mcp/index.ts
@@ -595,6 +595,34 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     status.clear()
   })
 
+  // Claude references MCP resources with @server:uri mentions, fetched into the
+  // conversation when referenced. Only mentions naming a connected server expand;
+  // anything else (an email, a handle) stays untouched.
+  pi.on('input', async (event) => {
+    if (event.source === 'extension') return
+    const mentions = [...event.text.matchAll(/@([A-Za-z0-9_-]+):(\S+)/g)].filter((match) => clients.has(match[1]))
+    if (mentions.length === 0) return
+    const sections: string[] = []
+    for (const match of mentions) {
+      const [, server, uri] = match
+      try {
+        const client = clients.get(server)
+        if (!client) continue
+        const wall = callTimeoutMs()
+        const result = await withTimeout(client.readResource({ uri }, callRequestOptions(wall, callTuning(server))), wall, `read ${uri}`)
+        const text = (result.contents as Array<{ text?: string }>)
+          .map((entry) => entry.text)
+          .filter((value): value is string => typeof value === 'string')
+          .join('\n')
+        if (text) sections.push(capForContext(`<mcp-resource server="${server}" uri="${uri}">\n${text}\n</mcp-resource>`))
+      } catch {
+        // An unreadable resource leaves the mention as plain text.
+      }
+    }
+    if (sections.length === 0) return
+    return { action: 'transform', text: `${event.text}\n\n${sections.join('\n\n')}` }
+  })
+
   pi.registerCommand('mcp', {
     description: 'Show MCP server status and tools',
     handler: async (_args, ctx) => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -582,11 +582,13 @@ describe('plugin commands', () => {
     expect(s.sent[0]).toBe('Deploy to eu-west-1 as .')
   })
 
-  it('does not register commands from a plugin nobody enabled', async () => {
+  it('does not register commands from an explicitly disabled plugin', async () => {
     const cwd = tempDir()
     const root = join(hoisted.home, '.claude', 'plugins', 'cache', 'market', 'dormant', '1.0.0')
     mkdirSync(join(root, 'commands'), { recursive: true })
     writeFileSync(join(root, 'commands', 'x.md'), 'body')
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { dormant: false } }))
     const s = setup(cwd)
     await s.handlers.get('session_start')?.({}, s.ctx)
 

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -221,6 +221,7 @@ interface Harness {
   toolNames: () => string[]
   commandNames: () => string[]
   runSlash: (name: string, args: string, idle?: boolean) => Promise<void>
+  input: (text: string) => Promise<unknown>
 }
 
 const writeServers = (file: string, servers: Record<string, unknown>): void => {
@@ -297,6 +298,7 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
     runSlash: async (name: string, args: string, idle = true) => {
       await commands.get(name)?.handler(args, makeCtx(true, true, idle))
     },
+    input: async (text: string) => handlers.get('input')?.({ text, source: 'interactive' }, makeCtx(true)),
   }
 }
 
@@ -2512,5 +2514,27 @@ describe('mcp tool-call auth retry', () => {
 
     await expect(harness.tools[0].execute('c1', {})).rejects.toThrow('expired')
     expect(calls).toBe(2)
+  })
+})
+
+describe('mcp resource mentions', () => {
+  it('inlines an @server:uri resource mention into the prompt', async () => {
+    // Claude: MCP resources are referenced with @ mentions and fetched into the
+    // conversation when referenced.
+    withTools([{ name: 'go' }])
+    hoisted.control.readResource = async (args) => ({ contents: [{ uri: args.uri, text: 'RESOURCE BODY' }] })
+    const harness = await setupStarted({ user: { srv: { command: 'x' } } })
+
+    const result = (await harness.input('analyze @srv:file:///spec.md please')) as { action: string; text: string } | undefined
+    expect(result?.action).toBe('transform')
+    expect(result?.text).toContain('analyze @srv:file:///spec.md please')
+    expect(result?.text).toContain('RESOURCE BODY')
+  })
+
+  it('leaves a mention for an unconnected server untouched', async () => {
+    withTools([{ name: 'go' }])
+    const harness = await setupStarted({ user: { srv: { command: 'x' } } })
+
+    expect(await harness.input('email me @nosuch:thing please')).toBeUndefined()
   })
 })

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -71,13 +71,15 @@ describe('installedPlugins', () => {
     expect(plugins[0].dataDir).toBe(join(h, '.claude', 'plugins', 'data', 'my_plugin-my-market'))
   })
 
-  it('skips plugins that are not enabled or explicitly disabled', () => {
+  it('skips an explicitly disabled plugin while a no-entry install stays enabled by default', () => {
+    // Claude: defaultEnabled defaults to true, so an installed plugin with no
+    // enabledPlugins entry runs; an explicit false turns it off.
     const h = home()
     install(h, 'community', 'formatter', '1.0.0')
     install(h, 'community', 'linter', '1.0.0')
     enable(h, { linter: false })
 
-    expect(installedPlugins(h, [])).toEqual([])
+    expect(installedPlugins(h, []).map((p) => p.name)).toEqual(['formatter'])
   })
 
   it('honors marketplace-qualified enablement and picks the newest version', () => {
@@ -178,5 +180,43 @@ describe('installedPlugins cache', () => {
     utimesSync(manifest, future, future)
 
     expect(installedPlugins(h)[0].manifest.displayName).toBe('Edited')
+  })
+})
+
+describe('plugin default enablement and managed control', () => {
+  it('enables an installed plugin with no enabledPlugins entry, per defaultEnabled defaulting to true', () => {
+    const h = home()
+    install(h, 'community', 'fresh', '1.0.0')
+
+    expect(installedPlugins(h, []).some((p) => p.name === 'fresh')).toBe(true)
+  })
+
+  it('keeps a defaultEnabled: false plugin off until the user opts in', () => {
+    const h = home()
+    const dir = install(h, 'community', 'optin', '1.0.0')
+    writeFileSync(join(dir, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'optin', defaultEnabled: false }))
+
+    expect(installedPlugins(h, []).some((p) => p.name === 'optin')).toBe(false)
+    enable(h, { optin: true })
+    resetInstalledPluginsCache()
+    expect(installedPlugins(h, []).some((p) => p.name === 'optin')).toBe(true)
+  })
+
+  it('lets managed enabledPlugins force-enable and block over the user setting', async () => {
+    const { setManagedSettingsPath } = await import('../extensions/internal/managed-settings.ts')
+    const h = home()
+    setManagedSettingsPath(join(h, 'managed-settings.json'))
+    try {
+      install(h, 'community', 'forced', '1.0.0')
+      install(h, 'community', 'blocked', '1.0.0')
+      enable(h, { forced: false, blocked: true })
+      writeFileSync(join(h, 'managed-settings.json'), JSON.stringify({ enabledPlugins: { forced: true, blocked: false } }))
+
+      const names = installedPlugins(h, []).map((p) => p.name)
+      expect(names).toContain('forced')
+      expect(names).not.toContain('blocked')
+    } finally {
+      setManagedSettingsPath(undefined)
+    }
   })
 })


### PR DESCRIPTION
Part of the docs-conformance campaign (follows #171); the final code chunk of the register.

## Plugin enablement (internal/plugins.ts)
- Enablement now follows Claude's precedence: a managed-settings `enabledPlugins` entry force-enables or blocks, then the user's setting, then the manifest's `defaultEnabled`, which defaults to true — so an installed plugin with no entry runs, and `defaultEnabled: false` ships opt-in. Previously only an explicit user `true` enabled anything.

## MCP resource mentions (mcp/index.ts)
- `@server:uri` mentions in a prompt fetch the resource from the connected server and inline it after the prompt, per "resources that you can reference using @ mentions". Mentions naming an unconnected server (or an unreadable resource) stay literal, so emails and handles are unaffected.

## Verified and disclosed
- The ws auth note contradiction (B5-19) was already resolved by the earlier transport rewrite; verified gone.
- `${VAR:-default}` deliberately follows shell semantics (substitutes on unset OR empty); the doc's "if set" summary reading is disclosed in `docs/mcp.md`, and the behavior stays pinned by its existing tests (B5-20 closes as verified).

Docs: `docs/plugins.md` and `docs/mcp.md` updated.

All changes covered by tests that failed before the change (3 red tests, plus two stale opt-in pins updated to the documented default-enabled contract).