### PR TITLE
Give the mcp-more harness the project-trust capability

### DIFF
--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -260,7 +260,11 @@ const setup = async (opts: { user?: Record<string, unknown>; project?: Record<st
       notify: (message: string, level: string) => notifications.push({ message, level }),
       confirm: opts.confirm ?? (async () => approve),
     },
-    isProjectTrusted: trusted === undefined ? undefined : () => trusted,
+    // Always provide the capability: without it the first sessionStart in the
+    // file emits the once-per-module runtime-too-old warning into whichever
+    // test runs first, making notification assertions order-dependent under
+    // shuffle. The old-runtime path is tested in project-approval.test.ts.
+    isProjectTrusted: () => trusted === true,
     isIdle: () => idle,
   })
 


### PR DESCRIPTION
Second instance of the order-dependence class fixed in #178: the mcp-more harness ctx lacked `isProjectTrusted`, so the once-per-module runtime-too-old warning landed in whichever test ran first under shuffle, breaking notification assertions (caught by the 1.0.42 release gate at seed 1788327127770; red reproduced, green after). The old-runtime path stays covered by project-approval.test.ts, which resets modules per case. Six full-suite shuffled runs verified green.