### PR TITLE
Adopt knip and fast-check; document the hardened gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ npm install
 npm run check
 ```
 
-`npm run check` is the whole gate: [Biome](https://biomejs.dev) (format and lint), strict `tsc`, and [Vitest](https://vitest.dev) with coverage. It must pass before a change is ready.
+`npm run check` is the whole gate: [Biome](https://biomejs.dev) (format and lint), strict `tsc`, [knip](https://knip.dev) (unused exports and dependencies), and [Vitest](https://vitest.dev) with coverage floors and shuffled test order. It must pass before a change is ready. CI runs it on ubuntu and windows, node 22 and 24, plus the headless smoke.
 
 To try your changes in a real session, install the checkout and reload after edits:
 
@@ -27,6 +27,7 @@ pi install ./pi-code
 - `extensions/*.ts` are the extensions pi loads, one file per feature.
 - `extensions/internal/*.ts` are shared helpers that pi must not load as extensions (parsers, the trust check, shared-bus contracts, cross-extension seams).
 - `tests/*.ts` are the Vitest suites.
+- `scripts/e2e-smoke.sh` is the headless deterministic smoke: it boots the pi devDependency against a dead-port model and asserts the exact provider payload (no real model or network); CI runs it on every PR.
 - `scripts/e2e.sh` and `scripts/e2e-full.sh` drive a real pi TUI through tmux; they need a working local model.
 
 ## Making a change

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Vendored bases (`question`, `notify`, `status-line`) come from pi's MIT example 
 
 ```bash
 npm install
-npm run check           # biome + strict tsc + vitest, the whole gate
+npm run check           # biome + strict tsc + knip + vitest with coverage floors, the whole gate
+scripts/e2e-smoke.sh    # headless deterministic smoke: wire payload against a dead-port model, no real model (also runs in CI)
 scripts/e2e.sh          # quick smoke of the real pi TUI via tmux (needs a working model)
 scripts/e2e-full.sh     # every README feature end to end, model turns included (5-15 min)
 scripts/record-demos.sh # re-records demos/*.tape with vhs at low thinking

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -45,7 +45,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from '@earendil-works/pi-c
 import { Type } from 'typebox'
 
 import { matchesBashRules } from './internal/bash-rules.js'
-import { type CommandExec, type DiscoveredCommand, discoverCommandFiles, expandDynamicContent, type ParsedCommand, parseCommandFile, resolvePowershellBinary, spanExec, substituteArgsDetailed, substituteVars } from './internal/command-file.js'
+import { type CommandExec, type DiscoveredCommand, discoverCommandFiles, expandDynamicContent, type ParsedCommand, type PathRuleTool, parseCommandFile, resolvePowershellBinary, spanExec, substituteArgsDetailed, substituteVars } from './internal/command-file.js'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { managedSettingsFile, readManagedSettings } from './internal/managed-settings.js'
 import { capForContext } from './internal/output-guard.js'
@@ -55,8 +55,6 @@ import { isProjectApproved } from './internal/project-approval.js'
 import { ancestorDirs, repoRoot } from './internal/project-root.js'
 import { claudeSettingsChain } from './internal/settings-chain.js'
 import { createTurnOverride } from './internal/turn-override.js'
-
-type PathRuleTool = 'read' | 'edit' | 'write'
 
 /** Just enough of pi's Model to match and restore; getAvailable returns these. */
 interface ModelLike {

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -307,7 +307,7 @@ export function parseCommandFile(content: string): ParsedCommand {
 }
 
 /** Split a raw argument string, keeping quoted runs together. */
-export function splitArgs(args: string): string[] {
+function splitArgs(args: string): string[] {
   const out: string[] = []
   const pattern = /"([^"]*)"|'([^']*)'|(\S+)/g
   let match = pattern.exec(args)

--- a/extensions/plan-mode/utils.ts
+++ b/extensions/plan-mode/utils.ts
@@ -120,7 +120,7 @@ export interface TodoItem {
   completed: boolean
 }
 
-export function cleanStepText(text: string): string {
+function cleanStepText(text: string): string {
   let cleaned = text
     .replace(/\*{1,2}([^*]+)\*{1,2}/g, '$1') // Remove bold/italic
     .replace(/`([^`]+)`/g, '$1') // Remove code

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "entry": [
+    "extensions/*.ts",
+    "extensions/*/index.ts",
+    "tests/**/*.test.ts",
+    "scripts/lib/wire-probe.ts"
+  ],
+  "project": [
+    "extensions/**/*.ts",
+    "tests/**/*.ts"
+  ],
+  "ignoreExportsUsedInFile": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@earendil-works/pi-tui": "^0.84.2",
         "@types/node": "^26.1.1",
         "@vitest/coverage-v8": "^4.1.10",
+        "fast-check": "^4.9.0",
+        "knip": "^6.34.0",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10"
       },
@@ -651,9 +653,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -671,9 +670,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -691,9 +687,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -711,9 +704,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2791,6 +2781,40 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
@@ -2896,6 +2920,28 @@
         }
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -2904,6 +2950,329 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.147.0.tgz",
+      "integrity": "sha512-fOtoGvIoirkvxQVw9J1WJPxz571XPgLsPf9uhRD+PJteUnvrJHMDmK9pw2yZEGGyismtRoEsp+JcXUdF/JDMDw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.147.0.tgz",
+      "integrity": "sha512-emjQHOYJaomo4ykaXQ1EItunr/I94Nk01oqBmU4dSkKSTupIDx6OysVDf2e8Eytm77rb+4ZxzgElyWP7rcEX7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.147.0.tgz",
+      "integrity": "sha512-kXvBPJL7RmDPJ2mze/vXPPVQimCDtFr9OFLjf7dyhV5Dx64cgcXh9KKrA1sMWvCObvJll9CZZUO0FBlFwD0l6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.147.0.tgz",
+      "integrity": "sha512-mgFF8pLU6R64LbT27lSrtVRspVC/3IcZ0qyIikzmi78Y3Ik2OPnlAHHI0UEBRcC3qmNgtjaef7zkFt7/uPxIcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.147.0.tgz",
+      "integrity": "sha512-v38aiF11qufOTBcCAKL4skgQf0zJ4NEvRlivq7B5kHrlyvjCLjvNrMtNWDTz1SDUL6/xVsJRmLDxv2e+Cp4oWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.147.0.tgz",
+      "integrity": "sha512-AeIiBbwUaP0H1+4/qGW9l5qHecS/+XA5iMuieVcGb1T+tyc2dVGspFW13BWk/XrLsiGP/CiDJTJqAPLLCzZHkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.147.0.tgz",
+      "integrity": "sha512-/41MKPW4RgPY4DJco0NCF0RYX3IMZaVlRNMNzvhaxRavc7tN3Txm+qllZbh0aMRs0VHdgUlbI8TcAOiTai4TKg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.147.0.tgz",
+      "integrity": "sha512-bmpw/RPhVXgZbtb3xBDuwW5s8+LvZYdqcDSX/sP2ltL77aTio3DP/B5ZTwwgoJ6Mr9vJs4RrmgEKW9XkLNUU1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.147.0.tgz",
+      "integrity": "sha512-gd7VX/FDVOw6mjQcu45iIcp4QkgybgJwh3a0OFG2NxmPCj628mQWD96QGu1kK8+mZF9qK4b/gIEyC63vQoB7+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.147.0.tgz",
+      "integrity": "sha512-HnAzcfki7dSUNHf510Q2NmbJlz8Ys7rn8l9l588Pkx0tYe1BHLZnmELIgqizJ4WPhHGSwN8Ce+B/menVxS3odA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.147.0.tgz",
+      "integrity": "sha512-qlkOL6wT44U+fT5s/+sR6Shx0OdwvQF83JyIPZUxG/ovqZF5/7atOtjH+JPZ5/7ATQLbFBBSmghcy/+2NVB/ew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.147.0.tgz",
+      "integrity": "sha512-DlefD7L7sMXs/3hIBH23Egk0phj8kG0SA81dVGOQ3S1ekjOlmTLH2E+F2Thwfh1slKx6aH+lNc5fQYAw0GU7/g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.147.0.tgz",
+      "integrity": "sha512-Xqpagk/031IvZ4svrk2FF01YEqM/iN3MJV3SVZadKg/CsGlDCGoREqKHXYnoV5+8SfGe/m6RM1szXFLusTu/Uw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.147.0.tgz",
+      "integrity": "sha512-QioQOeUbI4ATUr0S2z88uA3Cds2R3Mm5Ge7U8XNYtlTb2GJF3rWlcj70z0AJhhOlbdm0YgVjqPBldUNbFylDIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.147.0.tgz",
+      "integrity": "sha512-NXy1tv/OdC+pPTwf9RiCZWPK53V/Xq/2cjSnjOSyKopajdaDqMIkgtDY+jXZemp2e8px5FeWfY2L2LwhKZQovg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.147.0.tgz",
+      "integrity": "sha512-GpGWZ6oKz4bjCWW9Mz5pCaGPyk2Aaze6zEoaslIQqpSLtpx5pXj/ap5gUNb5Jn2LIbqWyjkGLX9yv3NMuNcBVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.147.0.tgz",
+      "integrity": "sha512-a8mlt7CC8z7LUdCfaxhff4kCd+vSjE+NEFL0cxA8ukfuSnvAto/pWTjytW4BuVLnQGcCVdHJwcRKOfs++H+tjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.147.0.tgz",
+      "integrity": "sha512-M5ViVDBcFLnl2632AuuWuP35zEL5oikK1jTx8r3+902VEDeSNHxFZAB6RZyfZ7MU6Oi5QTOG8MmMkIeHsudSaw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.147.0.tgz",
+      "integrity": "sha512-DUaE13OwnUSlHpLZNcC/nuT10ivlWqc5EZgsfgXuAmWYw0r3nDxGeLD1zlGwYwIgVk1/ZMAxoXpV+05stvbHaA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -2915,6 +3284,277 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+      "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+      "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+      "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+      "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+      "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+      "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+      "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+      "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+      "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+      "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+      "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+      "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+      "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+      "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+      "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+      "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+      "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+      "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+      "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -3075,9 +3715,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3095,9 +3732,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3115,9 +3749,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3135,9 +3766,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3155,9 +3783,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3175,9 +3800,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3379,6 +4001,17 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -4449,6 +5082,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4470,6 +5126,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4532,6 +5198,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/formatly": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.7.0.tgz",
+      "integrity": "sha512-7CXJtIIA0zy/u12StsYk25qVKxvdLA2ep2sTNxK3ov0mGNIIDqIvAXDSgTnAfDJFsPfWjuz0WjfYSdpvnLA5Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^2.0.0",
+        "package-manager-detector": "^1.8.0"
+      },
+      "bin": {
+        "formatly": "bin/index.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -4667,6 +5350,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.3.tgz",
+      "integrity": "sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/google-auth-library": {
@@ -4908,6 +5604,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.9",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
@@ -4981,6 +5687,45 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/knip": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.34.0.tgz",
+      "integrity": "sha512-bbHIrnGspYwe4EBPjjx+lvkUor0F2qfKQc5BPzPI4SOAImYA+k2ueVpIcF7d/W1LEVT7XoJUPt6zELeGZhXBgA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/knip"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "formatly": "^0.7.0",
+        "get-tsconfig": "4.14.3",
+        "jiti": "^2.7.0",
+        "oxc-parser": "^0.147.0",
+        "oxc-resolver": "11.24.2",
+        "picomatch": "^4.0.7",
+        "smol-toml": "^1.8.0",
+        "strip-json-comments": "5.0.3",
+        "tinyglobby": "^0.2.17",
+        "unbash": "^4.0.10",
+        "yaml": "^2.9.0",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "knip": "bin/knip.js",
+        "knip-bun": "bin/knip-bun.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/lightningcss": {
@@ -5126,9 +5871,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5150,9 +5892,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5174,9 +5913,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5198,9 +5934,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5522,6 +6255,84 @@
         }
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.147.0.tgz",
+      "integrity": "sha512-5xaug6t7GfV3BO5Iv+xHW1rmQkDEQ3BEu3L8g3InsvWO5i8CYGc4tCZ2X985QcwWNycFJam+aOns6Nr2XAThTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.147.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.147.0",
+        "@oxc-parser/binding-android-arm64": "0.147.0",
+        "@oxc-parser/binding-darwin-arm64": "0.147.0",
+        "@oxc-parser/binding-darwin-x64": "0.147.0",
+        "@oxc-parser/binding-freebsd-x64": "0.147.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.147.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.147.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.147.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.147.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.147.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.147.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.147.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.147.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.147.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.147.0"
+      }
+    },
+    "node_modules/oxc-parser/node_modules/@oxc-project/types": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+      "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+        "@oxc-resolver/binding-android-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-x64": "11.24.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
+      }
+    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -5535,6 +6346,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -5586,9 +6404,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5673,6 +6491,23 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -5724,6 +6559,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/retry": {
@@ -5976,6 +6821,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6008,6 +6866,19 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -6159,6 +7030,16 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/unbash": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.11.tgz",
+      "integrity": "sha512-FoSOKV7NEofQSkAefMVHam4ZPKYMxjAydxiV72UFEDNV/YofxjGfiZ2A9pZjdL/lRJzTjcu4PABo1JYJX8N5iQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/undici-types": {
@@ -6352,6 +7233,16 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "biome:fix": "npx --no-install @biomejs/biome check --write .",
     "type:check": "tsc --noEmit",
     "test": "vitest run --coverage",
-    "check": "npm run biome && npm run type:check && npm run test",
-    "prepublishOnly": "npm run check"
+    "check": "npm run biome && npm run type:check && npm run knip && npm run test",
+    "prepublishOnly": "npm run check",
+    "knip": "npx --no-install knip"
   },
   "engines": {
     "node": ">=22.19"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "@earendil-works/pi-tui": "^0.84.2",
     "@types/node": "^26.1.1",
     "@vitest/coverage-v8": "^4.1.10",
+    "fast-check": "^4.9.0",
+    "knip": "^6.34.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   }

--- a/tests/properties.test.ts
+++ b/tests/properties.test.ts
@@ -19,7 +19,7 @@ describe('substituteArgs properties', () => {
   const token = fc.stringMatching(/^[!#-&(-~]{1,20}$/).filter((s) => !s.includes("'") && !s.includes('"'))
 
   it('returns an argument byte-for-byte through $0, metacharacters included', () => {
-    fc.assert(
+    void fc.assert(
       fc.property(token, (arg) => {
         expect(substituteArgs('$0', arg)).toBe(arg)
       }),
@@ -28,7 +28,7 @@ describe('substituteArgs properties', () => {
   })
 
   it('never re-expands placeholder text arriving inside an argument (one pass)', () => {
-    fc.assert(
+    void fc.assert(
       fc.property(token, (arg) => {
         const carrying = `${arg}$ARGUMENTS`
         expect(substituteArgs('$ARGUMENTS', carrying)).toBe(carrying)
@@ -43,7 +43,7 @@ describe('path-rules properties', () => {
   const seg = fc.stringMatching(/^[a-z0-9]{1,6}$/)
 
   it('brace expansion is equivalent to the union of its alternatives', () => {
-    fc.assert(
+    void fc.assert(
       fc.property(seg, seg, seg, seg, (x, y, pre, post) => {
         const target = `${pre}${x}${post}.md`
         const braced = matchesPathRules(target, [`${pre}{${x},${y}}${post}.md`], anchors)
@@ -55,7 +55,7 @@ describe('path-rules properties', () => {
   })
 
   it('compiles any printable pattern without throwing, to a constructible regex', () => {
-    fc.assert(
+    void fc.assert(
       fc.property(fc.stringMatching(/^[ -~]{0,30}$/), (pattern) => {
         const source = globToRegExpSource(pattern)
         expect(() => new RegExp(source)).not.toThrow()
@@ -71,7 +71,7 @@ describe('interpolateEnv properties', () => {
   const value = fc.stringMatching(/^[ -~]{0,25}$/)
 
   it('returns the environment value verbatim, whatever it contains', () => {
-    fc.assert(
+    void fc.assert(
       fc.property(value, (v) => {
         expect(interpolateEnv('${X}', { X: v })).toBe(v)
       }),
@@ -80,7 +80,7 @@ describe('interpolateEnv properties', () => {
   })
 
   it('honors the shell :- contract: unset OR empty falls back to the default', () => {
-    fc.assert(
+    void fc.assert(
       fc.property(fc.stringMatching(/^[ -|~]{0,20}$/), (fallback) => {
         expect(interpolateEnv(`\${X:-${fallback}}`, {})).toBe(fallback)
         expect(interpolateEnv(`\${X:-${fallback}}`, { X: '' })).toBe(fallback)
@@ -95,7 +95,7 @@ describe('hook matcher properties', () => {
   const fold = (value: string): string => value.toLowerCase().replaceAll('-', '_')
 
   it('an exact list matches exactly its members, case- and dash-folded, cache or not', () => {
-    fc.assert(
+    void fc.assert(
       fc.property(fc.array(name, { minLength: 1, maxLength: 5 }), name, fc.constantFrom(', ', '|'), (members, candidate, sep) => {
         const matcher = members.join(sep)
         const config = [{ matcher, hooks: [{ command: 'x' }] }]
@@ -105,7 +105,11 @@ describe('hook matcher properties', () => {
         // generator: every member must match its own case-flipped, dash-to-
         // underscore variant (random draws almost never produce near-miss pairs,
         // which let a fold mutant survive the differential alone).
-        const variant = members[0].replaceAll('-', '_').split('').map((ch, i) => (i % 2 ? ch.toUpperCase() : ch.toLowerCase())).join('')
+        const variant = members[0]
+          .replaceAll('-', '_')
+          .split('')
+          .map((ch, i) => (i % 2 ? ch.toUpperCase() : ch.toLowerCase()))
+          .join('')
         expect(matchingCommands(config, variant).length > 0).toBe(true)
         // Cache transparency: a cold cache answers identically.
         resetMatcherCache()

--- a/tests/properties.test.ts
+++ b/tests/properties.test.ts
@@ -1,0 +1,117 @@
+import * as fc from 'fast-check'
+import { describe, expect, it } from 'vitest'
+
+import { matchingCommands, resetMatcherCache } from '../extensions/hooks/index.ts'
+import { substituteArgs } from '../extensions/internal/command-file.ts'
+import { globToRegExpSource, matchesPathRules } from '../extensions/internal/path-rules.ts'
+import { interpolateEnv } from '../extensions/mcp/config.ts'
+
+// Property-based pins for the parser-shaped modules: each property is a stated
+// invariant from the module's contract, explored across generated inputs and
+// shrunk to a minimal counterexample on failure. Seeds are fast-check's own
+// (reported on failure for replay), runs are bounded for suite speed.
+const RUNS = { numRuns: 200 }
+
+describe('substituteArgs properties', () => {
+  // A single whitespace/quote-free token: $0 must return it byte-for-byte. The
+  // replacer-function form guarantees $&-style metacharacters in the ARGUMENT
+  // are never interpreted as replacement patterns (a real past defect class).
+  const token = fc.stringMatching(/^[!#-&(-~]{1,20}$/).filter((s) => !s.includes("'") && !s.includes('"'))
+
+  it('returns an argument byte-for-byte through $0, metacharacters included', () => {
+    fc.assert(
+      fc.property(token, (arg) => {
+        expect(substituteArgs('$0', arg)).toBe(arg)
+      }),
+      RUNS,
+    )
+  })
+
+  it('never re-expands placeholder text arriving inside an argument (one pass)', () => {
+    fc.assert(
+      fc.property(token, (arg) => {
+        const carrying = `${arg}$ARGUMENTS`
+        expect(substituteArgs('$ARGUMENTS', carrying)).toBe(carrying)
+      }),
+      RUNS,
+    )
+  })
+})
+
+describe('path-rules properties', () => {
+  const anchors = { cwd: '/proj/sub', projectRoot: '/proj', home: '/home/u' }
+  const seg = fc.stringMatching(/^[a-z0-9]{1,6}$/)
+
+  it('brace expansion is equivalent to the union of its alternatives', () => {
+    fc.assert(
+      fc.property(seg, seg, seg, seg, (x, y, pre, post) => {
+        const target = `${pre}${x}${post}.md`
+        const braced = matchesPathRules(target, [`${pre}{${x},${y}}${post}.md`], anchors)
+        const union = matchesPathRules(target, [`${pre}${x}${post}.md`], anchors) || matchesPathRules(target, [`${pre}${y}${post}.md`], anchors)
+        expect(braced).toBe(union)
+      }),
+      RUNS,
+    )
+  })
+
+  it('compiles any printable pattern without throwing, to a constructible regex', () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^[ -~]{0,30}$/), (pattern) => {
+        const source = globToRegExpSource(pattern)
+        expect(() => new RegExp(source)).not.toThrow()
+      }),
+      RUNS,
+    )
+  })
+})
+
+describe('interpolateEnv properties', () => {
+  // Any printable value, including ones that look like ${OTHER} or carry $&:
+  // the function-form replace must never rescan or reinterpret them.
+  const value = fc.stringMatching(/^[ -~]{0,25}$/)
+
+  it('returns the environment value verbatim, whatever it contains', () => {
+    fc.assert(
+      fc.property(value, (v) => {
+        expect(interpolateEnv('${X}', { X: v })).toBe(v)
+      }),
+      RUNS,
+    )
+  })
+
+  it('honors the shell :- contract: unset OR empty falls back to the default', () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^[ -|~]{0,20}$/), (fallback) => {
+        expect(interpolateEnv(`\${X:-${fallback}}`, {})).toBe(fallback)
+        expect(interpolateEnv(`\${X:-${fallback}}`, { X: '' })).toBe(fallback)
+      }),
+      RUNS,
+    )
+  })
+})
+
+describe('hook matcher properties', () => {
+  const name = fc.stringMatching(/^[A-Za-z][\w-]{0,10}$/)
+  const fold = (value: string): string => value.toLowerCase().replaceAll('-', '_')
+
+  it('an exact list matches exactly its members, case- and dash-folded, cache or not', () => {
+    fc.assert(
+      fc.property(fc.array(name, { minLength: 1, maxLength: 5 }), name, fc.constantFrom(', ', '|'), (members, candidate, sep) => {
+        const matcher = members.join(sep)
+        const config = [{ matcher, hooks: [{ command: 'x' }] }]
+        const naive = members.some((member) => fold(member) === fold(candidate))
+        expect(matchingCommands(config, candidate).length > 0).toBe(naive)
+        // The discriminating fold case, derived rather than hoped for from the
+        // generator: every member must match its own case-flipped, dash-to-
+        // underscore variant (random draws almost never produce near-miss pairs,
+        // which let a fold mutant survive the differential alone).
+        const variant = members[0].replaceAll('-', '_').split('').map((ch, i) => (i % 2 ? ch.toUpperCase() : ch.toLowerCase())).join('')
+        expect(matchingCommands(config, variant).length > 0).toBe(true)
+        // Cache transparency: a cold cache answers identically.
+        resetMatcherCache()
+        expect(matchingCommands(config, candidate).length > 0).toBe(naive)
+      }),
+      RUNS,
+    )
+  })
+})


### PR DESCRIPTION
## What

QA campaign batch 6: the tooling adoptions the audit ranked worth their cost, plus the docs catching up with the gate.

- **knip in the check chain**: `npm run check` now runs knip between tsc and vitest with an entry config for the dynamic loader roots. Its three verified findings are fixed: `splitArgs` and `cleanStepText` were exported but used only internally; `PathRuleTool` existed twice (an unused export beside a local duplicate in `commands.ts`, a drift hazard) and is now imported from its one definition.
- **fast-check properties** for the parser-shaped modules: `substituteArgs` returns arguments byte-for-byte (replacement metacharacters included, the past defect class) and never re-expands placeholder text in one pass; path-rules brace expansion equals the union of its alternatives and any printable pattern compiles; `interpolateEnv` returns values verbatim and honors the shell `:-` contract on unset and empty; the hook matcher matches exactly its folded member list, identically on a cold cache (mutation-checked: dropping dash folding fails the differential).
- **Docs**: README and CONTRIBUTING now describe the check chain (biome, tsc, knip, vitest with coverage floors and shuffled order), the CI matrix, and the headless smoke alongside the tmux e2e scripts.

Stryker was spiked and deferred with evidence (Stryker 10 is incompatible with TypeScript 7's JS API, and its non-isolated vitest worker leaks module-level caches across test files); its devDependencies are not kept.

## Verification

`npm run check` green with knip in the chain (2016 tests). Every property was watched failing under a mutant of its module.
