### PR TITLE
Harden the e2e layer: oracles, isolation, signal safety, new checks

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -95,4 +95,4 @@ jobs:
       - name: Run the deterministic smoke
         # Boots the pi devDependency headless against a dead-port model and
         # asserts the exact provider payload; no real model or network needed.
-        run: zsh scripts/e2e-smoke.sh
+        run: bash scripts/e2e-smoke.sh

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -71,3 +71,28 @@ jobs:
             -Dsonar.test.exclusions=tests/**
             -Dsonar.coverage.exclusions=tests/**
             -Dsonar.qualitygate.wait=true
+
+  smoke:
+    name: Headless e2e smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Installing dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run the deterministic smoke
+        # Boots the pi devDependency headless against a dead-port model and
+        # asserts the exact provider payload; no real model or network needed.
+        run: zsh scripts/e2e-smoke.sh

--- a/scripts/e2e-full.sh
+++ b/scripts/e2e-full.sh
@@ -43,6 +43,18 @@ wait_file() { # wait_file <path> <timeout-seconds>
 # --- Fixture: a project exercising every .claude surface ------------------------------
 FX=$(mktemp -d)
 FX=$(cd "$FX" && pwd -P)
+
+# Installed before anything else exists so an abort at any point cleans up. zsh
+# runs no EXIT trap on an untrapped INT/TERM, and a Ctrl-C mid-model-turn would
+# otherwise leave a live pi burning the account plus both temp trees; the signal
+# traps clean up and re-raise so the exit status stays signal-shaped.
+cleanup() {
+  tmux kill-session -t "$SESSION" 2>/dev/null
+  rm -rf ${FAKEHOME:+"$FAKEHOME"} "$FX"
+}
+trap cleanup EXIT
+trap 'cleanup; trap - INT; kill -INT $$' INT
+trap 'cleanup; trap - TERM; kill -TERM $$' TERM
 git -C "$FX" init -qb main
 git -C "$FX" -c user.name=e2e -c user.email=e2e@local commit -q --allow-empty -m init
 mkdir -p "$FX/.claude/rules" "$FX/.claude/commands" "$FX/.claude/skills/greet" "$FX/.claude/output-styles" "$FX/.claude/agents" "$FX/notes"
@@ -65,7 +77,10 @@ EOF
 printf 'Project context for the e2e run.\n\n@notes/extra.md\n' > "$FX/CLAUDE.md"
 printf 'The codeword is ZANZIBAR.\n' > "$FX/notes/extra.md"
 printf 'PERSONAL LOCAL NOTE MARKER\n' > "$FX/CLAUDE.local.md"
-printf -- '---\nname: echoer\ndescription: Replies with a requested marker word\n---\nWhen given a task asking for a marker word, reply with exactly that word and nothing else.\n' > "$FX/.claude/agents/echoer.md"
+# The marker lives ONLY in the agent body, never in the typed prompt: the prompt
+# echoes into the pane as the rendered user message, so a prompt-carried marker
+# would green the check before (and regardless of whether) the child pi ran.
+printf -- '---\nname: echoer\ndescription: Replies with its fixed marker word\n---\nWhatever the task says, reply with exactly the word SUBAGENT_OK and nothing else.\n' > "$FX/.claude/agents/echoer.md"
 printf 'ORIGINAL\n' > "$FX/data.txt"
 printf 'node_modules\n' > "$FX/.gitignore"
 ln -s "$REPO/node_modules" "$FX/node_modules"
@@ -175,14 +190,15 @@ if [ -z "$PI_VERSION" ] || ! is-at-least 0.79.1 "$PI_VERSION"; then
 fi
 
 say "fixture: $FX"
-cleanup() {
-  tmux kill-session -t "$SESSION" 2>/dev/null
-  rm -rf "$FAKEHOME" "$FX"
-}
-trap cleanup EXIT
 
+# The tmux server keeps its own environment: an inherited PI_CODING_AGENT_DIR or
+# CLAUDE_CONFIG_DIR would point pi inside the "isolated" home at the real config
+# (the scripted trust-approve would then write the real trust store), and PATH
+# drift could boot a different pi than the one the guards above validated.
+PI_BIN=$(command -v pi)
+BOOT_CMD="env -u PI_CODING_AGENT_DIR -u CLAUDE_CONFIG_DIR HOME=$FAKEHOME PI_E2E_WIRE=$WIRE PI_SKIP_VERSION_CHECK=1 $PI_BIN"
 tmux kill-session -t "$SESSION" 2>/dev/null || true
-tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "$FX" "HOME=$FAKEHOME PI_E2E_WIRE=$WIRE PI_SKIP_VERSION_CHECK=1 pi"
+tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "$FX" "$BOOT_CMD"
 
 # --- Deterministic checks -------------------------------------------------------------
 if wait_for 'Trust this project\?' 30; then
@@ -377,7 +393,7 @@ json.dump(settings, open(path, "w"))
 PY
 
 tmux kill-session -t "$SESSION" 2>/dev/null || true
-tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "$FX" "HOME=$FAKEHOME PI_E2E_WIRE=$WIRE PI_SKIP_VERSION_CHECK=1 pi"
+tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "$FX" "$BOOT_CMD"
 if wait_for '\[Extensions\]' 120; then ok "trust: stored decision honored on re-boot"; else bad "trust: re-boot failed"; fi
 # The statusLine command runs on the first status refresh after boot; its output replaces
 # the built-in segment, so STATUS_E2E in the pane proves the configured command drove it.

--- a/scripts/e2e-full.sh
+++ b/scripts/e2e-full.sh
@@ -82,6 +82,7 @@ printf -- '---\nname: Pirate\ndescription: e2e style\nkeep-coding-instructions: 
 printf '{"outputStyle": "Pirate"}\n' > "$FX/.claude/settings.local.json"
 cat > "$FX/.claude/settings.json" <<'EOF'
 {
+  "env": { "E2E_ENV_MARKER": "ENVWIRE_ABC" },
   "hooks": {
     "SessionStart": [{ "hooks": [{ "command": "touch .e2e-session-start" }] }],
     "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "command": "if grep -q FORBIDDEN_MARKER; then echo BLOCKED_BY_E2E_HOOK >&2; exit 2; fi" }] }]
@@ -152,18 +153,9 @@ done
 # A wire probe records the exact provider payload of each request, giving the context
 # checks a deterministic oracle: what the model was actually sent, not what it recalls.
 WIRE="$FAKEHOME/wire.json"
-# Appends one JSON line per request: an overwrite-per-request dump could be
-# clobbered by a later request (session titling, a follow-up turn) between the
-# turn under test and the greps, flipping good checks into false FAILs.
-cat > "$FAKEHOME/wire-probe.ts" <<'EOF'
-import * as fs from 'node:fs'
-export default function wireProbe(pi: { on: (event: string, handler: (event: unknown) => void) => void }) {
-  pi.on('before_provider_request', (event) => {
-    const target = process.env.PI_E2E_WIRE
-    if (target) fs.appendFileSync(target, `${JSON.stringify(event)}\n`)
-  })
-}
-EOF
+# The committed probe (also used by the headless smoke) appends one JSON line
+# per request, so a later request cannot clobber the payload under test.
+cp "$REPO/scripts/lib/wire-probe.ts" "$FAKEHOME/wire-probe.ts"
 # Allowlist, not denylist: only the model-selection keys ride in from the real
 # settings. Copying everything minus a strip list let any other developer key (a
 # global statusLine, hooks, timeout tuning) shape the "isolated" run; a fresh
@@ -270,10 +262,18 @@ if wait_for 'No checkpoints recorded yet' 15; then ok "checkpoint: empty-session
 send "/hooks" Enter
 if wait_for 'PreToolUse:' 15 && capture | grep -q 'FORBIDDEN_MARKER'; then ok "hooks: /hooks viewer shows the PreToolUse guard"; else bad "hooks: /hooks viewer missing the guard"; fi
 
+# The fixture ships a project agent, so /agents must list it with its file path.
+send "/agents" Enter
+if wait_for 'echoer - ' 15; then ok "agents: /agents lists the project agent"; else bad "agents: echoer missing from the listing"; fi
+
 # --- Model turns ----------------------------------------------------------------------
 type_prompt "/hello"
 if wait_for 'HELLO_MARKER' 200; then ok "commands: /hello template drove the turn"; else bad "commands: no HELLO_MARKER"; fi
 if wait_for '✓ turn' 60; then ok "statusline: turn counter"; else bad "statusline: no turn segment"; fi
+
+# After a completed turn /context has usage to report.
+send "/context" Enter
+if wait_for 'Context usage' 15; then ok "context: /context renders usage"; else bad "context: no usage output"; fi
 
 # The wire dump written during the /hello turn is the ground truth for context
 # injection: the exact payload the provider received, independent of model recall
@@ -295,6 +295,12 @@ if wait_for 'E2EPONG' 200; then ok "mcp: model called the MCP tool"; else bad "m
 
 type_prompt "Run this exact bash command: echo FORBIDDEN_MARKER"
 if wait_for 'BLOCKED_BY_E2E_HOOK' 200; then ok "hooks: PreToolUse blocked with its reason"; else bad "hooks: block reason missing"; fi
+
+# env-settings: the fixture's settings env must reach tool subprocesses. The
+# typed prompt carries the variable NAME unexpanded, so the value can only
+# appear through real execution.
+type_prompt "Run this exact bash command: echo marker is \$E2E_ENV_MARKER"
+if wait_for 'marker is ENVWIRE_ABC' 200; then ok "env-settings: settings env reached the bash tool"; else bad "env-settings: ENVWIRE_ABC missing"; fi
 
 type_prompt "Use the memory tool with action save, name wraptest, description e2e check, content MEMCONTENT_XYZ. Do nothing else."
 if wait_file "$FAKEHOME/.pi/agent/memory/$SLUG/wraptest.md" 200 && grep -q 'MEMCONTENT_XYZ' "$FAKEHOME/.pi/agent/memory/$SLUG/wraptest.md"; then
@@ -352,7 +358,7 @@ fi
 # The echoer agent's BODY carries SUBAGENT_OK, so the pane can only show it when
 # the child pi actually loaded the project agent and ran. The self-check makes
 # that property mechanical for future edits.
-SUBAGENT_PROMPT="Use the subagent tool with agentScope set to both, agent echoer, and this task: introduce yourself."
+SUBAGENT_PROMPT="Use the subagent tool with agentScope set to both, agent echoer, and this task: follow your instructions exactly."
 case "$SUBAGENT_PROMPT" in *SUBAGENT_OK*) bad "self-check: subagent prompt must not carry the marker" ;; esac
 type_prompt "$SUBAGENT_PROMPT"
 if wait_for 'project agent|Source:' 200; then
@@ -426,6 +432,14 @@ else
   bad "plan-mode: review prompt missing"
 fi
 send "/plan" Enter
+sleep 2
+
+# /init sends the analysis prompt as a user message; the deterministic part is
+# that prompt reaching the conversation. Escape cancels the model turn so the
+# suite does not pay for a full codebase analysis.
+send "/init" Enter
+if wait_for 'AGENTS.md' 20; then ok "init: /init sent the analysis prompt"; else bad "init: no analysis prompt"; fi
+send Escape
 sleep 2
 
 # --- Second session: persistence checks -----------------------------------------------

--- a/scripts/e2e-full.sh
+++ b/scripts/e2e-full.sh
@@ -18,14 +18,19 @@ ok() { PASS=$((PASS + 1)); print -P "%F{green}PASS%f $1" }
 bad() { FAIL=$((FAIL + 1)); print -P "%F{red}FAIL%f $1" }
 warn() { WARN=$((WARN + 1)); print -P "%F{yellow}WARN%f $1" }
 
+# Two depths: capture() is the CURRENT screen, for state checks (badges,
+# status segments) where scrollback would resurrect stale frames; capture_all()
+# adds scrollback, for marker searches where a verbose reply can scroll a
+# marker past the visible rows between 2s polls.
 capture() { tmux capture-pane -t "$SESSION" -p }
+capture_all() { tmux capture-pane -t "$SESSION" -p -S -200 }
 send() { tmux send-keys -t "$SESSION" "$@" }
 type_prompt() { tmux send-keys -t "$SESSION" -l "$1"; tmux send-keys -t "$SESSION" Enter }
 
-wait_for() { # wait_for <regex> <timeout-seconds>
+wait_for() { # wait_for <regex> <timeout-seconds>: appearance searches include scrollback
   local deadline=$(($(date +%s) + $2))
   while (($(date +%s) < deadline)); do
-    if capture | grep -qE "$1"; then return 0; fi
+    if capture_all | grep -qE "$1"; then return 0; fi
     sleep 2
   done
   return 1
@@ -35,6 +40,15 @@ wait_file() { # wait_file <path> <timeout-seconds>
   local deadline=$(($(date +%s) + $2))
   while (($(date +%s) < deadline)); do
     [ -e "$1" ] && return 0
+    sleep 2
+  done
+  return 1
+}
+
+wait_for_absent() { # wait_for_absent <regex> <timeout-seconds>: poll until the pane no longer matches
+  local deadline=$(($(date +%s) + $2))
+  while (($(date +%s) < deadline)); do
+    capture | grep -qE "$1" || return 0
     sleep 2
   done
   return 1
@@ -138,32 +152,33 @@ done
 # A wire probe records the exact provider payload of each request, giving the context
 # checks a deterministic oracle: what the model was actually sent, not what it recalls.
 WIRE="$FAKEHOME/wire.json"
+# Appends one JSON line per request: an overwrite-per-request dump could be
+# clobbered by a later request (session titling, a follow-up turn) between the
+# turn under test and the greps, flipping good checks into false FAILs.
 cat > "$FAKEHOME/wire-probe.ts" <<'EOF'
 import * as fs from 'node:fs'
 export default function wireProbe(pi: { on: (event: string, handler: (event: unknown) => void) => void }) {
   pi.on('before_provider_request', (event) => {
     const target = process.env.PI_E2E_WIRE
-    if (target) fs.writeFileSync(target, JSON.stringify(event))
+    if (target) fs.appendFileSync(target, `${JSON.stringify(event)}\n`)
   })
 }
 EOF
+# Allowlist, not denylist: only the model-selection keys ride in from the real
+# settings. Copying everything minus a strip list let any other developer key (a
+# global statusLine, hooks, timeout tuning) shape the "isolated" run; a fresh
+# home also means no stale lastChangelogVersion, so no changelog wall over boot.
 python3 - "$HOME/.pi/agent/settings.json" "$FAKEHOME/.pi/agent/settings.json" "$REPO" "$FAKEHOME/wire-probe.ts" <<'PY'
 import json, sys
 src, dst, repo, probe = sys.argv[1:5]
 try:
-    settings = json.load(open(src))
+    real = json.load(open(src))
 except Exception:
-    settings = {}
+    real = {}
+settings = {key: real[key] for key in ("defaultModel", "defaultProvider") if key in real}
 settings["packages"] = [repo]
 settings["defaultThinkingLevel"] = "low"
 settings["extensions"] = [probe]
-# lastChangelogVersion rides in from the developer's real global settings; a stale value
-# (e.g. an install several releases back) makes pi paint the full "What's New" changelog
-# wall over the boot screen, burying the banners these checks grep for. Dropping it lets
-# pi treat the throwaway home as a fresh install: it records the current version silently
-# and shows no changelog.
-for key in ("skills", "prompts", "lastChangelogVersion"):
-    settings.pop(key, None)
 json.dump(settings, open(dst, "w"))
 PY
 
@@ -210,18 +225,27 @@ fi
 
 # pi 0.81 flushes the resource block only after session_start handlers complete,
 # which serial MCP connect timeouts can push well past an eager window.
-if wait_for '\[Extensions\]' 120 && capture | grep -A20 '\[Extensions\]' | grep -q 'todo.ts'; then
+# Two independent greps, not a fixed -A window: the extension block grows with
+# every added extension and a clipped window false-FAILs at exactly the count
+# that pushes an entry out of it.
+if wait_for '\[Extensions\]' 120 && capture_all | grep -q 'todo.ts'; then
   ok "boot: extensions loaded"
 else
   bad "boot: extensions missing"
 fi
 
 # Known pi TUI interaction: on a fast boot pi drops all but the last session_start
-# notify() banner (reproduced with only this checkout loaded). The features are asserted
-# on substance elsewhere: rules by the unit suite, MCP by the tool-call turn below.
+# notify() banner (reproduced with only this checkout loaded). One consistent rule:
+# every individual banner is a warn (which banner survives is ordering luck; the
+# old scheme hard-failed output-style only because it happened to be last), and
+# ONE bad check requires that at least one banner rendered at all, so a
+# regression silencing the whole notify path cannot hide behind the warns.
+# Features are asserted on substance elsewhere: rules/imports on the wire, MCP by
+# the /mcp turn, memory by the on-disk file.
 if wait_for 'Rules loaded: global (yes|no), project 1' 20; then ok "rules: project rule counted"; else warn "rules: banner not rendered (known pi TUI interaction)"; fi
-if wait_for 'Output style: Pirate' 15; then ok "output-style: active style announced"; else bad "output-style: no banner"; fi
+if wait_for 'Output style: Pirate' 15; then ok "output-style: active style announced"; else warn "output-style: banner not rendered (known pi TUI interaction)"; fi
 if wait_for 'MCP: ' 30; then ok "mcp: connect summary banner"; else warn "mcp: summary banner not rendered (known pi TUI interaction)"; fi
+if capture_all | grep -qE 'Rules loaded: |Output style: |MCP: '; then ok "boot: at least one session-start banner rendered"; else bad "boot: notify path rendered no banner at all"; fi
 if wait_file "$FX/.e2e-session-start" 10; then ok "hooks: SessionStart hook ran"; else bad "hooks: SessionStart marker missing"; fi
 if capture | grep -q '○ ready'; then ok "statusline: ready segment"; else bad "statusline: no ready segment"; fi
 
@@ -235,8 +259,7 @@ sleep 1
 send "/plan" Enter
 if wait_for '⏸ plan' 15; then ok "plan-mode: badge on"; else bad "plan-mode: badge missing"; fi
 send "/plan" Enter
-sleep 2
-if capture | grep -q '⏸ plan'; then bad "plan-mode: badge stuck"; else ok "plan-mode: badge off"; fi
+if wait_for_absent '⏸ plan' 20; then ok "plan-mode: badge off"; else bad "plan-mode: badge stuck"; fi
 
 send "/rewind" Enter
 if wait_for 'No checkpoints recorded yet' 15; then ok "checkpoint: empty-session notice"; else bad "checkpoint: no empty notice"; fi
@@ -261,6 +284,11 @@ if grep -q 'PERSONAL LOCAL NOTE MARKER' "$WIRE" 2>/dev/null; then ok "context-im
 # inlines its body into the system prompt rather than surfacing a scoped pointer. Assert the
 # injected body on the wire, like the two import checks above; the filename never rides along.
 if grep -q 'Tests must be deterministic' "$WIRE" 2>/dev/null; then ok "rules: project rule on the wire"; else bad "rules: project rule missing from payload"; fi
+# The skills PLUMBING is deterministic even though the invocation below is
+# model-dependent: the available_skills listing with the fixture skill must
+# reach the provider payload, so a discovery regression fails here instead of
+# hiding behind the model-declined warn.
+if grep -q 'available_skills' "$WIRE" 2>/dev/null && grep -q 'greet' "$WIRE" 2>/dev/null; then ok "skills: listing reaches the wire"; else bad "skills: available_skills/greet missing from payload"; fi
 
 type_prompt "Call the e2e_ping tool now and repeat its output verbatim."
 if wait_for 'E2EPONG' 200; then ok "mcp: model called the MCP tool"; else bad "mcp: no E2EPONG"; fi
@@ -304,7 +332,9 @@ if grep -q MODIFIED "$FX/data.txt" 2>/dev/null; then
     send Enter
     if wait_for 'Code only' 20; then
       send Down Down Enter
-      sleep 5
+      # Wait for the completion notice instead of a fixed sleep; a slow restore
+      # made the file assertions race the checkout.
+      wait_for 'Rewind complete|Code restored' 30 || true
       if grep -q ORIGINAL "$FX/data.txt"; then ok "checkpoint: code-only restore reverted data.txt"; else bad "checkpoint: data.txt not reverted"; fi
       if [ -f "$FX/probe-new.txt" ]; then ok "checkpoint: later file survives restore (overlay semantics)"; else bad "checkpoint: restore deleted a later file"; fi
     else
@@ -317,7 +347,14 @@ else
   bad "checkpoint: model never modified data.txt"
 fi
 
-type_prompt "Use the subagent tool with agentScope set to both, agent echoer, and this task: reply with the word SUBAGENT_OK."
+# The marker must never appear in the typed prompt: the prompt echoes into the
+# pane as the rendered user message, which once made this check unable to fail.
+# The echoer agent's BODY carries SUBAGENT_OK, so the pane can only show it when
+# the child pi actually loaded the project agent and ran. The self-check makes
+# that property mechanical for future edits.
+SUBAGENT_PROMPT="Use the subagent tool with agentScope set to both, agent echoer, and this task: introduce yourself."
+case "$SUBAGENT_PROMPT" in *SUBAGENT_OK*) bad "self-check: subagent prompt must not carry the marker" ;; esac
+type_prompt "$SUBAGENT_PROMPT"
 if wait_for 'project agent|Source:' 200; then
   ok "subagent: consent prompt for project agent"
   sleep 1
@@ -362,6 +399,17 @@ if wait_for 'Started background run' 200; then
   sleep 2
   send "/tasks" Enter
   if wait_for 'general-purpose: (running|done)' 30; then ok "tasks: /tasks lists the background run"; else bad "tasks: no background run entry"; fi
+  # 'running' alone proved only registration: a child that hangs or crashes
+  # after registering still listed as running. Re-poll /tasks until it reports
+  # done, so the check covers actual execution to completion.
+  finished=0
+  for attempt in 1 2 3 4 5 6 7 8; do
+    if capture_all | grep -qE 'general-purpose: done'; then finished=1; break; fi
+    sleep 15
+    send "/tasks" Enter
+    sleep 3
+  done
+  if ((finished)); then ok "tasks: background run ran to completion"; else bad "tasks: background run never reached done"; fi
 else
   bad "subagent: background run did not start"
 fi

--- a/scripts/e2e-full.sh
+++ b/scripts/e2e-full.sh
@@ -281,7 +281,7 @@ if wait_for 'Context usage' 15; then ok "context: /context renders usage"; else 
 # as a follow-up. Escape cancels the model turn so the suite does not pay for
 # a full codebase analysis.
 send "/init" Enter
-if wait_for 'AGENTS.md' 20; then ok "init: /init sent the analysis prompt"; else bad "init: no analysis prompt"; fi
+if wait_for 'analyze this codebase' 20; then ok "init: /init sent the analysis prompt"; else bad "init: no analysis prompt"; fi
 send Escape
 sleep 2
 

--- a/scripts/e2e-full.sh
+++ b/scripts/e2e-full.sh
@@ -275,6 +275,16 @@ if wait_for '✓ turn' 60; then ok "statusline: turn counter"; else bad "statusl
 send "/context" Enter
 if wait_for 'Context usage' 15; then ok "context: /context renders usage"; else bad "context: no usage output"; fi
 
+# /init sends its analysis prompt as a user message; the deterministic part is
+# that prompt reaching the conversation, and the session is provably idle here
+# (the /hello turn completed), so it renders immediately rather than queueing
+# as a follow-up. Escape cancels the model turn so the suite does not pay for
+# a full codebase analysis.
+send "/init" Enter
+if wait_for 'AGENTS.md' 20; then ok "init: /init sent the analysis prompt"; else bad "init: no analysis prompt"; fi
+send Escape
+sleep 2
+
 # The wire dump written during the /hello turn is the ground truth for context
 # injection: the exact payload the provider received, independent of model recall
 # (which proved unreliable in both directions as the prompt and thinking level varied).
@@ -353,14 +363,14 @@ else
   bad "checkpoint: model never modified data.txt"
 fi
 
-# The marker must never appear in the typed prompt: the prompt echoes into the
-# pane as the rendered user message, which once made this check unable to fail.
-# The echoer agent's BODY carries SUBAGENT_OK, so the pane can only show it when
-# the child pi actually loaded the project agent and ran. The self-check makes
-# that property mechanical for future edits.
-SUBAGENT_PROMPT="Use the subagent tool with agentScope set to both, agent echoer, and this task: follow your instructions exactly."
-case "$SUBAGENT_PROMPT" in *SUBAGENT_OK*) bad "self-check: subagent prompt must not carry the marker" ;; esac
-type_prompt "$SUBAGENT_PROMPT"
+# The task carries the marker (a small child model reliably echoes an explicit
+# instruction; two runs proved it ignores a marker living only in the agent
+# body). The old check greped the pane where the typed prompt itself echoes, so
+# it could never fail; discrimination now comes from counting: the echo
+# contributes a fixed number of occurrences, and only the child's reply adds
+# more.
+SUBAGENT_BASELINE=$(capture_all | grep -c 'SUBAGENT_OK' || true)
+type_prompt "Use the subagent tool with agentScope set to both, agent echoer, and this task: reply with the word SUBAGENT_OK."
 if wait_for 'project agent|Source:' 200; then
   ok "subagent: consent prompt for project agent"
   sleep 1
@@ -368,7 +378,15 @@ if wait_for 'project agent|Source:' 200; then
 else
   bad "subagent: no consent prompt"
 fi
-if wait_for 'SUBAGENT_OK' 280; then ok "subagent: child pi ran and reported back"; else bad "subagent: no SUBAGENT_OK"; fi
+# The echoed prompt adds one occurrence; the child's reported reply must add at
+# least one more on top of the echo.
+subagent_done=1
+deadline=$(($(date +%s) + 280))
+while (($(date +%s) < deadline)); do
+  if (($(capture_all | grep -c 'SUBAGENT_OK' || true) >= SUBAGENT_BASELINE + 2)); then subagent_done=0; break; fi
+  sleep 3
+done
+if ((subagent_done == 0)); then ok "subagent: child pi ran and reported back"; else bad "subagent: reply never exceeded the prompt echo"; fi
 
 # --- MCP prompts/resources, slash_command, skills, background tasks --------------------
 # The fixture MCP server also advertises the prompts and resources capabilities. The
@@ -432,14 +450,6 @@ else
   bad "plan-mode: review prompt missing"
 fi
 send "/plan" Enter
-sleep 2
-
-# /init sends the analysis prompt as a user message; the deterministic part is
-# that prompt reaching the conversation. Escape cancels the model turn so the
-# suite does not pay for a full codebase analysis.
-send "/init" Enter
-if wait_for 'AGENTS.md' 20; then ok "init: /init sent the analysis prompt"; else bad "init: no analysis prompt"; fi
-send Escape
 sleep 2
 
 # --- Second session: persistence checks -----------------------------------------------

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 # Headless deterministic e2e smoke: boots the pi devDependency against an
 # isolated home whose model points at a dead port, and asserts the exact
 # provider payload captured by scripts/lib/wire-probe.ts. No tmux, no model,
@@ -13,16 +13,16 @@ PI_BIN="$REPO/node_modules/.bin/pi"
 PASS=0
 FAIL=0
 
-ok() { PASS=$((PASS + 1)); print "PASS $1" }
-bad() { FAIL=$((FAIL + 1)); print "FAIL $1" }
+ok() { PASS=$((PASS + 1)); printf 'PASS %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL %s\n' "$1"; }
 
 SMOKE=$(mktemp -d)
-cleanup() { rm -rf "$SMOKE" }
+cleanup() { rm -rf "$SMOKE"; }
 trap cleanup EXIT
 trap 'cleanup; trap - INT; kill -INT $$' INT
 trap 'cleanup; trap - TERM; kill -TERM $$' TERM
 
-[ -x "$PI_BIN" ] || { print "FAIL smoke: $PI_BIN missing; run npm ci first"; exit 1 }
+[ -x "$PI_BIN" ] || { printf 'FAIL smoke: %s missing; run npm ci first\n' "$PI_BIN"; exit 1; }
 
 # --- Fixture: the context surfaces whose payload injection is deterministic ---
 FX="$SMOKE/fx"
@@ -63,12 +63,12 @@ if run_pi "$PI_BIN" list 2>/dev/null | grep -qF "$REPO"; then ok "smoke: pi list
 run_pi "$PI_BIN" -p "hi" > "$SMOKE/pi-out.log" 2>&1
 [ -s "$WIRE" ] && ok "smoke: wire probe captured the provider payload" || bad "smoke: no wire payload captured (pi output: $(tail -1 "$SMOKE/pi-out.log" 2>/dev/null))"
 
-wire_has() { grep -q "$1" "$WIRE" 2>/dev/null }
+wire_has() { grep -q "$1" "$WIRE" 2>/dev/null; }
 if wire_has 'ZANZIBAR'; then ok "smoke: @import chain content on the wire"; else bad "smoke: import content missing from payload"; fi
 if wire_has 'PERSONAL LOCAL NOTE MARKER'; then ok "smoke: CLAUDE.local.md on the wire"; else bad "smoke: local marker missing from payload"; fi
 if wire_has 'Tests must be deterministic'; then ok "smoke: project rule on the wire"; else bad "smoke: project rule missing from payload"; fi
 if wire_has 'available_skills' && wire_has 'greet'; then ok "smoke: skills listing on the wire"; else bad "smoke: skills listing missing from payload"; fi
 
-print ""
-print "e2e-smoke finished: $PASS passed, $FAIL failed"
+printf '\n'
+printf 'e2e-smoke finished: %s passed, %s failed\n' "$PASS" "$FAIL"
 exit $((FAIL > 0))

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -1,0 +1,74 @@
+#!/bin/zsh
+# Headless deterministic e2e smoke: boots the pi devDependency against an
+# isolated home whose model points at a dead port, and asserts the exact
+# provider payload captured by scripts/lib/wire-probe.ts. No tmux, no model,
+# no network: before_provider_request fires before the transport acts, so the
+# payload exists even though the request itself fails (pi's nonzero exit is
+# expected). Runs anywhere `npm ci` has run, including CI.
+# Usage: scripts/e2e-smoke.sh
+set -uo pipefail
+
+REPO=$(cd "$(dirname "$0")/.." && pwd -P)
+PI_BIN="$REPO/node_modules/.bin/pi"
+PASS=0
+FAIL=0
+
+ok() { PASS=$((PASS + 1)); print "PASS $1" }
+bad() { FAIL=$((FAIL + 1)); print "FAIL $1" }
+
+SMOKE=$(mktemp -d)
+cleanup() { rm -rf "$SMOKE" }
+trap cleanup EXIT
+trap 'cleanup; trap - INT; kill -INT $$' INT
+trap 'cleanup; trap - TERM; kill -TERM $$' TERM
+
+[ -x "$PI_BIN" ] || { print "FAIL smoke: $PI_BIN missing; run npm ci first"; exit 1 }
+
+# --- Fixture: the context surfaces whose payload injection is deterministic ---
+FX="$SMOKE/fx"
+mkdir -p "$FX/.claude/rules" "$FX/.claude/skills/greet" "$FX/notes"
+# Resolved path: the trust key must match the cwd pi sees (on macOS mktemp
+# hands out /var/... while processes resolve /private/var/...).
+FX=$(cd "$FX" && pwd -P)
+git -C "$FX" init -qb main 2>/dev/null
+printf 'Project context for the smoke.\n\n@notes/extra.md\n' > "$FX/CLAUDE.md"
+printf 'The codeword is ZANZIBAR.\n' > "$FX/notes/extra.md"
+printf 'PERSONAL LOCAL NOTE MARKER\n' > "$FX/CLAUDE.local.md"
+printf -- '- Tests must be deterministic.\n' > "$FX/.claude/rules/testing.md"
+printf -- '---\nname: greet\ndescription: Greets people for the smoke\n---\nReply with a greeting.\n' > "$FX/.claude/skills/greet/SKILL.md"
+
+# --- Isolated home: dead-port model, the committed probe, pre-seeded trust ---
+HOMEDIR="$SMOKE/home"
+mkdir -p "$HOMEDIR/.pi/agent"
+WIRE="$HOMEDIR/wire.jsonl"
+python3 - "$HOMEDIR" "$REPO" "$FX" <<'PY'
+import json, sys
+home, repo, fx = sys.argv[1:4]
+agent = f"{home}/.pi/agent"
+json.dump({"providers": {"dead": {"api": "openai-completions", "apiKey": "dead-key", "baseUrl": "http://127.0.0.1:1/v1", "models": [{"contextWindow": 131072, "id": "dead-model", "input": ["text"]}]}}}, open(f"{agent}/models.json", "w"))
+json.dump({"packages": [repo], "defaultModel": "dead-model", "defaultProvider": "dead", "defaultThinkingLevel": "off", "extensions": [f"{repo}/scripts/lib/wire-probe.ts"]}, open(f"{agent}/settings.json", "w"))
+# Pre-seeded trust: headless -p has no dialog, and untrusted projects load no
+# project-scoped config at all, which is most of what this smoke asserts.
+json.dump({fx: True}, open(f"{agent}/trust.json", "w"))
+PY
+
+run_pi() {
+  (cd "$FX" && env -u PI_CODING_AGENT_DIR -u CLAUDE_CONFIG_DIR HOME="$HOMEDIR" PI_E2E_WIRE="$WIRE" PI_SKIP_VERSION_CHECK=1 perl -e 'alarm 150; exec @ARGV' "$@" < /dev/null)
+}
+
+# --- Discovery: pi under the isolated home loads THIS checkout ---
+if run_pi "$PI_BIN" list 2>/dev/null | grep -qF "$REPO"; then ok "smoke: pi list discovers this checkout"; else bad "smoke: pi list does not load $REPO"; fi
+
+# --- One headless turn; the connection error afterwards is expected ---
+run_pi "$PI_BIN" -p "hi" > "$SMOKE/pi-out.log" 2>&1
+[ -s "$WIRE" ] && ok "smoke: wire probe captured the provider payload" || bad "smoke: no wire payload captured (pi output: $(tail -1 "$SMOKE/pi-out.log" 2>/dev/null))"
+
+wire_has() { grep -q "$1" "$WIRE" 2>/dev/null }
+if wire_has 'ZANZIBAR'; then ok "smoke: @import chain content on the wire"; else bad "smoke: import content missing from payload"; fi
+if wire_has 'PERSONAL LOCAL NOTE MARKER'; then ok "smoke: CLAUDE.local.md on the wire"; else bad "smoke: local marker missing from payload"; fi
+if wire_has 'Tests must be deterministic'; then ok "smoke: project rule on the wire"; else bad "smoke: project rule missing from payload"; fi
+if wire_has 'available_skills' && wire_has 'greet'; then ok "smoke: skills listing on the wire"; else bad "smoke: skills listing missing from payload"; fi
+
+print ""
+print "e2e-smoke finished: $PASS passed, $FAIL failed"
+exit $((FAIL > 0))

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -8,24 +8,50 @@ SESSION="pi-e2e-$$"
 WORKDIR="${1:-}"
 PASS=0
 FAIL=0
+WARN=0
 
 say() { print -P "%F{blue}[e2e]%f $1" }
 ok() { PASS=$((PASS + 1)); print -P "%F{green}PASS%f $1" }
 bad() { FAIL=$((FAIL + 1)); print -P "%F{red}FAIL%f $1" }
+warn() { WARN=$((WARN + 1)); print -P "%F{yellow}WARN%f $1" }
 
+# Two depths, as in e2e-full.sh: current screen for state, scrollback for markers.
 capture() { tmux capture-pane -t "$SESSION" -p }
+capture_all() { tmux capture-pane -t "$SESSION" -p -S -200 }
 send() { tmux send-keys -t "$SESSION" "$@" }
 
 wait_for() { # wait_for <regex> <timeout-seconds>
   local deadline=$(($(date +%s) + $2))
   while (($(date +%s) < deadline)); do
-    if capture | grep -qE "$1"; then return 0; fi
+    if capture_all | grep -qE "$1"; then return 0; fi
     sleep 2
   done
   return 1
 }
 
+wait_for_absent() { # wait_for_absent <regex> <timeout-seconds>
+  local deadline=$(($(date +%s) + $2))
+  while (($(date +%s) < deadline)); do
+    capture | grep -qE "$1" || return 0
+    sleep 2
+  done
+  return 1
+}
+
+# Signal-safe cleanup, installed before the first mktemp: zsh runs no EXIT trap
+# on an untrapped INT/TERM, which leaked the session and both temp trees. A
+# caller-supplied workdir is not ours to delete.
 FIXTURE=0
+cleanup() {
+  tmux kill-session -t "$SESSION" 2>/dev/null
+  rm -rf ${FAKEHOME:+"$FAKEHOME"}
+  [ "$FIXTURE" = 1 ] && rm -rf ${WORKDIR:+"$WORKDIR"}
+  return 0
+}
+trap cleanup EXIT
+trap 'cleanup; trap - INT; kill -INT $$' INT
+trap 'cleanup; trap - TERM; kill -TERM $$' TERM
+
 if [ -z "$WORKDIR" ]; then
   FIXTURE=1
   WORKDIR=$(mktemp -d)
@@ -41,7 +67,8 @@ say "workdir: $WORKDIR"
 
 # Isolated HOME: keeps the developer's global MCP servers, rules and skills out of the
 # boot (they inflate the prompt and stall session_start on failing servers) and lands
-# the trust decision in a throwaway store. See e2e-full.sh for the measured impact.
+# the trust decision in a throwaway store. Settings are an allowlist, as in e2e-full.sh:
+# only the model-selection keys ride in from the real file.
 REPO=$(cd "$(dirname "$0")/.." && pwd -P)
 FAKEHOME=$(mktemp -d)
 mkdir -p "$FAKEHOME/.pi/agent"
@@ -52,19 +79,20 @@ python3 - "$HOME/.pi/agent/settings.json" "$FAKEHOME/.pi/agent/settings.json" "$
 import json, sys
 src, dst, repo = sys.argv[1:4]
 try:
-    settings = json.load(open(src))
+    real = json.load(open(src))
 except Exception:
-    settings = {}
+    real = {}
+settings = {key: real[key] for key in ("defaultModel", "defaultProvider") if key in real}
 settings["packages"] = [repo]
 settings["defaultThinkingLevel"] = "low"
-for key in ("extensions", "skills", "prompts"):
-    settings.pop(key, None)
 json.dump(settings, open(dst, "w"))
 PY
 
+# Absolute pi path plus scrubbed config-dir vars: an inherited PI_CODING_AGENT_DIR
+# or CLAUDE_CONFIG_DIR would point the "isolated" session at the real config.
+PI_BIN=$(command -v pi)
 tmux kill-session -t "$SESSION" 2>/dev/null || true
-tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "$WORKDIR" "HOME=$FAKEHOME pi"
-trap 'tmux kill-session -t "$SESSION" 2>/dev/null || true; rm -rf "$FAKEHOME"' EXIT
+tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "$WORKDIR" "env -u PI_CODING_AGENT_DIR -u CLAUDE_CONFIG_DIR HOME=$FAKEHOME PI_SKIP_VERSION_CHECK=1 $PI_BIN"
 
 # 0. The fixture ships .claude config pi would trust silently, so pi-code must ask.
 #    Session start blocks on the answer; approve before expecting anything else.
@@ -79,21 +107,22 @@ fi
 
 # 1. Boot: all pi-code extensions load. First boot after a pi upgrade also renders the
 # changelog, and failing MCP servers block session_start serially, so allow the full budget.
-if wait_for '\[Extensions\]' 120 && capture | grep -A20 '\[Extensions\]' | grep -q 'todo.ts'; then
+if wait_for '\[Extensions\]' 120 && capture_all | grep -q 'todo.ts'; then
   ok "boot: extensions loaded"
 else
   bad "boot: extensions missing"
 fi
 
-# 2. Rules plugin announces itself
-if capture | grep -q 'Rules loaded'; then ok "rules: loaded"; else bad "rules: no announcement"; fi
+# 2. Rules banner: same known pi TUI interaction as e2e-full.sh (fast boot drops all
+# but the last session_start banner), so a warn, not a failure; the rule content is
+# wire-asserted in e2e-full.sh.
+if capture_all | grep -q 'Rules loaded'; then ok "rules: loaded"; else warn "rules: banner not rendered (known pi TUI interaction)"; fi
 
 # 3. Plan mode toggles on and off with status badge
 send "/plan" Enter
 if wait_for '⏸ plan' 15; then ok "plan-mode: badge on"; else bad "plan-mode: badge missing"; fi
 send "/plan" Enter
-sleep 2
-if capture | grep -q '⏸ plan'; then bad "plan-mode: badge stuck"; else ok "plan-mode: badge off"; fi
+if wait_for_absent '⏸ plan' 20; then ok "plan-mode: badge off"; else bad "plan-mode: badge stuck"; fi
 
 # 4. Model turn: todo tool renders the persistent overlay
 send "Use the todo tool to add two todos for testing, then use the start action on the first. Do nothing else." Enter
@@ -109,5 +138,5 @@ else
 fi
 
 print ""
-print "e2e finished: $PASS passed, $FAIL failed"
+print "e2e finished: $PASS passed, $FAIL failed, $WARN warned"
 exit $((FAIL > 0))

--- a/scripts/lib/wire-probe.ts
+++ b/scripts/lib/wire-probe.ts
@@ -1,0 +1,15 @@
+/**
+ * E2e wire probe: records every provider request payload as one JSON line in
+ * the file named by PI_E2E_WIRE. The captured payload is the deterministic
+ * oracle the e2e checks grep: what the model was actually sent, independent of
+ * model recall, and written before the transport acts, so it exists even when
+ * the request then fails (the headless smoke points the model at a dead port).
+ */
+import * as fs from 'node:fs'
+
+export default function wireProbe(pi: { on: (event: string, handler: (event: unknown) => void) => void }) {
+  pi.on('before_provider_request', (event) => {
+    const target = process.env.PI_E2E_WIRE
+    if (target) fs.appendFileSync(target, `${JSON.stringify(event)}\n`)
+  })
+}

--- a/scripts/record-demos.sh
+++ b/scripts/record-demos.sh
@@ -23,8 +23,9 @@ if ! curl -sf http://localhost:11434/api/tags 2>/dev/null | grep -q '"gpt-oss:20
   exit 1
 fi
 
-DEMO_DIR=/tmp/pi-demo
-rm -rf "$DEMO_DIR"
+# A fresh dir per run: the old fixed /tmp/pi-demo was rm -rf'd on every start,
+# colliding across users and concurrent runs on a shared machine.
+DEMO_DIR=$(mktemp -d -t pi-demo)
 mkdir -p "$DEMO_DIR/.claude/rules" "$DEMO_DIR/.claude/commands"
 git -C "$DEMO_DIR" init -qb main
 git -C "$DEMO_DIR" -c user.name=demo -c user.email=demo@local commit -q --allow-empty -m init

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,15 +20,26 @@ NOTES=${3:?release notes}
 
 gate() {
   local pr=$1
-  gh pr checks "$pr" > /dev/null \
-    && python3 ~/.claude/scripts/sonar-findings.py "$REPO_KEY" "$pr" \
+  # gh pr checks exits 8 while any check is still pending (it caused three
+  # releases to abort at this line with no message); poll on 8, fail on 1.
+  until gh pr checks "$pr" > /dev/null; do
+    local rc=$?
+    [ "$rc" -eq 8 ] || return "$rc"
+    sleep 20
+  done
+  python3 ~/.claude/scripts/sonar-findings.py "$REPO_KEY" "$pr" \
     && [ "$(curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$REPO_KEY&pullRequest=$pr" | python3 -c 'import json,sys; print(json.load(sys.stdin)["projectStatus"]["status"])')" = "OK" ] \
     && echo "GATE-OK-$pr"
 }
 
 wait_ci() {
   local branch=$1
-  until gh run list --branch "$branch" --json headSha,status -q '.[] | select(.headSha=="'"$(git rev-parse HEAD)"'") | .status' | grep -q completed; do sleep 20; done
+  local sha
+  sha=$(git rev-parse HEAD)
+  # Every run for this commit must be complete: the old any-run check returned
+  # as soon as CodeQL finished while the PR check (and its smoke job) still ran.
+  until [ -n "$(gh run list --branch "$branch" --json headSha,status -q '.[] | select(.headSha=="'"$sha"'") | .status')" ] \
+    && ! gh run list --branch "$branch" --json headSha,status -q '.[] | select(.headSha=="'"$sha"'") | .status' | grep -qv completed; do sleep 20; done
 }
 
 # Wait for the publish run CREATED AFTER the given UTC timestamp and require it


### PR DESCRIPTION
## What

QA campaign batch 5: the e2e layer.

- **Signal-safe cleanup** in both tmux scripts: traps install before the first mktemp and cover INT/TERM with re-raise (zsh runs no EXIT trap on untrapped signals; a Ctrl-C mid-model-turn leaked a live pi burning the account plus both temp trees). e2e.sh also now removes its own fixture workdir, which it never deleted.
- **Isolation**: the tmux boot resolves pi to an absolute path and unsets PI_CODING_AGENT_DIR/CLAUDE_CONFIG_DIR (either could point the "isolated" session at the real config and trust store); fakehome settings become an allowlist (model keys only) instead of copy-everything-minus-a-strip-list.
- **Oracles**: the wire probe graduates to the committed scripts/lib/wire-probe.ts and appends JSONL so a later request cannot clobber the payload under test; the subagent check counts marker occurrences past the prompt echo (the old grep could never fail; the echo contributes a fixed count and only the child's reply exceeds it); the background check requires the run to reach done, not merely register; the skills listing must reach the wire as a bad-classified plumbing check, so a discovery regression can no longer hide behind the model-declined warn.
- **Classification**: all session-start banners warn consistently (which banner survives pi's fast-boot drop is ordering luck) plus one bad check that at least one rendered, so a silenced notify path cannot hide.
- **Robustness**: two capture depths (current screen for state, scrollback for markers), wait_for_absent replaces sleep-then-grep negatives, the restore waits for its completion notice, the boot check drops its fixed grep window (it false-failed at exactly the extension count that outgrew it).
- **New checks** for previously unexercised extensions: /context usage, /agents listing, /init's analysis prompt (cancelled after the assertion to spare the full turn), and the settings env surfacing through a real bash execution.
- **A headless deterministic smoke** (scripts/e2e-smoke.sh) joins the PR check as its own CI job: it boots the pi devDependency against a dead-port model and asserts the exact provider payload (six checks) with no real model, network, or tmux.
- record-demos gets a per-run temp dir instead of a shared rm -rf'd /tmp path.

## Verification

Full e2e run green end to end: 43 passed, 0 failed, 4 warned (the four documented model/TUI warns). The smoke runs green locally and in this PR's CI. Two earlier verification runs caught and fixed a competing subagent task design and an /init check racing a non-idle session; the final design survived both.