### PR TITLE
Raise vitest testTimeout to 20s for spawn-heavy tests on slow runners

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     // Host-env quarantine + per-test env snapshot: the suite runs inside
     // Claude Code / pi subagents whose env carries variables the source reads.
     setupFiles: ['tests/setup.ts'],
+    // A hang detector, not a budget: tests spawn real git and shell processes,
+    // and a loaded Windows runner has pushed an 88ms-local test past the 5s default.
+    testTimeout: 20_000,
     // Mock hygiene is enforced globally so no test depends on a neighbor's spies
     // or stubbed env surviving; shuffle probes order-independence with a fresh
     // seed on every run.


### PR DESCRIPTION
Sets `testTimeout: 20_000` in `vitest.config.ts`.

The git-checkpoint tests drive a real shadow repo through several git processes per test. They finish in under 100ms locally, but a loaded windows-latest runner (module import alone took 55s there) pushed `collapses runs of whitespace in the prompt snippet` past the 5s default and failed the leg. The timeout only needs to catch hung tests, so 20s keeps that role without tripping on runner load.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [ ] Tests cover the change (config only; a timeout ceiling is not assertable from inside the suite)
