### PR TITLE
Release 1.0.48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-code",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-code",
-      "version": "1.0.47",
+      "version": "1.0.48",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-code",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, subagents, and goals",
   "keywords": [
     "pi",


### PR DESCRIPTION
Bumps `package.json` and `package-lock.json` from 1.0.47 to 1.0.48; no other file changes.

The release ships the `/goal` command (a session-scoped completion condition a separate model judges after every turn, with block cap, background-work deferral, resume, gating, and headless support) and the scanner-based tag and memory-index comment stripping that replaces the regex strips CodeQL flagged.
