### PR TITLE
Harden the test foundations: env quarantine, enforced floors, temp-dir funnel

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,12 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "preset": "recommended"
+      "preset": "recommended",
+      "nursery": {
+        "noFloatingPromises": "error",
+        "noMisusedPromises": "error",
+        "useExhaustiveSwitchCases": "error"
+      }
     }
   },
   "overrides": [

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -76,6 +76,13 @@ export function activeBackgroundRuns(): number {
  * completing in the same millisecond still evict in their true finish order. */
 let finishSequence = 0
 
+/** Test seam: the registry is module state, so tests reset it between cases to
+ * stay order-independent. */
+export function resetBackgroundRuns(): void {
+  runs.clear()
+  finishSequence = 0
+}
+
 function evictFinishedRuns(): void {
   const finished = [...runs.values()].filter((run) => !run.live && run.state !== 'running')
   finished.sort((a, b) => (a.finishedAt ?? 0) - (b.finishedAt ?? 0))

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from 'node:path'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { activeBackgroundRuns, type BackgroundRun, type BackgroundSpawn, backgroundStatusText, cancelBackgroundRun, createJsonlOutputParser, formatStatus, parseFinalOutputFromJsonl, resumeBackgroundRun, startBackgroundRun } from '../extensions/subagent/background.ts'
+import { activeBackgroundRuns, type BackgroundRun, type BackgroundSpawn, backgroundStatusText, cancelBackgroundRun, createJsonlOutputParser, formatStatus, MAX_FINISHED_RUNS, parseFinalOutputFromJsonl, resetBackgroundRuns, resumeBackgroundRun, startBackgroundRun } from '../extensions/subagent/background.ts'
 
 describe('createJsonlOutputParser onTurn', () => {
   const asst = (text: string) => JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text }] } })
@@ -60,6 +60,7 @@ class FakeProc extends EventEmitter {
 const children: FakeProc[] = []
 
 beforeEach(() => {
+  resetBackgroundRuns()
   children.length = 0
   spawnMock.mockReset()
   spawnMock.mockImplementation(() => {
@@ -156,7 +157,7 @@ describe('background run lifecycle', () => {
     const finished = backgroundStatusText()
       .split('\n')
       .filter((line) => line.includes('done (exit'))
-    expect(finished.length).toBeLessThanOrEqual(20)
+    expect(finished.length).toBe(MAX_FINISHED_RUNS)
   })
 
   it('refuses to resume while the running cap is full', () => {

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -321,13 +321,16 @@ const withTools = (tools: ToolDef[]): void => {
   hoisted.control.listTools = async () => ({ tools })
 }
 
-/** Poll a condition to a deadline; for interleaving a step into an in-flight connect flow. */
-const waitFor = async (predicate: () => boolean, timeoutMs = 3000): Promise<void> => {
-  const deadline = Date.now() + timeoutMs
-  while (!predicate()) {
-    if (Date.now() > deadline) throw new Error('condition not met within timeout')
-    await new Promise((resolve) => setTimeout(resolve, 10))
-  }
+/** Poll a condition to a deadline; for interleaving a step into an in-flight
+ * connect flow. Runs on the real clock, so the budget is generous for starved
+ * CI runners; vi.waitFor reports the elapsed wait on failure. */
+const waitFor = async (predicate: () => boolean, timeoutMs = 10_000): Promise<void> => {
+  await vi.waitFor(
+    () => {
+      if (!predicate()) throw new Error('condition not met within timeout')
+    },
+    { timeout: timeoutMs, interval: 10 },
+  )
 }
 
 const defaultControl = (): typeof hoisted.control => ({

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -13,7 +13,10 @@
  * registered first, so vitest runs it after every file-local afterEach.
  */
 
-import { afterEach, beforeEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterAll, afterEach, beforeEach } from 'vitest'
 
 const HOST_LEAK_VARS = [
   'CLAUDECODE',
@@ -38,6 +41,20 @@ function quarantine(): void {
 }
 
 quarantine()
+
+// Every temp fixture in the suite goes through os.tmpdir(), which resolves from
+// TMPDIR (TEMP/TMP on Windows). Pointing it at a per-file root at setup load,
+// before any test module runs, funnels every mkdtempSync in the file under one
+// directory that afterAll removes wholesale, so no fixture can outlive its file
+// regardless of whether the test cleans up.
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-code-tests-'))
+process.env.TMPDIR = tmpRoot
+process.env.TEMP = tmpRoot
+process.env.TMP = tmpRoot
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
 
 let snapshot: NodeJS.ProcessEnv
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,56 @@
+/**
+ * Global test hygiene: the suite must be immune to the host environment.
+ *
+ * pi-code's own dev loop runs the tests inside Claude Code and inside pi
+ * subagents, so the host env carries the very variables the source reads
+ * (CLAUDECODE, PI_CODE_SUBAGENT, CLAUDE_CONFIG_DIR, the MCP timeout family).
+ * They are deleted at module load, before any test file imports source that
+ * could read them at import time, and again before each test so a leaky
+ * earlier test cannot reintroduce them.
+ *
+ * Each test also runs against a snapshot of process.env: whatever a test sets
+ * and forgets to restore is rolled back afterwards. The global afterEach is
+ * registered first, so vitest runs it after every file-local afterEach.
+ */
+
+import { afterEach, beforeEach } from 'vitest'
+
+const HOST_LEAK_VARS = [
+  'CLAUDECODE',
+  'CLAUDE_CODE_CHILD_SESSION',
+  'CLAUDE_CONFIG_DIR',
+  'PI_CODE_SUBAGENT',
+  'PI_CODE_AGENT_HOOKS',
+  'MCP_TIMEOUT',
+  'MCP_TOOL_TIMEOUT',
+  'CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT',
+  'CLAUDE_CODE_SUBAGENT_MODEL',
+  'CLAUDE_CODE_DISABLE_AUTO_MEMORY',
+  'CLAUDE_CODE_STOP_HOOK_BLOCK_CAP',
+  'CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD',
+  'WT_SESSION',
+  'KITTY_WINDOW_ID',
+  'PI_CODE_SETTINGS_WATCH_INTERVAL_MS',
+]
+
+function quarantine(): void {
+  for (const name of HOST_LEAK_VARS) delete process.env[name]
+}
+
+quarantine()
+
+let snapshot: NodeJS.ProcessEnv
+
+beforeEach(() => {
+  quarantine()
+  snapshot = { ...process.env }
+})
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) delete process.env[key]
+  }
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (process.env[key] !== value) process.env[key] = value
+  }
+})

--- a/tests/web-transport.test.ts
+++ b/tests/web-transport.test.ts
@@ -44,8 +44,16 @@ describe('httpFetch pins the connection to the validated address', () => {
   })
 
   it('surfaces a connection error when the pinned address refuses', async () => {
-    // 127.0.0.1:1 is not listening; the pin sends the socket there and it fails.
-    await expect(httpFetch(new URL('http://blocked.internal.test/'), { signal: signal(), lookup: pinTo('127.0.0.1'), userAgent: 'pin-test/1' })).rejects.toThrow()
+    // A bind-then-closed port is guaranteed refusing on any machine, unlike a
+    // fixed port that a local server could be listening on. The specific code
+    // proves the pin carried the socket to the address (a DNS failure or URL
+    // error would reject with a different code and mean the pin was bypassed).
+    const server = createHttpServer()
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
+    const deadPort = (server.address() as AddressInfo).port
+    await new Promise<void>((r) => server.close(() => r()))
+
+    await expect(httpFetch(new URL(`http://blocked.internal.test:${deadPort}/`), { signal: signal(), lookup: pinTo('127.0.0.1'), userAgent: 'pin-test/1' })).rejects.toMatchObject({ code: 'ECONNREFUSED' })
   })
 
   it.each([204, 205, 304])('returns a bodyless response for null-body status %i without crashing', async (status) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
     "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["extensions", "tests"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    // Host-env quarantine + per-test env snapshot: the suite runs inside
+    // Claude Code / pi subagents whose env carries variables the source reads.
+    setupFiles: ['tests/setup.ts'],
     coverage: {
       provider: 'v8',
       // lcov feeds SonarQube (see .github/workflows/pr-check.yaml); text is for local runs.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,12 +5,22 @@ export default defineConfig({
     // Host-env quarantine + per-test env snapshot: the suite runs inside
     // Claude Code / pi subagents whose env carries variables the source reads.
     setupFiles: ['tests/setup.ts'],
+    // Mock hygiene is enforced globally so no test depends on a neighbor's spies
+    // or stubbed env surviving; shuffle probes order-independence with a fresh
+    // seed on every run.
+    restoreMocks: true,
+    mockReset: true,
+    unstubEnvs: true,
+    sequence: { shuffle: true },
     coverage: {
       provider: 'v8',
       // lcov feeds SonarQube (see .github/workflows/pr-check.yaml); text is for local runs.
       reporter: ['text', 'lcov'],
       include: ['extensions/**/*.ts'],
       exclude: ['tests/**'],
+      // A floor, not a ratchet: fails the run if coverage regresses below today's
+      // levels (96.2/89.9/95.1/97.8 at adoption).
+      thresholds: { statements: 96, branches: 89, functions: 94, lines: 97 },
     },
   },
 })


### PR DESCRIPTION
## What

Test-infrastructure hardening, first batch of the QA campaign. No behavior change to the shipped extensions beyond one additive test seam.

- **Global setup (`tests/setup.ts`)**: deletes the known host-leak env set (CLAUDECODE, CLAUDE_CONFIG_DIR, PI_CODE_SUBAGENT, the MCP timeout family, terminal markers) at load and before each test, and snapshot/restores `process.env` around every test. Before this, a host env carrying `CLAUDE_CONFIG_DIR` broke 44+ tests, `PI_CODE_SUBAGENT` 16, and `MCP_TOOL_TIMEOUT` 9 plus an unhandled rejection.
- **Temp-dir funnel**: `TMPDIR`/`TEMP`/`TMP` point at a per-file root removed in `afterAll`; all 158 `mkdtempSync` sites (cleanup previously in 13 of 29 files) now clean up mechanically.
- **vitest config**: `restoreMocks`, `mockReset`, `unstubEnvs`, `sequence.shuffle` (fresh seed per run), and coverage floors (96/89/94/97). The threshold gate is verified live: branches at 95 fails the run with exit 1.
- **tsc**: `noImplicitOverride` + `noFallthroughCasesInSwitch` (zero errors on the tree; fallthrough verified to fire).
- **biome**: `noFloatingPromises`, `noMisusedPromises`, `useExhaustiveSwitchCases` (zero findings; floating-promise verified to fire). `noUnnecessaryConditions` was evaluated and rejected: its type inference flags the as-then-validate runtime guards on untrusted bus/JSON payloads, which are load-bearing.
- **web-transport refusal test**: bind-then-closed port + `ECONNREFUSED` assertion instead of a portless URL dialing :80 with a bare `rejects.toThrow()` (mutation-checked against an ENOTFOUND-shaped failure).
- **background-run registry**: per-test reset seam; the eviction assertion tightens from `<= 20` to exactly `MAX_FINISHED_RUNS`.
- **mcp-more connect-flow poll**: `vi.waitFor` with a 10s starved-runner budget.

## Verification

- `npm run check` green, and green again under a maximally hostile env (`CLAUDECODE=1 CLAUDE_CONFIG_DIR=/nonexistent PI_CODE_SUBAGENT=1 MCP_TOOL_TIMEOUT=1234567`).
- Two full-suite runs under different shuffle seeds.
- Settings-watch flake re-verified fixed on current code: 30 serial + 5 concurrent-under-CPU-load runs, zero failures (the 2/100 CI failures predate the content-comparison watcher #170).
- Heaviest temp-litter files leave zero directories behind.
- Full e2e run against the branch before merge.