### PR TITLE
Pin the unpinned guards: oracle and coverage batch

### DIFF
--- a/tests/bash-rules.test.ts
+++ b/tests/bash-rules.test.ts
@@ -38,6 +38,9 @@ describe('matchesBashRules', () => {
   it('fails closed on substitution, which can hide any command', () => {
     expect(matchesBashRules('git add $(rm -rf /)', ['git add:*'])).toBe(false)
     expect(matchesBashRules('git add `id`', ['git add:*'])).toBe(false)
+    // Process substitution runs the inner command too, in both directions.
+    expect(matchesBashRules('git add <(id)', ['git add:*'])).toBe(false)
+    expect(matchesBashRules('git add >(id)', ['git add:*'])).toBe(false)
   })
 
   it('fails closed on an unbalanced quote and on an empty command', () => {

--- a/tests/command-parse.test.ts
+++ b/tests/command-parse.test.ts
@@ -249,6 +249,10 @@ describe('substituteArgs', () => {
     expect(substituteArgs('first: $0, second: $1', 'a b')).toBe('first: a, second: b')
     expect(substituteArgs('indexed: $ARGUMENTS[1]', 'a b')).toBe('indexed: b')
     expect(substituteArgs('missing: ${2:-none}', 'a')).toBe('missing: none')
+    // The default forms both ways: the present value wins, the default fills.
+    expect(substituteArgs('have: ${1:-none}', 'a b')).toBe('have: b')
+    expect(substituteArgs('all: ${ARGUMENTS:-nothing given}', '')).toBe('all: nothing given')
+    expect(substituteArgs('all: ${ARGUMENTS:-nothing given}', 'x y')).toBe('all: x y')
     // Claude leaves an indexed placeholder with no matching argument in place unchanged.
     expect(substituteArgs('bare: $3', 'a')).toBe('bare: $3')
     expect(substituteArgs('bare: $ARGUMENTS[3]', 'a')).toBe('bare: $ARGUMENTS[3]')

--- a/tests/hooks-claude-tools.test.ts
+++ b/tests/hooks-claude-tools.test.ts
@@ -40,6 +40,11 @@ describe('claudeToolInput', () => {
   it('maps grep ignoreCase to the documented -i flag', () => {
     expect(claudeToolInput('grep', { pattern: 'todo', ignoreCase: true }, '/proj')).toEqual({ pattern: 'todo', '-i': true })
   })
+
+  it('maps pi find input to the documented Glob fields, resolving the path', () => {
+    expect(claudeToolInput('find', { pattern: '*.ts', path: 'src' }, '/proj')).toEqual({ pattern: '*.ts', path: '/proj/src' })
+    expect(claudeToolInput('find', { pattern: '*.ts' }, '/proj')).toEqual({ pattern: '*.ts' })
+  })
 })
 
 describe('piToolInput', () => {
@@ -53,6 +58,15 @@ describe('piToolInput', () => {
     expect(piToolInput('bash', { description: 'no command' })).toBeUndefined()
     expect(piToolInput('edit', { file_path: '/p/a.ts' })).toBeUndefined()
     expect(piToolInput('write', { file_path: '/p/a.ts' })).toBeUndefined()
+  })
+
+  it('converts read, grep and glob rewrites, which had no executions at all', () => {
+    expect(piToolInput('read', { file_path: '/p/a.ts', offset: 5, limit: 10 })).toEqual({ path: '/p/a.ts', offset: 5, limit: 10 })
+    expect(piToolInput('read', { offset: 5 })).toBeUndefined()
+    expect(piToolInput('grep', { pattern: 'todo', path: '/p', '-i': true })).toEqual({ pattern: 'todo', path: '/p', ignoreCase: true })
+    expect(piToolInput('grep', { path: '/p' })).toBeUndefined()
+    expect(piToolInput('find', { pattern: '*.ts', path: '/p' })).toEqual({ pattern: '*.ts', path: '/p' })
+    expect(piToolInput('find', { path: '/p' })).toBeUndefined()
   })
 })
 

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -2578,3 +2578,35 @@ describe('mcp_tool hook dispatch', () => {
     expect(await ext.toolCall('bash', { command: 'ls' })).toBeUndefined()
   })
 })
+
+describe('prompt hook model override', () => {
+  afterEach(() => setCompleteBackend(null))
+
+  const answer = { role: 'assistant', content: [{ type: 'text', text: '{"hookSpecificOutput":{"permissionDecision":"allow"}}' }], api: 'x', provider: 'x', model: 'm', usage: {}, stopReason: 'stop', timestamp: 0 }
+
+  const runWith = async (override: string | undefined, available: Array<{ id: string; name?: string }>) => {
+    const seen: string[] = []
+    setCompleteBackend(async (model) => {
+      seen.push((model as { id: string }).id)
+      return answer as never
+    })
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'prompt', prompt: 'ok? $ARGUMENTS', ...(override === undefined ? {} : { model: override }) }] }] })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.toolCall('bash', { command: 'ls' }, 't1', { model: { id: 'session-model' }, modelRegistry: { getAvailable: () => available } })
+    return seen
+  }
+
+  it('resolves an exact model id from the registry', async () => {
+    expect(await runWith('guard-9', [{ id: 'big-1' }, { id: 'guard-9' }])).toEqual(['guard-9'])
+  })
+
+  it('falls back to a substring match on id or display name', async () => {
+    expect(await runWith('haiku', [{ id: 'big-1' }, { id: 'small-haiku-2', name: 'Small Haiku' }])).toEqual(['small-haiku-2'])
+  })
+
+  it('uses the session model when the override matches nothing or is absent', async () => {
+    expect(await runWith('nope', [{ id: 'big-1' }])).toEqual(['session-model'])
+    expect(await runWith(undefined, [{ id: 'big-1' }])).toEqual(['session-model'])
+  })
+})

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import contextImports from '../extensions/context-imports.ts'
 import hooksExtension, { type HookRunner, interpretHookResult, isBackgroundHook, loadHooks, matchingCommands, runHookCommand, runPreToolUse, runPromptHook, runUserPromptSubmit, sessionEndTimeoutMs, timeoutMs } from '../extensions/hooks/index.ts'
 import { setManagedSettingsPath } from '../extensions/internal/managed-settings.ts'
+import { setMcpToolCaller } from '../extensions/internal/mcp-call.ts'
 import { setCompleteBackend } from '../extensions/internal/model-complete.ts'
 
 /**
@@ -2543,5 +2544,37 @@ describe('settings watching', () => {
     } finally {
       delete process.env.PI_CODE_SETTINGS_WATCH_INTERVAL_MS
     }
+  })
+})
+
+describe('mcp_tool hook dispatch', () => {
+  afterEach(() => setMcpToolCaller(undefined))
+
+  it('routes a configured mcp_tool hook through the dispatcher to the caller seam', async () => {
+    // The type === 'mcp_tool' dispatch arm had no end-to-end path: config ->
+    // matcher -> boundRunner -> runMcpToolHook -> the seam, with the tool's
+    // verdict feeding the decision like any command hook's stdout.
+    const calls: Array<[string, string, Record<string, unknown>]> = []
+    setMcpToolCaller(async (server, tool, input) => {
+      calls.push([server, tool, input])
+      return { text: JSON.stringify({ decision: 'block', reason: 'mcp guard says no' }), isError: false }
+    })
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'mcp_tool', server: 'guard-srv', tool: 'vet', input: { command: '${tool_input.command}' } }] }] })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    const decision = (await ext.toolCall('bash', { command: 'rm -rf /' })) as { block: boolean; reason?: string }
+
+    expect(calls).toEqual([['guard-srv', 'vet', { command: 'rm -rf /' }]])
+    expect(decision?.block).toBe(true)
+    expect(decision?.reason).toContain('mcp guard says no')
+  })
+
+  it('lets the tool proceed when the mcp_tool hook returns no verdict', async () => {
+    setMcpToolCaller(async () => ({ text: 'all fine', isError: false }))
+    writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'mcp_tool', server: 'guard-srv', tool: 'vet' }] }] })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+
+    expect(await ext.toolCall('bash', { command: 'ls' })).toBeUndefined()
   })
 })

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -1964,6 +1964,18 @@ describe('hook spawn failures', () => {
     expect(decision.context).toBe('')
   })
 
+  it('fails closed on a timed-out UserPromptSubmit hook, like PreToolUse does', async () => {
+    // A gate that delivered no verdict must not read as an allow; the timeout
+    // direction was only pinned for PreToolUse.
+    const runner: HookRunner = async () => ({ code: 0, stdout: '', stderr: '', timedOut: true })
+    const config = { UserPromptSubmit: [{ hooks: [{ command: 'audit.sh' }] }] }
+    const decision = await runUserPromptSubmit(config, 'hello', runner)
+    expect(decision.block).toBe(true)
+    expect(decision.reason).toContain('timed out')
+    expect(decision.reason).toContain('audit.sh')
+    expect(decision.context).toBe('')
+  })
+
   it('blocks the tool end to end when the hook process errors before spawning', async () => {
     writeSettings(hoisted.home, 'settings.json', { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'guard' }] }] })
     script('guard', { error: new Error('spawn /bin/sh ENOENT') })

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -994,6 +994,17 @@ describe('hooks extension tool_result (PostToolUse)', () => {
     expect(patched?.content.map((c) => c.text)).toEqual(['boom', 'the network was down'])
   })
 
+  it('ignores a decision-block verdict on a failed tool: only its context lands', async () => {
+    // "A failed tool cannot be blocked": the exit-0 decision:block spelling must
+    // not surface a block notice on a failure, while additionalContext still does.
+    writeSettings(hoisted.home, 'settings.json', { PostToolUseFailure: [{ matcher: 'Bash', hooks: [{ command: 'judge' }] }] })
+    script('judge', { stdout: [JSON.stringify({ decision: 'block', reason: 'retry it', hookSpecificOutput: { additionalContext: 'the network was down' } })], code: 0 })
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    const patched = (await ext.toolResult('bash', { input: { command: 'x' }, content: [{ type: 'text', text: 'boom' }], isError: true })) as { content: Array<{ text: string }> } | undefined
+    expect(patched?.content.map((c) => c.text)).toEqual(['boom', 'the network was down'])
+  })
+
   it('appends a PostToolUseFailure hook stderr (exit 2) to the failed result', async () => {
     writeSettings(hoisted.home, 'settings.json', { PostToolUseFailure: [{ matcher: 'Bash', hooks: [{ command: 'diag' }] }] })
     script('diag', { stderr: ['check your credentials'], code: 2 })

--- a/tests/if-filter.test.ts
+++ b/tests/if-filter.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HookCommand } from '../extensions/hooks/config.ts'
+import { type IfFilterTarget, passesIfFilter } from '../extensions/hooks/matcher.ts'
+
+// Fixed anchors so every expectation is hand-derivable: rules resolve against
+// cwd, /-rules against the project root, ~-rules against home.
+const anchors = { cwd: '/proj/sub', projectRoot: '/proj', home: '/home/u' }
+
+const hookIf = (rule?: string): HookCommand => ({ command: 'x', ...(rule === undefined ? {} : { if: rule }) }) as HookCommand
+
+const target = (piName: string, input: unknown, claudeName?: string): IfFilterTarget => ({ piName, input, anchors, ...(claudeName === undefined ? {} : { claudeName }) })
+
+describe('passesIfFilter', () => {
+  it('always passes a hook without an if rule', () => {
+    expect(passesIfFilter(hookIf(), target('edit', {}))).toBe(true)
+    expect(passesIfFilter(hookIf(), undefined)).toBe(true)
+  })
+
+  it('matches a bare tool name case- and dash-insensitively', () => {
+    expect(passesIfFilter(hookIf('Edit'), target('edit', {}))).toBe(true)
+    expect(passesIfFilter(hookIf('Edit'), target('read', {}))).toBe(false)
+  })
+
+  it('matches any alternative of a | rule', () => {
+    expect(passesIfFilter(hookIf('Edit|Write'), target('write', {}))).toBe(true)
+    expect(passesIfFilter(hookIf('Edit|Write'), target('read', {}))).toBe(false)
+  })
+
+  it('matches via the claude-side tool name too', () => {
+    expect(passesIfFilter(hookIf('Glob'), target('find', {}, 'Glob'))).toBe(true)
+    expect(passesIfFilter(hookIf('Grep'), target('find', {}, 'Glob'))).toBe(false)
+  })
+
+  it('evaluates a Bash pattern against the command', () => {
+    expect(passesIfFilter(hookIf('Bash(git *)'), target('bash', { command: 'git status' }))).toBe(true)
+    expect(passesIfFilter(hookIf('Bash(git *)'), target('bash', { command: 'npm install' }))).toBe(false)
+  })
+
+  it('refuses a Bash pattern when the input carries no command', () => {
+    expect(passesIfFilter(hookIf('Bash(git *)'), target('bash', {}))).toBe(false)
+  })
+
+  it('evaluates a file-tool pattern against the path input, resolved from cwd', () => {
+    expect(passesIfFilter(hookIf('Edit(docs/**)'), target('edit', { path: '/proj/sub/docs/a.md' }))).toBe(true)
+    expect(passesIfFilter(hookIf('Edit(docs/**)'), target('edit', { path: 'docs/a.md' }))).toBe(true)
+    expect(passesIfFilter(hookIf('Edit(docs/**)'), target('edit', { path: '/proj/sub/src/a.md' }))).toBe(false)
+  })
+
+  it('reads the claude-shaped file_path input key as well', () => {
+    expect(passesIfFilter(hookIf('Write(docs/**)'), target('write', { file_path: '/proj/sub/docs/a.md' }))).toBe(true)
+  })
+
+  it('anchors a /-rule at the project root and a ~-rule at home', () => {
+    expect(passesIfFilter(hookIf('Edit(/docs/**)'), target('edit', { path: '/proj/docs/a.md' }))).toBe(true)
+    expect(passesIfFilter(hookIf('Edit(/docs/**)'), target('edit', { path: '/proj/sub/docs/a.md' }))).toBe(false)
+    expect(passesIfFilter(hookIf('Edit(~/notes/**)'), target('edit', { path: '/home/u/notes/n.md' }))).toBe(true)
+  })
+
+  it('refuses a file-tool pattern when the input carries no path', () => {
+    expect(passesIfFilter(hookIf('Edit(docs/**)'), target('edit', {}))).toBe(false)
+    // The discriminating case: an empty path resolves to cwd, so a rule that
+    // matches cwd itself must still refuse pathless input rather than fire.
+    expect(passesIfFilter(hookIf('Edit(/sub)'), target('edit', {}))).toBe(false)
+    expect(passesIfFilter(hookIf('Edit(/sub)'), target('edit', { path: '/proj/sub' }))).toBe(true)
+  })
+
+  it('matches nothing on an empty pattern, staying closed rather than open', () => {
+    expect(passesIfFilter(hookIf('Edit()'), target('edit', { path: '/proj/sub/docs/a.md' }))).toBe(false)
+  })
+
+  it('matches nothing on an unparseable rule', () => {
+    expect(passesIfFilter(hookIf('Edit(docs/**'), target('edit', { path: '/proj/sub/docs/a.md' }))).toBe(false)
+    expect(passesIfFilter(hookIf('Edit)('), target('edit', { path: '/proj/sub/docs/a.md' }))).toBe(false)
+  })
+})

--- a/tests/mcp-listing.test.ts
+++ b/tests/mcp-listing.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { collectServerResourceEntries } from '../extensions/mcp/listing.ts'
+
+type Resources = Array<{ uri: string; name: string }>
+const clientOf = (resources: () => Promise<{ resources: Resources }>, templates: () => Promise<{ resourceTemplates: Array<{ uriTemplate: string; name: string }> }>): Client => ({ listResources: resources, listResourceTemplates: templates }) as unknown as Client
+
+const emptyTemplates = async () => ({ resourceTemplates: [] })
+
+describe('collectServerResourceEntries', () => {
+  it('records a listing failure inline so one server cannot empty the whole listing', async () => {
+    const entries: Array<Record<string, unknown>> = []
+    await collectServerResourceEntries(
+      entries,
+      'bad',
+      clientOf(async () => {
+        throw new Error('boom')
+      }, emptyTemplates),
+      1000,
+    )
+    await collectServerResourceEntries(
+      entries,
+      'good',
+      clientOf(async () => ({ resources: [{ uri: 'x://a', name: 'A' }] }), emptyTemplates),
+      1000,
+    )
+    expect(entries).toEqual([
+      { server: 'bad', error: 'boom' },
+      { server: 'good', uri: 'x://a', name: 'A' },
+    ])
+  })
+
+  it('keeps the entries collected before a mid-pagination failure', async () => {
+    const entries: Array<Record<string, unknown>> = []
+    let page = 0
+    await collectServerResourceEntries(
+      entries,
+      'flaky',
+      clientOf(async () => {
+        page += 1
+        if (page === 1) return { resources: [{ uri: 'x://first', name: 'First' }], nextCursor: 'more' } as { resources: Resources }
+        throw new Error('page 2 died')
+      }, emptyTemplates),
+      1000,
+    )
+    expect(entries).toEqual([
+      { server: 'flaky', uri: 'x://first', name: 'First' },
+      { server: 'flaky', error: 'page 2 died' },
+    ])
+  })
+
+  it('stays silent when only the optional template listing fails', async () => {
+    const entries: Array<Record<string, unknown>> = []
+    await collectServerResourceEntries(
+      entries,
+      's',
+      clientOf(async () => ({ resources: [] }), async () => {
+        throw new Error('method not found')
+      }),
+      1000,
+    )
+    expect(entries).toEqual([])
+  })
+})

--- a/tests/mcp-listing.test.ts
+++ b/tests/mcp-listing.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from 'vitest'
-
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { describe, expect, it } from 'vitest'
 import { collectServerResourceEntries } from '../extensions/mcp/listing.ts'
 
 type Resources = Array<{ uri: string; name: string }>
@@ -55,9 +54,12 @@ describe('collectServerResourceEntries', () => {
     await collectServerResourceEntries(
       entries,
       's',
-      clientOf(async () => ({ resources: [] }), async () => {
-        throw new Error('method not found')
-      }),
+      clientOf(
+        async () => ({ resources: [] }),
+        async () => {
+          throw new Error('method not found')
+        },
+      ),
       1000,
     )
     expect(entries).toEqual([])

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2551,7 +2551,12 @@ describe('the registered mcp_tool caller (cross-extension joint)', () => {
     await setupStarted({ user: { db: { command: 'db-server' } } })
     hoisted.control.callTool = async (params: Record<string, unknown>) => {
       calls.push(params)
-      return { content: [{ type: 'text', text: 'row 1' }, { type: 'text', text: 'row 2' }] }
+      return {
+        content: [
+          { type: 'text', text: 'row 1' },
+          { type: 'text', text: 'row 2' },
+        ],
+      }
     }
 
     await expect(callMcpTool('db', 'query', { sql: 'select 1' })).resolves.toEqual({ text: 'row 1\nrow 2', isError: false })

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2541,3 +2541,35 @@ describe('mcp resource mentions', () => {
     expect(await harness.input('email me @nosuch:thing please')).toBeUndefined()
   })
 })
+
+describe('the registered mcp_tool caller (cross-extension joint)', () => {
+  // Both halves of the seam were green against stubs while the real registered
+  // callback had zero executions; these pin the joint with only the SDK client faked.
+  it('serves callMcpTool through the real callback: config lookup, text mapping, isError', async () => {
+    const { callMcpTool } = await import('../extensions/internal/mcp-call.ts')
+    const calls: Array<Record<string, unknown>> = []
+    await setupStarted({ user: { db: { command: 'db-server' } } })
+    hoisted.control.callTool = async (params: Record<string, unknown>) => {
+      calls.push(params)
+      return { content: [{ type: 'text', text: 'row 1' }, { type: 'text', text: 'row 2' }] }
+    }
+
+    await expect(callMcpTool('db', 'query', { sql: 'select 1' })).resolves.toEqual({ text: 'row 1\nrow 2', isError: false })
+    expect(calls[0]).toMatchObject({ name: 'query', arguments: { sql: 'select 1' } })
+  })
+
+  it('maps a server-reported tool error to isError true', async () => {
+    const { callMcpTool } = await import('../extensions/internal/mcp-call.ts')
+    await setupStarted({ user: { db: { command: 'db-server' } } })
+    hoisted.control.callTool = async () => ({ content: [{ type: 'text', text: 'no such table' }], isError: true })
+
+    await expect(callMcpTool('db', 'query', {})).resolves.toEqual({ text: 'no such table', isError: true })
+  })
+
+  it('rejects for a server name that is not connected', async () => {
+    const { callMcpTool } = await import('../extensions/internal/mcp-call.ts')
+    await setupStarted({ user: { db: { command: 'db-server' } } })
+
+    await expect(callMcpTool('nosuch', 'query', {})).rejects.toThrow('not connected')
+  })
+})

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -238,7 +238,14 @@ describe('runInteractiveOAuth failure typing', () => {
       close: async () => {},
     }
     const transport = { finishAuth: async () => {} }
-    return runInteractiveOAuth('srv', { url: 'https://mcp.example/' }, () => transport as never, 'connect srv', authUi as never, () => client as never)
+    return runInteractiveOAuth(
+      'srv',
+      { url: 'https://mcp.example/' },
+      () => transport as never,
+      'connect srv',
+      authUi as never,
+      () => client as never,
+    )
   }
 
   it('types a declined consent as OAuthRequiredError without opening anything', async () => {
@@ -259,8 +266,11 @@ describe('runInteractiveOAuth failure typing', () => {
       connect: async () => {
         throw Object.assign(new Error('boom mid-flow'), { code: 500 })
       },
-    }).catch((e: Error) => e)
-    expect(error.message).toBe('login for srv failed: boom mid-flow')
+    }).then(
+      () => undefined,
+      (e: Error) => e,
+    )
+    expect(error?.message).toBe('login for srv failed: boom mid-flow')
   })
 
   it('returns the client when the retry connects clean (authorized between attempts)', async () => {

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -221,3 +221,69 @@ describe('openBrowser', () => {
     expect(spawnMock.calls).toHaveLength(1)
   })
 })
+
+describe('runInteractiveOAuth failure typing', () => {
+  // The typed OAuthRequiredError is what keeps the typeless-url caller from
+  // retrying an auth failure over SSE and stacking a second login prompt; the
+  // whole failure half of the flow had zero executions.
+  const flow = async (over: { approve?: boolean; connect?: (attempt: number) => Promise<void> } = {}) => {
+    const { runInteractiveOAuth } = await import('../extensions/mcp/oauth-flow.ts')
+    const authUi = { confirm: async () => over.approve !== false, notify: () => {} }
+    let attempts = 0
+    const client = {
+      connect: async () => {
+        attempts += 1
+        await over.connect?.(attempts)
+      },
+      close: async () => {},
+    }
+    const transport = { finishAuth: async () => {} }
+    return runInteractiveOAuth('srv', { url: 'https://mcp.example/' }, () => transport as never, 'connect srv', authUi as never, () => client as never)
+  }
+
+  it('types a declined consent as OAuthRequiredError without opening anything', async () => {
+    const { OAuthRequiredError } = await import('../extensions/mcp/transport.ts')
+    await expect(flow({ approve: false })).rejects.toBeInstanceOf(OAuthRequiredError)
+    await expect(flow({ approve: false })).rejects.toThrow('login declined for srv')
+  })
+
+  it('wraps a non-auth flow failure as OAuthRequiredError with the detail', async () => {
+    const { OAuthRequiredError } = await import('../extensions/mcp/transport.ts')
+    const failing = flow({
+      connect: async () => {
+        throw Object.assign(new Error('boom mid-flow'), { code: 500 })
+      },
+    })
+    await expect(failing).rejects.toBeInstanceOf(OAuthRequiredError)
+    const error = await flow({
+      connect: async () => {
+        throw Object.assign(new Error('boom mid-flow'), { code: 500 })
+      },
+    }).catch((e: Error) => e)
+    expect(error.message).toBe('login for srv failed: boom mid-flow')
+  })
+
+  it('returns the client when the retry connects clean (authorized between attempts)', async () => {
+    await expect(flow()).resolves.toBeDefined()
+  })
+})
+
+describe('headless OAuth refusal', () => {
+  it('reports a typed run-pi-interactively error for a 401 server with no UI', async () => {
+    const { createServer } = await import('node:http')
+    const server = createServer((_req, res) => {
+      res.writeHead(401, { 'content-type': 'text/plain' })
+      res.end('unauthorized')
+    })
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
+    const port = (server.address() as { port: number }).port
+    try {
+      const { connect, OAuthRequiredError } = await import('../extensions/mcp/transport.ts')
+      const failing = connect('locked', { type: 'http', url: `http://127.0.0.1:${port}/` } as never)
+      await expect(failing).rejects.toBeInstanceOf(OAuthRequiredError)
+      await expect(connect('locked', { type: 'http', url: `http://127.0.0.1:${port}/` } as never)).rejects.toThrow('run pi interactively')
+    } finally {
+      server.close()
+    }
+  })
+})

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -517,3 +517,43 @@ describe('plugin server substitution safety', () => {
     expect((servers.beta as { command: string }).command).toBe('b-srv')
   })
 })
+
+describe('connect misconfiguration diagnostics', () => {
+  // Each connect attempt targets something that fails fast; the diagnostic must
+  // land before the failure so a misconfigured server never dies silently.
+  const spyWarn = () => vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  it('warns about an undefined ${VAR} reference instead of failing with a mystery', async () => {
+    const { connect } = await import('../extensions/mcp/transport.ts')
+    const warn = spyWarn()
+    try {
+      await expect(connect('s', { command: '/nonexistent-mcp-${PI_CODE_TEST_UNSET_VAR}' } as never)).rejects.toThrow()
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('undefined variable'))
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('PI_CODE_TEST_UNSET_VAR'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('warns that configured auth is ignored on a WebSocket server', async () => {
+    const { connect } = await import('../extensions/mcp/transport.ts')
+    const warn = spyWarn()
+    try {
+      await expect(connect('w', { type: 'ws', url: 'ws://127.0.0.1:1/', headers: { Authorization: 'Bearer x' } } as never)).rejects.toThrow()
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('headers/bearerToken/headersHelper are ignored'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('warns that oauth.authServerMetadataUrl cannot override SDK discovery', async () => {
+    const { connect } = await import('../extensions/mcp/transport.ts')
+    const warn = spyWarn()
+    try {
+      await expect(connect('h', { type: 'http', url: 'http://127.0.0.1:1/', oauth: { authServerMetadataUrl: 'http://127.0.0.1:1/meta' } } as never)).rejects.toThrow()
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('standard discovery'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -101,6 +101,16 @@ describe('installedPlugins', () => {
     expect(installedPlugins(h)[0].userConfig).toEqual({ api_token: 'tok-1' })
   })
 
+  it('coerces number and boolean option values to strings and drops the rest', () => {
+    // ${user_config.KEY} substitutes into command strings, so scalars must
+    // arrive as text and structured values must not arrive at all.
+    const h = home()
+    install(h, 'community', 'formatter', '1.0.0')
+    mkdirSync(join(h, '.claude'), { recursive: true })
+    writeFileSync(join(h, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { formatter: true }, pluginConfigs: { formatter: { options: { retries: 3, verbose: true, name: 'x', nested: { no: 1 }, list: [1] } } } }))
+    expect(installedPlugins(h)[0].userConfig).toEqual({ retries: '3', verbose: 'true', name: 'x' })
+  })
+
   it('lets a later user settings file toggle a plugin off, project files never counted', () => {
     const h = home()
     install(h, 'community', 'formatter', '1.0.0')

--- a/tests/shell-split.test.ts
+++ b/tests/shell-split.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasSubstitution, splitSegments } from '../extensions/internal/shell-split.ts'
+
+describe('splitSegments', () => {
+  it('splits on each documented separator', () => {
+    expect(splitSegments('a && b')).toEqual(['a', 'b'])
+    expect(splitSegments('a || b')).toEqual(['a', 'b'])
+    expect(splitSegments('a; b')).toEqual(['a', 'b'])
+    expect(splitSegments('a | b')).toEqual(['a', 'b'])
+    expect(splitSegments('a |& b')).toEqual(['a', 'b'])
+    expect(splitSegments('a & b')).toEqual(['a', 'b'])
+    expect(splitSegments('a\nb')).toEqual(['a', 'b'])
+  })
+
+  it('keeps an escaped separator inside its segment', () => {
+    // find's \; is an argument, not a command boundary.
+    expect(splitSegments(String.raw`find . -exec rm {} \;`)).toEqual([String.raw`find . -exec rm {} \;`])
+  })
+
+  it('keeps quoted separators inside their segment', () => {
+    expect(splitSegments("grep 'a|b' f")).toEqual(["grep 'a|b' f"])
+    expect(splitSegments('echo "x && y"')).toEqual(['echo "x && y"'])
+  })
+
+  it('returns nothing on an unbalanced quote, failing the caller closed', () => {
+    expect(splitSegments("echo 'oops")).toEqual([])
+  })
+
+  it('drops empty segments left by doubled or trailing separators', () => {
+    expect(splitSegments('a &&  && b; ')).toEqual(['a', 'b'])
+  })
+})
+
+describe('hasSubstitution', () => {
+  it('flags every construct that can hide a command', () => {
+    expect(hasSubstitution('echo $(id)')).toBe(true)
+    expect(hasSubstitution('echo `id`')).toBe(true)
+    expect(hasSubstitution('diff <(id) x')).toBe(true)
+    expect(hasSubstitution('tee >(id)')).toBe(true)
+  })
+
+  it('passes ordinary commands, including plain variables', () => {
+    expect(hasSubstitution('echo $HOME')).toBe(false)
+    expect(hasSubstitution('git status')).toBe(false)
+  })
+})

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -281,6 +281,16 @@ describe('context: fork and skillOverrides', () => {
 
       const dirs = skillDirs(cwd, hoisted.home, true)
       expect(dirs[0]).toBe(join(managedDir, '.claude', 'skills'))
+
+      // The observable outcome, not the directory ordering: invoking the clashing
+      // name expands the enterprise body. Directory order alone would still pass
+      // if resolution flipped to last-match; the expansion cannot.
+      const handlers = new Map<string, (event: Record<string, unknown>, ctx: unknown) => Promise<unknown>>()
+      skillsExt({ on: (name: string, fn: never) => handlers.set(name, fn), exec: async () => ({ stdout: '', stderr: '', code: 0 }) } as never)
+      const result = (await handlers.get('input')?.({ text: '/skill:deploy', source: 'interactive' }, { cwd })) as { action: string; text: string }
+      expect(result?.action).toBe('transform')
+      expect(result.text).toContain('ENTERPRISE BODY')
+      expect(result.text).not.toContain('PERSONAL BODY')
     } finally {
       setManagedSettingsPath(undefined)
     }

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -1959,3 +1959,59 @@ describe('subagent context and hooks conformance', () => {
     expect(env.PI_CODE_AGENT_HOOKS).toBeUndefined()
   })
 })
+
+describe('execute dispatch: resume and cancel arms', () => {
+  // These arms of the tool never executed through execute(); only the text
+  // helpers were unit-tested, so a regression in the wiring (events, completion
+  // notification, registry calls) had no test to fail.
+  it('refuses a resume without a follow-up task before touching the registry', async () => {
+    const result = await execute('c1', { resume: 'bg-1' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toBe('Pass task with resume: the follow-up needs an instruction.')
+    expect(resumeBackgroundRunMock).not.toHaveBeenCalled()
+  })
+
+  it('resumes through the registry, emits the start phase, and notifies on completion', async () => {
+    resumeBackgroundRunMock.mockReturnValue('resumed')
+    backgroundRunMock.mockReturnValue({ id: 'bg-1', agent: 'scout', state: 'running', turns: 0 })
+
+    const result = await execute('c1', { resume: 'bg-1', task: 'continue the audit' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).toContain('Resumed background run bg-1')
+    expect(resumeBackgroundRunMock).toHaveBeenCalledWith('bg-1', 'continue the audit', expect.any(Function))
+    expect(emittedEvents).toContainEqual({ channel: 'pi-code:subagent', data: { phase: 'start', agentType: 'scout', agentId: 'bg-1' } })
+
+    // The completion callback handed to the registry is the wired notification
+    // path: it must emit the stop phase and wake the model with the outcome.
+    const onComplete = resumeBackgroundRunMock.mock.calls[0][2] as (run: unknown) => void
+    onComplete({ id: 'bg-1', agent: 'scout', state: 'done', turns: 2, output: 'all clear' })
+    expect(emittedEvents).toContainEqual({ channel: 'pi-code:subagent', data: { phase: 'stop', agentType: 'scout', agentId: 'bg-1' } })
+    expect(sendMessageMock).toHaveBeenCalledWith(expect.objectContaining({ customType: 'subagent-background' }), { triggerTurn: true })
+  })
+
+  it.each([
+    ['still-running', 'is still running'],
+    ['at-capacity', 'cap reached'],
+    ['cwd-gone', 'no longer exists'],
+    ['unknown', 'Unknown background run'],
+  ])('reports a %s resume outcome in the tool text', async (outcome, expected) => {
+    resumeBackgroundRunMock.mockReturnValue(outcome)
+    backgroundStatusTextMock.mockReturnValue('(no background runs)')
+
+    const result = await execute('c1', { resume: 'bg-9', task: 'again' }, undefined, undefined, trustedCtx)
+    expect(text(result)).toContain(expected)
+  })
+
+  it('cancels through the registry and reports each outcome', async () => {
+    cancelBackgroundRunMock.mockReturnValue('cancelled')
+    expect(text(await execute('c1', { cancel: 'bg-1' }, undefined, undefined, trustedCtx))).toBe('Cancelled background run bg-1.')
+    expect(cancelBackgroundRunMock).toHaveBeenCalledWith('bg-1')
+
+    cancelBackgroundRunMock.mockReturnValue('not-running')
+    expect(text(await execute('c1', { cancel: 'bg-1' }, undefined, undefined, trustedCtx))).toContain('already finished')
+
+    cancelBackgroundRunMock.mockReturnValue('unknown')
+    backgroundStatusTextMock.mockReturnValue('(no background runs)')
+    expect(text(await execute('c1', { cancel: 'bg-9' }, undefined, undefined, trustedCtx))).toContain('Unknown background run: bg-9')
+  })
+})

--- a/tests/subagent-worktree.test.ts
+++ b/tests/subagent-worktree.test.ts
@@ -56,7 +56,10 @@ describe('createAgentWorktree', () => {
     const origin = makeRepo()
     const clone = mkdtempSync(join(tmpdir(), 'wt-clone-'))
     execFileSync('git', ['clone', '--quiet', origin, clone], { env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' } })
-    const git = (...args: string[]) => execFileSync('git', args, { cwd: clone, env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' } }).toString().trim()
+    const git = (...args: string[]) =>
+      execFileSync('git', args, { cwd: clone, env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' } })
+        .toString()
+        .trim()
     const originMain = git('rev-parse', 'origin/main')
     git('config', 'user.email', 'test@test')
     git('config', 'user.name', 'test')

--- a/tests/subagent-worktree.test.ts
+++ b/tests/subagent-worktree.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -40,6 +40,34 @@ describe('createAgentWorktree', () => {
     const created = await createAgentWorktree(plain, 'x')
     expect('error' in created).toBe(true)
   })
+
+  it('reports the git failure when the worktree cannot be created', async () => {
+    // A repo with no commits has no default branch and no HEAD to branch from;
+    // the declared isolation boundary must fail the run, not silently drop.
+    const empty = mkdtempSync(join(tmpdir(), 'wt-empty-'))
+    execFileSync('git', ['init', '--initial-branch=main'], { cwd: empty })
+    const created = await createAgentWorktree(empty, 'x')
+    expect('error' in created).toBe(true)
+  })
+
+  it('branches from the default branch, not the parent checkout HEAD', async () => {
+    // Claude: the worktree starts from the repository's default branch. A clone
+    // has origin/HEAD; a commit on the local checkout must not become the base.
+    const origin = makeRepo()
+    const clone = mkdtempSync(join(tmpdir(), 'wt-clone-'))
+    execFileSync('git', ['clone', '--quiet', origin, clone], { env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' } })
+    const git = (...args: string[]) => execFileSync('git', args, { cwd: clone, env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' } }).toString().trim()
+    const originMain = git('rev-parse', 'origin/main')
+    git('config', 'user.email', 'test@test')
+    git('config', 'user.name', 'test')
+    writeFileSync(join(clone, 'local.txt'), 'ahead\n')
+    git('add', 'local.txt')
+    git('commit', '-m', 'local work')
+
+    const worktree = asWorktree(await createAgentWorktree(clone, 'based'))
+    expect(worktree.baseSha).toBe(originMain)
+    expect(worktree.baseSha).not.toBe(git('rev-parse', 'HEAD'))
+  })
 })
 
 describe('cleanupAgentWorktree', () => {
@@ -59,6 +87,28 @@ describe('cleanupAgentWorktree', () => {
     writeFileSync(join(worktree.dir, 'a.txt'), 'changed\n')
     expect(await cleanupAgentWorktree(repo, worktree)).toBe('kept')
     expect(existsSync(worktree.dir)).toBe(true)
+  })
+
+  it('keeps the worktree when the only changes are untracked files', async () => {
+    // The refactor trap: git diff --quiet would call this clean and delete an
+    // agent's freshly written output; git status --porcelain must count it.
+    const repo = makeRepo()
+    const worktree = asWorktree(await createAgentWorktree(repo, 'author'))
+    writeFileSync(join(worktree.dir, 'new-output.txt'), 'work\n')
+    expect(await cleanupAgentWorktree(repo, worktree)).toBe('kept')
+    expect(existsSync(worktree.dir)).toBe(true)
+  })
+
+  it('keeps rather than destroys when the cleanup inspection itself fails', async () => {
+    // Losing work is the only unacceptable outcome: a worktree dir that cannot
+    // be inspected (here: already gone) must resolve to kept, never to a delete
+    // of the branch that may still hold commits.
+    const repo = makeRepo()
+    const worktree = asWorktree(await createAgentWorktree(repo, 'ghost'))
+    rmSync(worktree.dir, { recursive: true, force: true })
+    expect(await cleanupAgentWorktree(repo, worktree)).toBe('kept')
+    const branches = execFileSync('git', ['branch', '--list'], { cwd: repo }).toString()
+    expect(branches).toContain(worktree.branch)
   })
 
   it('keeps the worktree when the agent committed past the base', async () => {


### PR DESCRIPTION
## What

QA campaign batch 2: twelve test-only additions closing the verified oracle and coverage gaps, each mutation-checked (mutant applied, new test fails, restore, green).

- `passesIfFilter` full grammar both ways: the file-tool path branch had zero executions despite gating which hooks run; new unit suite covers bare names, alternation, claude-side names, bash and file patterns on both input keys, cwd//-root/~ anchoring, empty/unparseable rules, and pathless refusal.
- Process substitution refusal in both directions for bash scopes: a mutant dropping `>(` from the substitution regex previously survived the whole suite, after which `git add >(sh)` would pass a `git add:*` scope.
- Worktree isolation contract: untracked-only changes keep the worktree, a failed cleanup inspection keeps it with its branch, an empty repo fails creation, and a clone branches from origin/HEAD, not the parent checkout's HEAD.
- Skills precedence pinned on the expanded body (enterprise wins the clash), not directory order.
- A failed tool's `decision: block` is suppressed while its additionalContext still lands.
- Direct unit contract for the trust-gated shell splitter, including escaped separators.
- MCP resource-listing error isolation: one broken server records `{server, error}` inline and cannot blank the whole listing; mid-pagination survivors kept.
- `${ARGUMENTS:-default}` and the present side of `${N:-default}`.
- A timed-out UserPromptSubmit hook fails closed, like PreToolUse.
- The read/grep/glob `updatedInput` rewrite mappers and the find-to-Glob input map (four functions with zero executions).
- Connect-time misconfiguration diagnostics (undefined `${VAR}`, WebSocket ignored auth, `authServerMetadataUrl` discovery).
- Plugin option scalar coercion for `${user_config.*}`.

Two equivalent mutants discovered and documented in commit messages: `git worktree remove` itself refuses a tree with untracked files (kept-ness is doubly guarded), and the splitter's two-char `|&` arm is observationally redundant under empty-segment dropping.

## Verification

`npm run check` green (1965 tests). Every new guard test was watched failing under its mutant. Full e2e runs before merge.