### PR TITLE
Strip tags and index comments with a scanner instead of a regex

### DIFF
--- a/extensions/internal/html-markdown.ts
+++ b/extensions/internal/html-markdown.ts
@@ -5,7 +5,8 @@
  * A regex pipeline, not a DOM: pi ships no HTML parser and the output is prose
  * for a model, not a rendering. Every pattern bounds its tag matches with
  * [^<>]* so a failed match stops at the next tag instead of rescanning to the
- * end of input, keeping the pass linear on hostile pages.
+ * end of input, keeping the pass linear on hostile pages. Bare tag removal is a
+ * scanner rather than a regex: see removeTags.
  */
 
 const NAMED_ENTITIES: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' }
@@ -18,7 +19,34 @@ function decodeAllEntities(text: string): string {
   })
 }
 
-const stripInnerTags = (html: string): string => html.replace(/<[^<>]*>/g, '')
+/** The HTML tokenizer's tag-open rule: `<` starts a tag only before a letter, `/`,
+ * `!`, or `?`; any other `<` (as in `1 < 2`) is text. */
+const TAG_OPEN = /^<[A-Za-z/!?]/
+
+/**
+ * Drop every tag in one linear pass. A regex strip can rebuild a tag out of nested
+ * brackets: `<scr<b>ipt>` loses `<b>` and becomes `<script>` (CodeQL's incomplete
+ * multi-character sanitization). Skipping from a tag's `<` to the next `>` removes the
+ * whole span, so nothing removed can reassemble; a tag that never closes stays as text.
+ */
+export function removeTags(html: string): string {
+  let out = ''
+  let cursor = 0
+  while (cursor < html.length) {
+    const open = html.indexOf('<', cursor)
+    if (open === -1) return out + html.slice(cursor)
+    if (!TAG_OPEN.test(html.slice(open, open + 2))) {
+      out += html.slice(cursor, open + 1)
+      cursor = open + 1
+      continue
+    }
+    const close = html.indexOf('>', open + 1)
+    if (close === -1) return out + html.slice(cursor)
+    out += html.slice(cursor, open)
+    cursor = close + 1
+  }
+  return out
+}
 
 // Strip leading and trailing newline runs in linear time. The equivalent
 // /^\n+|\n+$/g backtracks super-linearly on a long run of newlines (S8786).
@@ -37,23 +65,23 @@ export function htmlToMarkdown(html: string): string {
     .replace(/<!--[\s\S]*?-->/g, ' ')
     .replace(/<(script|style|noscript|head|svg)\b[^<>]*>[\s\S]*?<\/\1[^<>]*>/gi, ' ')
     .replace(/<pre\b[^<>]*>([\s\S]*?)<\/pre>/gi, (_whole, inner: string) => {
-      preBodies.push(trimNewlines(decodeAllEntities(stripInnerTags(inner))))
+      preBodies.push(trimNewlines(decodeAllEntities(removeTags(inner))))
       return `\n\n\uE000PRE${preBodies.length - 1}\uE000\n\n`
     })
 
   work = work
-    .replace(/<code\b[^<>]*>([\s\S]*?)<\/code>/gi, (_whole, inner: string) => `\`${stripInnerTags(inner)}\``)
+    .replace(/<code\b[^<>]*>([\s\S]*?)<\/code>/gi, (_whole, inner: string) => `\`${removeTags(inner)}\``)
     // Only real web links become markdown links; fragment and javascript hrefs
     // keep their label and lose the target.
     .replace(/<a\b[^<>]*?href=(?:"([^"]*)"|'([^']*)')[^<>]*>([\s\S]*?)<\/a>/gi, (_whole, dq: string | undefined, sq: string | undefined, inner: string) => {
       const href = decodeAllEntities(dq ?? sq ?? '')
-      const label = stripInnerTags(inner).trim()
+      const label = removeTags(inner).trim()
       if (!label) return ' '
       return /^https?:\/\//i.test(href) ? `[${label}](${href})` : label
     })
-    .replace(/<(strong|b)\b[^<>]*>([\s\S]*?)<\/\1>/gi, (_whole, _tag, inner: string) => `**${stripInnerTags(inner).trim()}**`)
-    .replace(/<(em|i)\b[^<>]*>([\s\S]*?)<\/\1>/gi, (_whole, _tag, inner: string) => `*${stripInnerTags(inner).trim()}*`)
-    .replace(/<h([1-6])\b[^<>]*>([\s\S]*?)<\/h\1>/gi, (_whole, level: string, inner: string) => `\n\n${'#'.repeat(Number(level))} ${stripInnerTags(inner).trim()}\n\n`)
+    .replace(/<(strong|b)\b[^<>]*>([\s\S]*?)<\/\1>/gi, (_whole, _tag, inner: string) => `**${removeTags(inner).trim()}**`)
+    .replace(/<(em|i)\b[^<>]*>([\s\S]*?)<\/\1>/gi, (_whole, _tag, inner: string) => `*${removeTags(inner).trim()}*`)
+    .replace(/<h([1-6])\b[^<>]*>([\s\S]*?)<\/h\1>/gi, (_whole, level: string, inner: string) => `\n\n${'#'.repeat(Number(level))} ${removeTags(inner).trim()}\n\n`)
     .replace(/<img\b[^<>]*?alt=(?:"([^"]*)"|'([^']*)')[^<>]*>/gi, (_whole, dq?: string, sq?: string) => dq ?? sq ?? '')
     .replace(/<li\b[^<>]*>/gi, '\n- ')
     .replace(/<blockquote\b[^<>]*>/gi, '\n\n> ')
@@ -61,7 +89,7 @@ export function htmlToMarkdown(html: string): string {
     .replace(/<(?:br|hr)\b[^<>]*>/gi, '\n')
     .replace(/<\/(?:p|div|section|article|ul|ol|li|table|tr|blockquote|tbody|thead|header|footer|main|nav)[^<>]*>/gi, '\n\n')
 
-  const text = decodeAllEntities(work.replace(/<[^<>]*>/g, ''))
+  const text = decodeAllEntities(removeTags(work))
     .replace(/[ \t]+/g, ' ')
     .replace(/ ?\n ?/g, '\n')
     .replace(/\n{3,}/g, '\n\n')

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -98,11 +98,31 @@ export function stampModified(content: string, iso: string): string {
   return `---\n${body}modified: ${iso}\n---${rest}`
 }
 
+/** Drop every `<!-- ... -->` (and the line break after it) in one pass. A regex strip
+ * can rebuild a comment from one nested in another: `<!-<!-- x -->-- y -->` loses the
+ * inner comment and becomes `<!--- y -->`. After a removal the scan resumes three
+ * characters back, so a comment assembled across the cut is removed too; an opener
+ * that never closes stays as text. */
+function removeComments(text: string): string {
+  let out = text
+  let cursor = 0
+  while (cursor < out.length) {
+    const open = out.indexOf('<!--', cursor)
+    const close = open === -1 ? -1 : out.indexOf('-->', open + 4)
+    if (close === -1) return out
+    const tail = out.slice(close + 3)
+    const lineBreak = tail.startsWith('\r\n') ? 2 : tail.startsWith('\n') ? 1 : 0
+    out = out.slice(0, open) + tail.slice(lineBreak)
+    cursor = Math.max(0, open - 3)
+  }
+  return out
+}
+
 /** The index content that actually loads: YAML frontmatter and block-level HTML
  * comments are stripped, so they neither show in the prompt nor count toward the
  * 200-line / 25KB read limits, matching Claude Code. */
 export function stripNonLoaded(text: string): string {
-  return text.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '').replace(/<!--[\s\S]*?-->\r?\n?/g, '')
+  return removeComments(text.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, ''))
 }
 
 /** Move a store written under an older slug to the current one, once. Two earlier

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -98,6 +98,12 @@ export function stampModified(content: string, iso: string): string {
   return `---\n${body}modified: ${iso}\n---${rest}`
 }
 
+/** Length of the line break `text` starts with: CRLF, LF, or none. */
+function leadingLineBreak(text: string): number {
+  if (text.startsWith('\r\n')) return 2
+  return text.startsWith('\n') ? 1 : 0
+}
+
 /** Drop every `<!-- ... -->` (and the line break after it) in one pass. A regex strip
  * can rebuild a comment from one nested in another: `<!-<!-- x -->-- y -->` loses the
  * inner comment and becomes `<!--- y -->`. After a removal the scan resumes three
@@ -111,8 +117,7 @@ function removeComments(text: string): string {
     const close = open === -1 ? -1 : out.indexOf('-->', open + 4)
     if (close === -1) return out
     const tail = out.slice(close + 3)
-    const lineBreak = tail.startsWith('\r\n') ? 2 : tail.startsWith('\n') ? 1 : 0
-    out = out.slice(0, open) + tail.slice(lineBreak)
+    out = out.slice(0, open) + tail.slice(leadingLineBreak(tail))
     cursor = Math.max(0, open - 3)
   }
   return out

--- a/extensions/web.ts
+++ b/extensions/web.ts
@@ -13,7 +13,7 @@ import type { Usage } from '@earendil-works/pi-ai'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { Type } from 'typebox'
 
-import { htmlToMarkdown } from './internal/html-markdown.js'
+import { htmlToMarkdown, removeTags } from './internal/html-markdown.js'
 import { completeText } from './internal/model-complete.js'
 import { capForContext } from './internal/output-guard.js'
 import { httpFetch } from './internal/web-transport.js'
@@ -40,11 +40,7 @@ export function decodeEntities(text: string): string {
 }
 
 export function stripTags(html: string): string {
-  // [^<>] rather than [^>]: excluding `<` bounds a failed match at the next tag start
-  // instead of rescanning to end of input, which is what makes the strip linear.
-  return decodeEntities(html.replace(/<[^<>]*>/g, ''))
-    .replace(/\s+/g, ' ')
-    .trim()
+  return decodeEntities(removeTags(html)).replace(/\s+/g, ' ').trim()
 }
 
 /** Resolve DuckDuckGo's redirect links (/l/?uddg=<encoded>) to the target URL. */

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -175,6 +175,18 @@ describe('stripNonLoaded', () => {
     expect(stripped).toContain('# Memory index')
     expect(stripped).toContain('- [a](a.md): first')
   })
+
+  it('cannot reassemble a comment from a comment nested inside another', () => {
+    // A single regex pass removes the inner comment and leaves <!--- y --> behind.
+    const stripped = stripNonLoaded('<!-<!-- x -->-- zzz -->\n# Memory index\n')
+    expect(stripped).not.toContain('<!--')
+    expect(stripped).not.toContain('zzz')
+    expect(stripped).toBe('# Memory index\n')
+  })
+
+  it('keeps an unterminated comment opener as text', () => {
+    expect(stripNonLoaded('# Memory index\n<!-- open')).toBe('# Memory index\n<!-- open')
+  })
 })
 
 describe('autoMemoryEnabled', () => {

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -71,6 +71,25 @@ describe('web helpers', () => {
     expect(decodeEntities('&lt;x&gt;')).toBe('<x>')
   })
 
+  it('cannot reassemble a tag from nested brackets', () => {
+    // A regex strip removes the inner <b> and leaves <script> behind.
+    expect(stripTags('<scr<b>ipt>alert(1)</script>x')).not.toContain('<script')
+    expect(stripTags('<scr<b>ipt>alert(1)</script>x')).toBe('ipt>alert(1)x')
+  })
+
+  it('keeps a lone < with no closing > as text', () => {
+    expect(stripTags('1 < 2 and <b>3</b>')).toBe('1 < 2 and 3')
+    expect(stripTags('a <b')).toBe('a <b')
+  })
+
+  it('strips a page of nested tag openers in one pass', () => {
+    expect(stripTags(`${'<a<b'.repeat(100_000)}>`)).toBe('')
+  })
+
+  it('leaves a < that opens no tag alone, as the HTML tokenizer does', () => {
+    expect(stripTags('x <3 y <<b>z</b>')).toBe('x <3 y <z')
+  })
+
   it('classifies private and internal addresses for the SSRF guard', () => {
     for (const ip of ['127.0.0.1', '10.1.2.3', '172.16.0.1', '172.31.255.255', '192.168.1.1', '169.254.169.254', '100.64.0.1', '0.0.0.0', '::1', '::', 'fe80::1', 'fd00::1', 'fc00::1', '::ffff:127.0.0.1', 'not-an-ip']) {
       expect(isPrivateAddress(ip), ip).toBe(true)
@@ -88,6 +107,12 @@ describe('web helpers', () => {
     for (const ip of ['2606:4700:4700::1111', '2001:4860:4860::8888']) {
       expect(isPrivateAddress(ip), ip).toBe(false)
     }
+  })
+
+  it('does not leave a script tag behind when brackets nest inside one', () => {
+    const md = htmlToMarkdown('<p>see</p><scr<b>ipt>alert(1)</script><p>done</p>')
+    expect(md).not.toContain('<script')
+    expect(md).toContain('done')
   })
 
   it('converts html to markdown, dropping script and style bodies', () => {


### PR DESCRIPTION
Replaces the four regex strips CodeQL reports as incomplete multi-character sanitization (`js/incomplete-multi-character-sanitization`, alerts #1 to #4) with single-pass scanners in `extensions/internal/html-markdown.ts`, `extensions/web.ts`, and `extensions/memory.ts`, each paired with a test that fails on the old code.

## Sanitization that could rebuild what it removed

- **A tag strip cannot reassemble a tag from nested brackets** (`html-markdown.ts` `removeTags`, used by `htmlToMarkdown` twice and by `web.ts` `stripTags`). The global `/<[^<>]*>/g` removed the inner `<b>` from `<scr<b>ipt>alert(1)</script>` and left `<script>alert(1)` in the text the model reads. The scanner skips from a tag's `<` to the next `>`, so the whole span goes and `ipt>alert(1)` remains; it is one linear pass, so a page of 100,000 nested openers strips as fast as any other.
- **A `<` that opens no tag stays text** (`removeTags`): the HTML tokenizer's rule applies, a tag starts only before a letter, `/`, `!`, or `?`, so `1 < 2 and <b>3</b>` still yields `1 < 2 and 3` and `a <b` with no closing `>` is kept, matching the previous output for prose.
- **A memory index comment strip cannot reassemble a comment** (`memory.ts` `stripNonLoaded`). The global `/<!--[\s\S]*?-->/g` turned `<!-<!-- x -->-- zzz -->` into `<!--- zzz -->`, which then counted toward the index's line and byte budget. The scanner removes each comment with its trailing line break and resumes three characters before the cut, so a comment assembled across it is removed too; an unterminated `<!--` stays as text, as before.
