### PR TITLE
Fix two test-order dependences exposed by the shuffled gate

### DIFF
--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -177,6 +177,10 @@ const setupExtension = () => {
   const notes: Array<{ msg: string; level: string }> = []
   const defaultCtx = {
     ui: { notify: (msg: string, level: string) => notes.push({ msg, level }) },
+    // Without this capability the first sessionStart in the file emits the
+    // once-per-module runtime-too-old warning into whichever test happens to run
+    // first, making every notes[N] index order-dependent under shuffle.
+    isProjectTrusted: () => false,
     cwd: '/proj',
     thinkingLevel: 'high',
     sessionManager: { getSessionId: () => 'sess-1', getSessionFile: () => '/tmp/sess-1.jsonl' },

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -766,6 +766,13 @@ describe('finished-run eviction', () => {
 })
 
 describe('agent skills preload', () => {
+  // Without this, fakeHome.path holds whatever an earlier describe left (or ''
+  // before any set it, when join('', '.claude', ...) resolves against the repo
+  // checkout and the fixtures leak into the real working tree).
+  beforeEach(() => {
+    fakeHome.path = mkdtempSync(join(tmpdir(), 'preload-home-'))
+  })
+
   it('parses a skills list and appends the named skill bodies to the prompt', () => {
     const skillsRoot = join(fakeHome.path, '.claude', 'skills')
     mkdirSync(join(skillsRoot, 'deploy'), { recursive: true })


### PR DESCRIPTION
## What

The first release gate run with sequence shuffling enabled (from #177) failed on a real order dependence, and surfaced a second, worse one:

- **hooks-more notes indexing**: the harness ctx lacked `isProjectTrusted`, so the once-per-module runtime-too-old warning landed in whichever test ran first, shifting `notes[0]`. The harness now supplies `isProjectTrusted: () => false` (the same unapproved outcome every test was written against, minus the notice). Red was reproduced deterministically with the failing seed 1788325214147; the file and the full suite are green under that seed and two others.
- **skills-preload fixture leak**: the `agent skills preload` describe never set `fakeHome.path`; when it ran before any describe that assigns it, `join('', '.claude', ...)` resolved against the repository checkout and wrote `.claude/skills/deploy`, `.claude/skills/nested`, and `.claude/secret.md` into the real working tree, which a live pi session then loaded as actual skills. The describe now creates its own temp home per test.

## Verification

Full suite green under seeds 1788325214147, 7, and 999983; `npm run check` green; no `.claude/` appears in the working tree after the run.