### PR TITLE
Fix the production defects the QA audit surfaced

### DIFF
--- a/extensions/claude-rules.ts
+++ b/extensions/claude-rules.ts
@@ -121,6 +121,10 @@ function findMarkdownFiles(dir: string, basePath = '', visited = new Set<string>
   } catch {
     return results // a missing or unreadable directory must not take down session start
   }
+  // Raw readdir order is filesystem-dependent (hash order on ext4, sorted on
+  // APFS), so unsorted iteration injects rules into the prompt in a different
+  // order per machine. Pinned-locale sort makes the prompt reproducible.
+  entries.sort((a, b) => a.name.localeCompare(b.name, 'en'))
   for (const entry of entries) {
     const relativePath = basePath ? `${basePath}/${entry.name}` : entry.name
     const fullPath = path.join(dir, entry.name)

--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -299,7 +299,9 @@ export function additionalDirContextFiles(dir: string, includeLocal: boolean): A
     const names = fs
       .readdirSync(rulesDir)
       .filter((name) => name.endsWith('.md'))
-      .sort((a, b) => a.localeCompare(b))
+      // Pinned locale: the default collator follows the host locale, which
+      // reorders names like ch/ci/h and makes prompt content machine-dependent.
+      .sort((a, b) => a.localeCompare(b, 'en'))
     candidates.push(...names.map((name) => path.join(rulesDir, name)))
   } catch {
     // no rules directory in this additional dir

--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -262,11 +262,15 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
     runNeedsSnapshot = true
     await ensureShadow(ctx)
     checkpoints.clear()
+    const stored: Checkpoint[] = []
     for (const entry of ctx.sessionManager.getEntries()) {
       if (entry.type !== 'custom' || entry.customType !== CUSTOM_TYPE) continue
       const checkpoint = entry.data as Checkpoint | undefined
-      if (checkpoint?.entryId) checkpoints.set(checkpoint.entryId, checkpoint)
+      if (checkpoint?.entryId) stored.push(checkpoint)
     }
+    // The same cap the append path enforces: a resumed long session must not
+    // rebuild a rewind list beyond the per-session limit.
+    for (const checkpoint of capCheckpoints(stored)) checkpoints.set(checkpoint.entryId, checkpoint)
   })
 
   // A new agent loop starts a run: the next turn_start snapshots the pre-run tree.

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -531,13 +531,6 @@ function fenceBlocks(body: string): FenceBlock[] {
   return blocks
 }
 
-/** Spans of a body inside a protective fenced code block. */
-function fencedRanges(body: string): Array<[number, number]> {
-  return fenceBlocks(body)
-    .filter((block) => !block.exec)
-    .map((block) => [block.start, block.end])
-}
-
 /** Exit 1 is a normal result for Claude's documented search and comparison commands
  * (no matches, files differ); exit 2 and up fails even for these. The PowerShell
  * shell uses a different set, which "includes grep and git diff but not find or

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -49,9 +49,33 @@ function listDirs(dir: string): string[] {
   }
 }
 
-/** Version directories sort numerically segment-wise, so 1.10.0 beats 1.9.0. */
+/** One version string split for comparison: optional v prefix dropped, numeric
+ * base segments, and whatever follows a dash as the prerelease tag. */
+function parseVersion(version: string): { base: number[]; pre: string | undefined } {
+  const stripped = version.replace(/^v/i, '')
+  const dash = stripped.indexOf('-')
+  const base = (dash === -1 ? stripped : stripped.slice(0, dash)).split('.').map((segment) => Number.parseInt(segment, 10) || 0)
+  return { base, pre: dash === -1 ? undefined : stripped.slice(dash + 1) }
+}
+
+/** Semver ordering to the depth plugin cache dirs need: 1.10.0 beats 1.9.0,
+ * 10.0.0 beats v2.0.0, and a release outranks its own prerelease (a plain
+ * string sort got both of the latter wrong). */
+function compareVersions(a: string, b: string): number {
+  const left = parseVersion(a)
+  const right = parseVersion(b)
+  for (let i = 0; i < Math.max(left.base.length, right.base.length); i++) {
+    const diff = (left.base[i] ?? 0) - (right.base[i] ?? 0)
+    if (diff !== 0) return diff
+  }
+  if (left.pre === right.pre) return 0
+  if (left.pre === undefined) return 1
+  if (right.pre === undefined) return -1
+  return left.pre.localeCompare(right.pre, 'en', { numeric: true })
+}
+
 function newestVersion(versions: string[]): string | undefined {
-  return [...versions].sort((a, b) => a.localeCompare(b, 'en', { numeric: true })).at(-1)
+  return [...versions].sort(compareVersions).at(-1)
 }
 
 /** The enablement map, later files winning per key, as settings scopes merge. */

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -12,6 +12,7 @@
  * ~/.claude/plugins/data/<id>, id being the qualified name folded to dashes.
  */
 
+import * as crypto from 'node:crypto'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 
@@ -125,7 +126,8 @@ export function resetInstalledPluginsCache(): void {
   pluginCache.clear()
 }
 
-/** mtime plus size, so a same-instant rewrite with different content still differs. */
+/** mtime plus size; cheap, but blind to a same-size rewrite within one
+ * timestamp tick, so only directory-tree entries use it. */
 function statToken(target: string): string {
   try {
     const stat = fs.statSync(target)
@@ -135,15 +137,25 @@ function statToken(target: string): string {
   }
 }
 
+/** Content hash for the small settings files: a same-size rewrite within one
+ * mtime tick (the settings-watch flake class) must still invalidate the cache. */
+function contentToken(target: string): string {
+  try {
+    return crypto.createHash('sha256').update(fs.readFileSync(target)).digest('hex')
+  } catch {
+    return 'missing'
+  }
+}
+
 /**
- * A cheap change signature for one home's plugin config: the settings files' stat
- * tokens plus the cache tree's directory names and mtimes down through each plugin's
+ * A cheap change signature for one home's plugin config: the settings files'
+ * content hashes plus the cache tree's directory names and mtimes down through each plugin's
  * version directories, and the stat token of the resolved (newest) version's manifest
  * so an in-place edit of it invalidates the cache. Costs a few stats where the full
  * walk reads and parses the settings and every manifest.
  */
 function pluginFingerprint(cacheDir: string, settingsFiles: string[]): string {
-  const parts = settingsFiles.map(statToken)
+  const parts = settingsFiles.map(contentToken)
   for (const marketplace of listDirs(cacheDir)) {
     const marketplaceDir = path.join(cacheDir, marketplace)
     parts.push(`${marketplace}:${statToken(marketplaceDir)}`)

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -105,7 +105,9 @@ async function writePromptToTempFile(agentName: string, prompt: string): Promise
   return { dir: tmpDir, filePath }
 }
 
-function getPiInvocation(args: string[]): { command: string; args: string[] } {
+/** Exported as a test seam: the fallbacks only fire in packaged distributions
+ * (bun single-file, compiled binary), which no CI run reaches naturally. */
+export function getPiInvocation(args: string[]): { command: string; args: string[] } {
   const currentScript = process.argv[1]
   const isBunVirtualScript = currentScript?.startsWith('/$bunfs/root/')
   if (currentScript && !isBunVirtualScript && fs.existsSync(currentScript)) {

--- a/tests/claude-rules.test.ts
+++ b/tests/claude-rules.test.ts
@@ -154,6 +154,21 @@ describe('extension wiring', () => {
     expect(failed).toBeUndefined()
   })
 
+  it('injects rules in pinned-locale name order, not filesystem readdir order', async () => {
+    // Raw readdir order is filesystem-dependent (hash order on ext4); the prompt
+    // must be reproducible across machines. Created deliberately out of order.
+    const cwd = mkdtempSync(join(tmpdir(), 'rules-'))
+    mkdirSync(join(cwd, '.claude', 'rules'), { recursive: true })
+    writeFileSync(join(cwd, '.claude', 'rules', 'zeta.md'), 'ZETA RULE')
+    writeFileSync(join(cwd, '.claude', 'rules', 'alpha.md'), 'ALPHA RULE')
+    writeFileSync(join(cwd, '.claude', 'rules', 'middle.md'), 'MIDDLE RULE')
+
+    const prompt = await sessionPrompt(approvedCtx(cwd))
+    const positions = ['alpha', 'middle', 'zeta'].map((name) => prompt.indexOf(`${name}.md`))
+    expect(positions.every((at) => at >= 0)).toBe(true)
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions)
+  })
+
   it('expands a brace glob in a scoped rule when matching a touched file', async () => {
     const cwd = projectWithRule('---\npaths:\n  - "src/{a,b}/**"\n---\nMind the shared modules.')
     const handlers = wire()

--- a/tests/claude-rules.test.ts
+++ b/tests/claude-rules.test.ts
@@ -164,7 +164,7 @@ describe('extension wiring', () => {
     writeFileSync(join(cwd, '.claude', 'rules', 'middle.md'), 'MIDDLE RULE')
 
     const prompt = await sessionPrompt(approvedCtx(cwd))
-    const positions = ['alpha', 'middle', 'zeta'].map((name) => prompt.indexOf(`${name}.md`))
+    const positions = ['ALPHA RULE', 'MIDDLE RULE', 'ZETA RULE'].map((marker) => prompt.indexOf(marker))
     expect(positions.every((at) => at >= 0)).toBe(true)
     expect([...positions].sort((a, b) => a - b)).toEqual(positions)
   })

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -831,6 +831,17 @@ describe('additionalDirContextFiles', () => {
     ])
   })
 
+  it('sorts rule names with pinned en collation regardless of host locale', () => {
+    // Czech collation orders ch after h; the default collator follows the host
+    // locale, so unpinned sorting reorders prompt content per machine.
+    const dir = tempDir()
+    mkdirSync(join(dir, '.claude', 'rules'), { recursive: true })
+    writeFileSync(join(dir, '.claude', 'rules', 'h.md'), 'H')
+    writeFileSync(join(dir, '.claude', 'rules', 'ci.md'), 'CI')
+    writeFileSync(join(dir, '.claude', 'rules', 'ch.md'), 'CH')
+    expect(additionalDirContextFiles(dir, false).map((file) => file.content)).toEqual(['CH', 'CI', 'H'])
+  })
+
   it('skips missing files and withholds CLAUDE.local.md when not approved', () => {
     const dir = tempDir()
     writeFileSync(join(dir, 'CLAUDE.md'), 'ROOT')

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -334,7 +334,16 @@ describe('capCheckpoints', () => {
 
     let seen: string[] = []
     const base = t.makeCtx(entries, [], []) as { ui: Record<string, unknown> }
-    const ctx = { ...base, ui: { ...base.ui, select: async (_title: string, labels: string[]) => (seen = labels, undefined) } }
+    const ctx = {
+      ...base,
+      ui: {
+        ...base.ui,
+        select: async (_title: string, labels: string[]) => {
+          seen = labels
+          return undefined
+        },
+      },
+    }
     await t.commands.get('rewind')?.handler('', ctx)
 
     expect(seen).toHaveLength(MAX_CHECKPOINTS_PER_SESSION)

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -319,4 +319,26 @@ describe('capCheckpoints', () => {
     const few = [entry(1), entry(2)]
     expect(capCheckpoints(few)).toEqual(few)
   })
+
+  it('caps the rewind list rebuilt on session resume, newest kept', async () => {
+    // The turn_end path trims as it appends, but the resume rebuild loaded every
+    // stored entry uncapped, so a long resumed session exceeded the limit until
+    // its next checkpoint landed.
+    const t = setup()
+    const entries = Array.from({ length: MAX_CHECKPOINTS_PER_SESSION + 5 }, (_, i) => ({
+      type: 'custom',
+      customType: 'git-checkpoint',
+      data: { entryId: `user${String(i).padStart(4, '0')}`, ref: '1'.repeat(40), prompt: `p${String(i).padStart(3, '0')}`, createdAt: new Date().toISOString() },
+    }))
+    await t.handlers.get('session_start')?.({ reason: 'resume' }, t.makeCtx(entries, [], []))
+
+    let seen: string[] = []
+    const base = t.makeCtx(entries, [], []) as { ui: Record<string, unknown> }
+    const ctx = { ...base, ui: { ...base.ui, select: async (_title: string, labels: string[]) => (seen = labels, undefined) } }
+    await t.commands.get('rewind')?.handler('', ctx)
+
+    expect(seen).toHaveLength(MAX_CHECKPOINTS_PER_SESSION)
+    expect(seen[0]).toContain('p104') // newest first in the picker
+    expect(seen.some((label) => label.includes('p004'))).toBe(false) // oldest five dropped
+  })
 })

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -93,6 +93,26 @@ describe('installedPlugins', () => {
     expect(plugins[0].root).toBe(newest)
   })
 
+  it('ranks a release above its own prerelease, per semver', () => {
+    // The update-then-grace layout can hold 1.0.0-beta beside 1.0.0; a plain
+    // string sort ranks the prerelease higher and serves stale plugin code.
+    const h = home()
+    install(h, 'community', 'formatter', '1.0.0-beta')
+    const release = install(h, 'community', 'formatter', '1.0.0')
+    enable(h, { formatter: true })
+
+    expect(installedPlugins(h, [])[0].root).toBe(release)
+  })
+
+  it('compares numerically across a stray v prefix', () => {
+    const h = home()
+    install(h, 'community', 'formatter', 'v2.0.0')
+    const newest = install(h, 'community', 'formatter', '10.0.0')
+    enable(h, { formatter: true })
+
+    expect(installedPlugins(h, [])[0].root).toBe(newest)
+  })
+
   it('attaches userConfig from pluginConfigs in settings', () => {
     const h = home()
     install(h, 'community', 'formatter', '1.0.0')

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -93,6 +93,26 @@ describe('installedPlugins', () => {
     expect(plugins[0].root).toBe(newest)
   })
 
+  it('sees a same-size settings rewrite within one timestamp tick', () => {
+    // The mtime:size token cannot distinguish these two writes; only content
+    // can. Same defect class as the settings-watch flake fixed in #170.
+    const h = home()
+    install(h, 'community', 'formatter', '1.0.0')
+    mkdirSync(join(h, '.claude'), { recursive: true })
+    const settings = join(h, '.claude', 'settings.json')
+    const on = '{"enabledPlugins":{"formatter":true }}'
+    const off = '{"enabledPlugins":{"formatter":false}}'
+    expect(on.length).toBe(off.length)
+    const frozen = new Date('2026-01-02T03:04:05Z')
+    writeFileSync(settings, on)
+    utimesSync(settings, frozen, frozen)
+    expect(installedPlugins(h, []).map((p) => p.name)).toEqual(['formatter'])
+
+    writeFileSync(settings, off)
+    utimesSync(settings, frozen, frozen)
+    expect(installedPlugins(h, [])).toEqual([])
+  })
+
   it('ranks a release above its own prerelease, per semver', () => {
     // The update-then-grace layout can hold 1.0.0-beta beside 1.0.0; a plain
     // string sort ranks the prerelease higher and serves stale plugin code.
@@ -155,8 +175,10 @@ describe('installedPlugins cache', () => {
 
     const mark = fsHoisted.reads
     expect(installedPlugins(h)).toEqual(first)
-    // The walk is memoized; a repeat call revalidates with stats, not file reads.
-    expect(fsHoisted.reads).toBe(mark)
+    // The walk is memoized. Revalidation re-reads only the one small settings
+    // file (content-hashed so a same-size rewrite is seen); the expensive part,
+    // re-parsing every manifest in the tree, must not happen.
+    expect(fsHoisted.reads).toBe(mark + 1)
   })
 
   it('re-reads after resetInstalledPluginsCache', () => {

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -6,7 +6,7 @@ import type { AgentToolResult } from '@earendil-works/pi-agent-core'
 import { DEFAULT_MAX_LINES } from '@earendil-works/pi-coding-agent'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { hasAgentRunner, runAgent, setAgentRunner } from '../extensions/internal/agent-run.ts'
-import subagentExtension, { AGENT_HOOK_SYSTEM, agentMemoryDir, agentMemorySection, agentsListText, buildHookAgent, tasksStatusText, withMemoryTools } from '../extensions/subagent/index.ts'
+import subagentExtension, { AGENT_HOOK_SYSTEM, agentMemoryDir, agentMemorySection, agentsListText, buildHookAgent, getPiInvocation, tasksStatusText, withMemoryTools } from '../extensions/subagent/index.ts'
 
 // The agent-memory tests read settings and stores under the home directory; point
 // homedir at a throwaway dir so the developer's real ~/.claude cannot influence them.
@@ -2013,5 +2013,43 @@ describe('execute dispatch: resume and cancel arms', () => {
     cancelBackgroundRunMock.mockReturnValue('unknown')
     backgroundStatusTextMock.mockReturnValue('(no background runs)')
     expect(text(await execute('c1', { cancel: 'bg-9' }, undefined, undefined, trustedCtx))).toContain('Unknown background run: bg-9')
+  })
+})
+
+describe('getPiInvocation packaging fallbacks', () => {
+  // The fallbacks fire only in packaged distributions, invisible to CI unless
+  // the inputs are faked; a regression breaks subagent spawning only for users
+  // of the compiled binary.
+  const withProcess = (script: string | undefined, execPath: string, fn: () => void): void => {
+    const savedArgv = process.argv[1]
+    const savedExec = process.execPath
+    if (script === undefined) process.argv.splice(1, 1)
+    else process.argv[1] = script
+    process.execPath = execPath
+    try {
+      fn()
+    } finally {
+      if (script === undefined) process.argv.splice(1, 0, savedArgv)
+      else process.argv[1] = savedArgv
+      process.execPath = savedExec
+    }
+  }
+
+  it('reruns the current script through the current runtime when it exists on disk', () => {
+    withProcess(__filename, '/usr/bin/node-x', () => {
+      expect(getPiInvocation(['--mode', 'json'])).toEqual({ command: '/usr/bin/node-x', args: [__filename, '--mode', 'json'] })
+    })
+  })
+
+  it('invokes the compiled binary directly when the script is a bun virtual path', () => {
+    withProcess('/$bunfs/root/cli.js', '/opt/pi-binary', () => {
+      expect(getPiInvocation(['--mode', 'json'])).toEqual({ command: '/opt/pi-binary', args: ['--mode', 'json'] })
+    })
+  })
+
+  it('falls back to pi on PATH when only a generic runtime is left', () => {
+    withProcess('/nonexistent/script-gone.js', '/usr/local/bin/node', () => {
+      expect(getPiInvocation(['-p', 'task'])).toEqual({ command: 'pi', args: ['-p', 'task'] })
+    })
   })
 })


### PR DESCRIPTION
## What

QA campaign batch 3: the five production-level findings, each red-first.

- **Plugin version sort was semver-wrong**: the plain numeric string sort ranked `1.0.0-beta` above `1.0.0` and `v2.0.0` above `10.0.0`, serving stale plugin code whenever the update grace period leaves both directories on disk. Versions now compare on numeric base segments with the `v` prefix dropped, and a release outranks its own prerelease.
- **Prompt content was machine-dependent**: rule discovery iterated raw readdir order (hash order on ext4, sorted on APFS) and the additional-dir rules sort followed the host locale (Czech collation reorders ch/h). Both now sort with pinned `en` collation; tests pin the injected order and the ch/ci/h case.
- **Plugin cache fingerprint was blind to same-size rewrites** within one mtime tick (the settings-watch flake class, one cache over): the settings-file part of the fingerprint is now a content hash. The cache perf pin tightens to what matters: revalidation reads the one small settings file, never re-parses the manifest tree.
- **The resume-rebuilt rewind list was uncapped**: `capCheckpoints` was exported but production never called it; a resumed long session rebuilt every stored checkpoint (105 stored produced a 105-row picker). The rebuild now runs through the same cap as the append path. The uncalled `fencedRanges` is deleted.
- **Packaged-distribution spawn fallbacks pinned**: `getPiInvocation`'s three arms only diverge in packaged builds no CI reaches; exported as a test seam and pinned with faked argv/execPath (with an honestly documented limit: the bun-virtual guard is only load-bearing under bun's virtual filesystem).

## Verification

`npm run check` green (2009 tests), green again under a hostile host env, every fix red-first with the failing case committed alongside. Full e2e runs before merge.