### PR TITLE
Fix session-state restore, span timeouts, checkpoint excludes, and scanner edge cases

### DIFF
--- a/extensions/claude-rules.ts
+++ b/extensions/claude-rules.ts
@@ -68,7 +68,8 @@ function parsePaths(frontmatter: string): string[] {
 
 /** Split YAML-ish frontmatter off the front of a rule file, extracting `paths`. */
 export function parseFrontmatter(content: string): Frontmatter {
-  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(content)
+  // A leading byte order mark (Windows editors add one) is part of the header, not the body.
+  const match = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(content)
   if (!match) return { paths: [], body: content }
   return { paths: parsePaths(match[1]), body: content.slice(match[0].length) }
 }

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -197,7 +197,7 @@ function commandVars(ctx: { cwd: string }, filePath: string, plugin?: CommandPlu
 
 /** The exec seam expandCommand runs spans through; pi itself satisfies it. */
 interface SpanRunner {
-  exec(command: string, args: string[], options?: { cwd?: string; timeout?: number }): Promise<{ stdout: string; stderr: string; code: number }>
+  exec(command: string, args: string[], options?: { cwd?: string; timeout?: number }): Promise<{ stdout: string; stderr: string; code: number; killed?: boolean }>
 }
 
 /**
@@ -231,7 +231,7 @@ export async function expandCommand(runner: SpanRunner, parsed: ParsedCommand, a
           // pwsh cannot merge a native command's stderr in-script (spanExec sets
           // mergeStreams), so it is appended here; the sh script merges via 2>&1.
           const stdout = run.mergeStreams ? result.stdout + result.stderr : result.stdout
-          return { stdout, stderr: result.stderr, code: result.code }
+          return { stdout, stderr: result.stderr, code: result.code, killed: result.killed }
         }
       : async () => ({ stdout: SHELL_DISABLED_PLACEHOLDER, stderr: '', code: 0 })
   let expanded = await expandDynamicContent(withVars, ctx.cwd, exec, parsed.shell === 'powershell' ? 'powershell' : 'bash')

--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -72,6 +72,7 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { type InstructionLoadEvent, memoryTypeForPath, publishInstructionLoad } from './internal/instruction-events.js'
 import { managedSettingsPath, readManagedSettings } from './internal/managed-settings.js'
+import { sliceBytes } from './internal/output-guard.js'
 import { globToRegExpSource } from './internal/path-rules.js'
 import { isProjectApproved, isProjectApprovedSilently } from './internal/project-approval.js'
 import { ancestorFiles, findNearestFile, repoRoot } from './internal/project-root.js'
@@ -222,8 +223,10 @@ function collectFrom(scan: ImportScan, content: string, fromDir: string, depth: 
     const file = readImport(target, fromDir, scan.home, scan.allowedRoots, scan.seen, scan.isExcluded)
     if (!file) continue
     scan.budget.files -= 1
-    const kept = file.body.slice(0, scan.budget.bytes)
-    scan.budget.bytes -= kept.length
+    // The budget is bytes: a string slice counts UTF-16 units and lets CJK text through
+    // at three times the budget without ever reaching the truncation marker.
+    const kept = sliceBytes(file.body, scan.budget.bytes)
+    scan.budget.bytes -= Buffer.byteLength(kept)
     const body = kept.length < file.body.length ? `${kept.trim()}\n${IMPORT_TRUNCATED_MARKER}` : kept.trim()
     // Comments are stripped before the scan for further imports, so a
     // commented-out @import stays dead at every depth, matching the top level

--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -78,7 +78,7 @@ import { isProjectApproved, isProjectApprovedSilently } from './internal/project
 import { ancestorFiles, findNearestFile, repoRoot } from './internal/project-root.js'
 import { claudeSettingsChain } from './internal/settings-chain.js'
 import { statToken } from './internal/stat-token.js'
-import { fenceMarker, stripBlockComments } from './internal/strip-comments.js'
+import { type Fence, fenceMarker, stepFence, stripBlockComments } from './internal/strip-comments.js'
 
 /** Claude documents "a maximum depth of four hops" for recursive imports. */
 const MAX_IMPORT_DEPTH = 4
@@ -146,16 +146,14 @@ export const createImportBudget = (): ImportBudget => ({ files: MAX_IMPORT_FILES
  * imports neither in fenced code blocks (backtick or tilde) nor in inline spans. */
 function importTargets(content: string): string[] {
   const targets: string[] = []
-  // A fence only closes with the character that opened it: a backtick-fenced
-  // example may legitimately contain tilde-fence lines, and vice versa.
-  let fence: string | null = null
+  // CommonMark fences: closed only by the same character in a run at least as long
+  // as the opener, so a backtick example may hold tilde lines or shorter fences.
+  let fence: Fence | null = null
   for (const line of content.split('\n')) {
-    const marker = fenceMarker(line.trimStart())
-    if (marker !== null && (fence === null || fence === marker)) {
-      fence = fence === null ? marker : null
-      continue
-    }
-    if (fence !== null) continue
+    const trimmed = line.trimStart()
+    const step = stepFence(fence, trimmed, fenceMarker(trimmed))
+    fence = step.fence
+    if (step.fenced) continue
     // Backreference so a multi-backtick span (``literal `@x` backticks``) strips whole.
     const withoutSpans = line.replace(/(`+)[^`]*?\1/g, '')
     for (const match of withoutSpans.matchAll(/(^|\s)@(\S+)/g)) targets.push(match[2])

--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -194,6 +194,32 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
     }
     // Written on every start, so repos that predate the sidecar pick it up too.
     rememberWorkTree(shadowDir, ctx.cwd)
+    await mirrorLocalExcludes(ctx.cwd)
+  }
+
+  /** git reads ignore rules from the tree's .gitignore files, the user's global excludes,
+   * and $GIT_DIR/info/exclude. The shadow is the GIT_DIR here, so the repo's own
+   * .git/info/exclude (where secrets and scratch that must never be committed live)
+   * would be snapshotted and restored. Mirror it into the shadow on every start; the
+   * global excludes stay untouched (core.excludesFile is single-valued, so pointing it
+   * at the repo file would replace them). */
+  async function mirrorLocalExcludes(cwd: string): Promise<void> {
+    if (!shadowDir) return
+    // Resolved through git so a linked worktree maps to its common dir; outside a repo
+    // git exits 128 and there is nothing to mirror.
+    const located = await pi.exec('git', ['rev-parse', '--git-path', 'info/exclude'], { cwd })
+    const target = path.join(shadowDir, 'info', 'exclude')
+    try {
+      const source = located.code === 0 ? path.resolve(cwd, located.stdout.trim()) : undefined
+      if (source && fs.existsSync(source)) {
+        fs.mkdirSync(path.dirname(target), { recursive: true })
+        fs.copyFileSync(source, target)
+      } else {
+        fs.rmSync(target, { force: true })
+      }
+    } catch {
+      // A failed mirror only means local excludes are not honored this session.
+    }
   }
 
   /** `checkout -f <ref> -- .` errors when the ref's tree holds no files, so an empty

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -13,8 +13,8 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 
 import { parseFrontmatter } from '@earendil-works/pi-coding-agent'
-
 import { splitSegments } from './shell-split.js'
+import { type Fence, fenceMarker, stepFence } from './strip-comments.js'
 
 /** The pi file tools a Claude path rule can govern. */
 export type PathRuleTool = 'read' | 'edit' | 'write'
@@ -511,20 +511,27 @@ interface FenceBlock {
 }
 
 /** Fenced blocks of a body: Claude's dynamic syntax is literal text inside a plain
- * fence, while a ```! fence is itself a placeholder that executes. */
+ * fence, while a ```! fence is itself a placeholder that executes. Fences follow
+ * CommonMark: any indentation, closed only by the opener's character in a run at
+ * least as long, so a tilde line or a shorter fence inside stays content. */
 function fenceBlocks(body: string): FenceBlock[] {
   const blocks: FenceBlock[] = []
-  const fence = /^(```|~~~)([^\n]*)$/gm
+  let fence: Fence | null = null
   let open: { index: number; exec: boolean; contentStart: number } | undefined
-  let match = fence.exec(body)
-  while (match !== null) {
-    if (open === undefined) {
-      open = { index: match.index, exec: match[1] === '```' && match[2].trim() === '!', contentStart: match.index + match[0].length + 1 }
-    } else {
-      blocks.push({ start: open.index, end: match.index + match[0].length, exec: open.exec, content: body.slice(Math.min(open.contentStart, match.index), match.index).replace(/\n$/, '') })
+  let offset = 0
+  for (const line of body.split('\n')) {
+    const trimmed = line.trimStart()
+    const step = stepFence(fence, trimmed, fenceMarker(trimmed))
+    const lineEnd = offset + line.length
+    if (fence === null && step.fence !== null) {
+      // Only the exact, unindented ```! opener executes, as Claude documents it.
+      open = { index: offset, exec: line.startsWith('```') && step.fence.length === 3 && trimmed.slice(3).trim() === '!', contentStart: lineEnd + 1 }
+    } else if (fence !== null && step.fence === null && open !== undefined) {
+      blocks.push({ start: open.index, end: lineEnd, exec: open.exec, content: body.slice(Math.min(open.contentStart, offset), offset).replace(/\n$/, '') })
       open = undefined
     }
-    match = fence.exec(body)
+    fence = step.fence
+    offset = lineEnd + 1
   }
   // An unterminated fence protects to the end of the body rather than executing.
   if (open !== undefined) blocks.push({ start: open.index, end: body.length, exec: false, content: '' })

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -421,7 +421,7 @@ export function discoverCommandFiles(root: string): DiscoveredCommand[] {
   return found
 }
 
-export type CommandExec = (command: string) => Promise<{ stdout: string; stderr: string; code: number }>
+export type CommandExec = (command: string) => Promise<{ stdout: string; stderr: string; code: number; killed?: boolean }>
 
 /** PowerShell single-quote escaping: inside a '...' literal the only special
  * characters are the quote delimiters themselves, written doubled. PowerShell's
@@ -563,6 +563,10 @@ export function benignExitOne(command: string, shell: SpanShell = 'bash'): boole
  * documents: the model never sees a half-expanded body. */
 async function runSpan(exec: CommandExec, command: string, pattern: string, shell: SpanShell): Promise<string> {
   const result = await exec(command)
+  // A timeout kill arrives as killed:true with code 0 (a signal death has no exit code),
+  // so the code alone would paste the partial output as a success. Claude kills a span
+  // at the Bash timeout and that failure aborts the invocation.
+  if (result.killed) throw new Error(`Shell command timed out for pattern "${pattern}"`)
   if (result.code !== 0 && !(result.code === 1 && benignExitOne(command, shell))) {
     throw new Error(`Shell command failed for pattern "${pattern}"\n[stderr]\n${(result.stderr || result.stdout).trim()}`)
   }

--- a/extensions/internal/output-guard.ts
+++ b/extensions/internal/output-guard.ts
@@ -15,12 +15,13 @@ import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from '
 /**
  * Trim `text` to a byte budget. `String.slice` counts UTF-16 units, so slicing a CJK
  * string by a byte budget keeps up to three times the bytes asked for; cutting the
- * encoded buffer is exact. A character straddling the cut decodes to U+FFFD.
- * Shorter input comes back whole and a negative budget yields nothing, so callers
- * need no length check of their own.
+ * encoded buffer is exact. A character straddling the cut is dropped (the streaming
+ * decoder holds back an incomplete sequence instead of emitting U+FFFD), so the
+ * result is whole characters within the budget. Shorter input comes back whole and a
+ * negative budget yields nothing, so callers need no length check of their own.
  */
-function sliceBytes(text: string, maxBytes: number): string {
-  return Buffer.from(text, 'utf-8').subarray(0, Math.max(0, maxBytes)).toString('utf-8')
+export function sliceBytes(text: string, maxBytes: number): string {
+  return new TextDecoder().decode(Buffer.from(text, 'utf-8').subarray(0, Math.max(0, maxBytes)), { stream: true })
 }
 
 /** Trim `text` to pi's documented tool-output budget, noting what was dropped. */

--- a/extensions/internal/strip-comments.ts
+++ b/extensions/internal/strip-comments.ts
@@ -11,7 +11,7 @@
  * fenced code block (backtick or tilde).
  */
 
-/** The fence a line opens or closes, if any; mirrors context-imports. */
+/** The fence a line opens or closes, if any. */
 export function fenceMarker(lineStart: string): string | null {
   if (lineStart.startsWith('```')) return '`'
   if (lineStart.startsWith('~~~')) return '~'
@@ -29,14 +29,14 @@ function fenceLength(lineStart: string, marker: string): number {
 // is at least as long as the opener, so both are tracked: a shorter same-char
 // fence line (the classic 3-backtick block quoted inside a 4-backtick one) is
 // content, not a closer.
-interface Fence {
+export interface Fence {
   marker: string
   length: number
 }
 
 /** The fence state after a line, plus whether the line is fenced code (opener,
  * body, or closer) and so emitted verbatim rather than scanned for comments. */
-function stepFence(fence: Fence | null, trimmed: string, marker: string | null): { fence: Fence | null; fenced: boolean } {
+export function stepFence(fence: Fence | null, trimmed: string, marker: string | null): { fence: Fence | null; fenced: boolean } {
   if (marker !== null && fence === null) {
     return { fence: { marker, length: fenceLength(trimmed, marker) }, fenced: true }
   }

--- a/extensions/plan-mode/index.ts
+++ b/extensions/plan-mode/index.ts
@@ -429,7 +429,9 @@ After completing a step, include a [DONE:n] tag in your response.`,
       planModeEnabled = true
     }
 
-    const entries = ctx.sessionManager.getEntries()
+    // The current branch only: getEntries() lists every branch in the file, so after a
+    // rewind past a plan it would resurrect the abandoned plan and its tool restriction.
+    const entries = ctx.sessionManager.getBranch()
 
     // Restore persisted state
     const planModeEntry = findLast(entries, (e: { type: string; customType?: string }) => e.type === 'custom' && e.customType === 'plan-mode') as { data?: { enabled: boolean; todos?: TodoItem[]; executing?: boolean; savedTools?: string[] } } | undefined

--- a/extensions/question.ts
+++ b/extensions/question.ts
@@ -179,7 +179,7 @@ export default function question(pi: ExtensionAPI) {
 
     renderCall(args, theme, _context) {
       const multi = args.multiSelect === true
-      const heading = args.header ? `[${args.header}] ` : ''
+      const heading = args.header ? `[${shortHeader(String(args.header))}] ` : ''
       let text = theme.fg('toolTitle', theme.bold('question ')) + theme.fg('muted', heading + String(args.question ?? ''))
       const opts = Array.isArray(args.options) ? args.options : []
       if (opts.length) {

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -67,7 +67,7 @@ export const MAX_FINISHED_RUNS = 20
 /** Grace between the cancel SIGTERM and the SIGKILL that ends a child ignoring it. */
 const CANCEL_KILL_GRACE_MS = 5000
 
-/** Bytes of stderr kept per run, enough for the boot error without buffering logs. */
+/** Characters of stderr kept per run, enough for the boot error without buffering logs. */
 const STDERR_TAIL_CHARS = 2048
 
 export function activeBackgroundRuns(): number {

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -198,6 +198,11 @@ export function resumeBackgroundRun(id: string, task: string, onComplete: (run: 
   run.exitCode = undefined
   run.stderr = undefined
   run.finishedAt = undefined
+  // Both belong to the child that ran: a resume that dies before its first turn would
+  // otherwise report the previous count, and a clean follow-up to a maxTurns-capped run
+  // would still be offered as partial.
+  run.turns = 0
+  run.partial = undefined
   driveRun(run, { ...run.spawn, args }, onComplete)
   return 'resumed'
 }

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -24,6 +24,8 @@ export interface BackgroundRun {
   stderr?: string
   /** Claude's partial marker: the run stopped at its maxTurns limit. */
   partial?: boolean
+  /** Temp dir holding a prompt file rebuilt for a resume; removed with the run. */
+  rebuiltPromptDir?: string
   /** Set while running so the run can be cancelled; cleared on completion. */
   kill?: () => void
   /** True until the child process actually closes: a cancelled child that ignores
@@ -79,6 +81,7 @@ let finishSequence = 0
 /** Test seam: the registry is module state, so tests reset it between cases to
  * stay order-independent. */
 export function resetBackgroundRuns(): void {
+  for (const run of runs.values()) removeRebuiltPrompt(run)
   runs.clear()
   finishSequence = 0
 }
@@ -86,7 +89,10 @@ export function resetBackgroundRuns(): void {
 function evictFinishedRuns(): void {
   const finished = [...runs.values()].filter((run) => !run.live && run.state !== 'running')
   finished.sort((a, b) => (a.finishedAt ?? 0) - (b.finishedAt ?? 0))
-  for (const stale of finished.slice(0, Math.max(0, finished.length - MAX_FINISHED_RUNS))) runs.delete(stale.id)
+  for (const stale of finished.slice(0, Math.max(0, finished.length - MAX_FINISHED_RUNS))) {
+    removeRebuiltPrompt(stale)
+    runs.delete(stale.id)
+  }
 }
 
 /** Line-by-line parser keeping only the last assistant text and a turn count, so a
@@ -162,6 +168,8 @@ export function cancelAllBackgroundRuns(): number {
   for (const id of Array.from(runs.keys())) {
     if (cancelBackgroundRun(id) === 'cancelled') count++
   }
+  // Called at quit: nothing in this registry is resumable once pi exits.
+  for (const run of runs.values()) removeRebuiltPrompt(run)
   return count
 }
 
@@ -190,8 +198,9 @@ export function resumeBackgroundRun(id: string, task: string, onComplete: (run: 
   // Persisted so the rebuild happens once: rebuilding per resume leaked one temp
   // prompt dir every follow-up.
   const rebuilt = withRebuiltPrompt(run.spawn)
-  run.spawn = { ...run.spawn, args: rebuilt }
-  const args = rebuilt.map((arg) => (arg.startsWith('Task: ') ? `Task: ${task}` : arg))
+  run.spawn = { ...run.spawn, args: rebuilt.args }
+  if (rebuilt.dir) run.rebuiltPromptDir = rebuilt.dir
+  const args = rebuilt.args.map((arg) => (arg.startsWith('Task: ') ? `Task: ${task}` : arg))
   run.state = 'running'
   run.task = task
   run.output = undefined
@@ -207,24 +216,33 @@ export function resumeBackgroundRun(id: string, task: string, onComplete: (run: 
   return 'resumed'
 }
 
-/** Re-point --system-prompt at a fresh file when the original is gone. */
-function withRebuiltPrompt(spawnSpec: BackgroundSpawn): string[] {
+/** Re-point --system-prompt at a fresh file when the original is gone; `dir` is the
+ * temp dir created for it, which the run then owns. */
+function withRebuiltPrompt(spawnSpec: BackgroundSpawn): { args: string[]; dir?: string } {
   const flag = spawnSpec.args.indexOf('--system-prompt')
-  if (flag === -1 || !spawnSpec.promptBody) return spawnSpec.args
+  if (flag === -1 || !spawnSpec.promptBody) return { args: spawnSpec.args }
   const current = spawnSpec.args[flag + 1]
-  if (current && fs.existsSync(current)) return spawnSpec.args
+  if (current && fs.existsSync(current)) return { args: spawnSpec.args }
   try {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-subagent-'))
     const file = path.join(dir, 'prompt.md')
     fs.writeFileSync(file, spawnSpec.promptBody, { mode: 0o600 })
     const rebuilt = [...spawnSpec.args]
     rebuilt[flag + 1] = file
-    return rebuilt
+    return { args: rebuilt, dir }
   } catch {
     // Cannot rewrite it: drop the pair rather than hand pi a path it will treat as
     // prompt text, which would replace the agent persona with a temp path.
-    return spawnSpec.args.filter((_arg, i) => i !== flag && i !== flag + 1)
+    return { args: spawnSpec.args.filter((_arg, i) => i !== flag && i !== flag + 1) }
   }
+}
+
+/** The rebuilt prompt lives as long as its run can be resumed, so it goes when the run
+ * leaves the registry: eviction, quit, or the test reset. */
+function removeRebuiltPrompt(run: BackgroundRun): void {
+  if (!run.rebuiltPromptDir) return
+  fs.rmSync(run.rebuiltPromptDir, { recursive: true, force: true })
+  run.rebuiltPromptDir = undefined
 }
 
 export function startBackgroundRun(agent: string, task: string, invocation: BackgroundSpawn, onComplete: (run: BackgroundRun) => void, presetId?: string): string | null {

--- a/extensions/todo.ts
+++ b/extensions/todo.ts
@@ -387,8 +387,12 @@ export default function todoExtension(pi: ExtensionAPI) {
     content: [{ type: 'text' as const, text }],
     details,
   })
-  const ok = (action: TodoAction, text: string) => toolMessage(text, { action, todos: [...todos], nextId })
-  const fail = (action: TodoAction, error: string) => toolMessage(`Error: ${error}`, { action, todos: [...todos], nextId, error })
+  // pi keeps a result's details by reference in the live session, and start/complete
+  // mutate the todo objects in place, so each result carries its own copies: without
+  // them a rewind replays, and the TUI re-renders, today's statuses on earlier calls.
+  const snapshot = () => todos.map((t) => ({ ...t }))
+  const ok = (action: TodoAction, text: string) => toolMessage(text, { action, todos: snapshot(), nextId })
+  const fail = (action: TodoAction, error: string) => toolMessage(`Error: ${error}`, { action, todos: snapshot(), nextId, error })
 
   const handleAdd = (params: TodoParamsType) => {
     if (!params.text) return fail('add', 'text required for add')

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -5,7 +5,21 @@ import { dirname, join } from 'node:path'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { activeBackgroundRuns, type BackgroundRun, type BackgroundSpawn, backgroundStatusText, cancelBackgroundRun, createJsonlOutputParser, formatStatus, MAX_FINISHED_RUNS, parseFinalOutputFromJsonl, resetBackgroundRuns, resumeBackgroundRun, startBackgroundRun } from '../extensions/subagent/background.ts'
+import {
+  activeBackgroundRuns,
+  type BackgroundRun,
+  type BackgroundSpawn,
+  backgroundStatusText,
+  cancelAllBackgroundRuns,
+  cancelBackgroundRun,
+  createJsonlOutputParser,
+  formatStatus,
+  MAX_FINISHED_RUNS,
+  parseFinalOutputFromJsonl,
+  resetBackgroundRuns,
+  resumeBackgroundRun,
+  startBackgroundRun,
+} from '../extensions/subagent/background.ts'
 
 describe('createJsonlOutputParser onTurn', () => {
   const asst = (text: string) => JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text }] } })
@@ -216,6 +230,37 @@ describe('background run lifecycle', () => {
 
     expect(done?.partial).toBeFalsy()
     expect(done?.turns).toBe(1)
+  })
+
+  it('removes the rebuilt prompt dir when the run is evicted from the registry', () => {
+    const id = startBackgroundRun('scout', 'one', spec({ args: ['--system-prompt', '/nonexistent/prompt.md', 'Task: one'], promptBody: 'PERSONA' }), () => {})
+    children.at(-1)!.emit('close', 0)
+    expect(resumeBackgroundRun(id!, 'two', () => {})).toBe('resumed')
+    const args = spawnMock.mock.calls.at(-1)![1] as string[]
+    const promptDir = dirname(args[args.indexOf('--system-prompt') + 1])
+    children.at(-1)!.emit('close', 0)
+    expect(existsSync(promptDir)).toBe(true)
+
+    // The rebuilt prompt is kept for further resumes, so it lives exactly as long as
+    // the run stays resumable: eviction from the registry must take it along.
+    for (let i = 0; i <= MAX_FINISHED_RUNS; i++) {
+      startBackgroundRun('scout', `filler ${i}`, spec(), () => {})
+      children.at(-1)!.emit('close', 0)
+    }
+
+    expect(existsSync(promptDir)).toBe(false)
+  })
+
+  it('removes rebuilt prompt dirs when every run is cancelled at quit', () => {
+    const id = startBackgroundRun('scout', 'one', spec({ args: ['--system-prompt', '/nonexistent/prompt.md', 'Task: one'], promptBody: 'PERSONA' }), () => {})
+    children.at(-1)!.emit('close', 0)
+    expect(resumeBackgroundRun(id!, 'two', () => {})).toBe('resumed')
+    const args = spawnMock.mock.calls.at(-1)![1] as string[]
+    const promptDir = dirname(args[args.indexOf('--system-prompt') + 1])
+
+    cancelAllBackgroundRuns()
+
+    expect(existsSync(promptDir)).toBe(false)
   })
 
   it('rebuilds the prompt file once and reuses it across resumes', () => {

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -74,6 +74,9 @@ beforeEach(() => {
 // cleaned-up isolation worktree), so the fixture must point at one that does.
 const spec = (over: Partial<BackgroundSpawn> = {}): BackgroundSpawn => ({ command: 'pi', args: ['--mode', 'json', 'Task: t'], cwd: tmpdir(), ...over })
 
+/** One assistant turn on the child's JSONL stdout. */
+const assistantTurn = (text: string) => `${JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text }] } })}\n`
+
 describe('background run lifecycle', () => {
   it('reports the final text of a stdout stream whose chunks split lines', () => {
     let done: BackgroundRun | undefined
@@ -174,6 +177,45 @@ describe('background run lifecycle', () => {
     }
     expect(resumeBackgroundRun(finished!.id, 'again', () => {})).toBe('at-capacity')
     for (const child of live) child.emit('close', 0)
+  })
+
+  it('reports zero turns when a resume fails to spawn', () => {
+    const id = startBackgroundRun('scout', 'one', spec(), () => {})
+    children.at(-1)!.stdout.emit('data', assistantTurn('turn one'))
+    children.at(-1)!.stdout.emit('data', assistantTurn('turn two'))
+    children.at(-1)!.emit('close', 0)
+
+    // The turn count belongs to the child that ran; a resume that never produced a
+    // turn must not report the previous run's two.
+    let failed: BackgroundRun | undefined
+    expect(
+      resumeBackgroundRun(id!, 'two', (run) => {
+        failed = run
+      }),
+    ).toBe('resumed')
+    children.at(-1)!.emit('error', new Error('spawn pi ENOENT'))
+
+    expect(failed?.state).toBe('failed')
+    expect(failed?.turns).toBe(0)
+  })
+
+  it('clears the partial marker when a capped run is resumed and finishes cleanly', () => {
+    const id = startBackgroundRun('scout', 'one', spec({ maxTurns: 2 }), () => {})
+    children.at(-1)!.stdout.emit('data', assistantTurn('turn one'))
+    children.at(-1)!.stdout.emit('data', assistantTurn('turn two'))
+    children.at(-1)!.emit('close', null)
+
+    let done: BackgroundRun | undefined
+    expect(
+      resumeBackgroundRun(id!, 'two', (run) => {
+        done = run
+      }),
+    ).toBe('resumed')
+    children.at(-1)!.stdout.emit('data', assistantTurn('again'))
+    children.at(-1)!.emit('close', 0)
+
+    expect(done?.partial).toBeFalsy()
+    expect(done?.turns).toBe(1)
   })
 
   it('rebuilds the prompt file once and reuses it across resumes', () => {

--- a/tests/claude-rules.test.ts
+++ b/tests/claude-rules.test.ts
@@ -21,6 +21,12 @@ describe('parseFrontmatter', () => {
     expect(parseFrontmatter('Just rules.')).toEqual({ paths: [], body: 'Just rules.' })
   })
 
+  it('detects frontmatter behind a UTF-8 byte order mark', () => {
+    // Windows editors prepend one; without this the whole header leaked into the body
+    // and the rule lost its path scope.
+    expect(parseFrontmatter('\uFEFF---\npaths: ["src/**"]\n---\nBody')).toEqual({ paths: ['src/**'], body: 'Body' })
+  })
+
   it('parses a block list of paths and strips the frontmatter from the body', () => {
     const md = '---\npaths:\n  - "src/**/*.ts"\n  - "**/*.test.ts"\n---\nUse strict types.'
     expect(parseFrontmatter(md)).toEqual({ paths: ['src/**/*.ts', '**/*.test.ts'], body: 'Use strict types.' })

--- a/tests/command-parse.test.ts
+++ b/tests/command-parse.test.ts
@@ -537,6 +537,27 @@ describe('expandDynamicContent', () => {
     const out = await expandDynamicContent('```\n@notes.md\n```', cwd, exec)
     expect(out).not.toContain('FILE_BODY')
   })
+
+  it('ignores an @ref inside an indented fence', async () => {
+    const cwd = tempDir()
+    writeFileSync(join(cwd, 'notes.md'), 'FILE_BODY')
+    const out = await expandDynamicContent('  ```\n@notes.md\n  ```', cwd, exec)
+    expect(out).not.toContain('FILE_BODY')
+  })
+
+  it('keeps a backtick fence open across a tilde fence line', async () => {
+    const cwd = tempDir()
+    writeFileSync(join(cwd, 'notes.md'), 'FILE_BODY')
+    const out = await expandDynamicContent('```\n~~~\n@notes.md\n```', cwd, exec)
+    expect(out).not.toContain('FILE_BODY')
+  })
+
+  it('closes a fence only with a run at least as long as its opener', async () => {
+    const cwd = tempDir()
+    writeFileSync(join(cwd, 'notes.md'), 'FILE_BODY')
+    const out = await expandDynamicContent('````\n```\n@notes.md\n````', cwd, exec)
+    expect(out).not.toContain('FILE_BODY')
+  })
 })
 
 describe('dollar signs stay literal', () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -179,7 +179,7 @@ const setup = (cwd: string, trusted = true) => {
     setIdle: (value: boolean) => {
       idle = value
     },
-    failExec: (result: { stderr: string; code: number }) => Object.assign(execResult, result),
+    failExec: (result: { stderr: string; code: number; killed?: boolean }) => Object.assign(execResult, result),
   }
 }
 
@@ -647,6 +647,20 @@ describe('claude variables and skill frontmatter wiring', () => {
 
     expect(s.sent).toEqual([])
     expect(s.notices.some((n) => n.includes('broken-cmd'))).toBe(true)
+  })
+
+  it('aborts the invocation when a bash span is killed at its timeout, even with exit code 0', async () => {
+    // pi reports a timeout kill as killed:true with code 0 (a signal death has no exit
+    // code); Claude kills the command at the Bash timeout and that failure aborts the skill.
+    const cwd = tempDir()
+    writeCommand(cwd, 'f.md', 'status: !`sleep 999`')
+    const s = setup(cwd)
+    s.failExec({ stderr: '', code: 0, killed: true })
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('f')?.handler('', s.ctx)
+
+    expect(s.sent).toEqual([])
+    expect(s.notices.some((n) => n.includes('sleep 999') && n.includes('timed out'))).toBe(true)
   })
 
   it('runs bash spans with merged stderr under the Bash tool budget', async () => {

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -287,6 +287,15 @@ describe('collectImports', () => {
     expect(budget.bytes).toBe(1)
   })
 
+  it('keeps a fence open across a shorter same-character fence line', () => {
+    // CommonMark: a closer must be at least as long as its opener, so the classic
+    // three-backtick block quoted inside a four-backtick one is content.
+    const dir = tempDir()
+    writeFileSync(join(dir, 'a.md'), '````\n```\n@b.md\n````')
+    writeFileSync(join(dir, 'b.md'), 'B')
+    expect(collectImports('@a.md', dir, dir, [dir], new Set()).map((f) => f.body)).toEqual(['````\n```\n@b.md\n````'])
+  })
+
   it('is cycle-safe', () => {
     const dir = tempDir()
     writeFileSync(join(dir, 'a.md'), '@b.md')

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -273,6 +273,20 @@ describe('collectImports', () => {
     expect(budget.bytes).toBe(MAX_IMPORT_BYTES)
   })
 
+  it('charges the import budget in bytes, not UTF-16 units', () => {
+    // MAX_IMPORT_BYTES is a byte budget; slicing by string length let CJK text through at
+    // three times the budget and never appended the truncation marker.
+    const dir = tempDir()
+    writeFileSync(join(dir, 'cjk.md'), '漢'.repeat(100))
+    const budget = createImportBudget()
+    budget.bytes = 100
+
+    const out = collectImports('@cjk.md', dir, dir, [dir], new Set(), { budget })
+
+    expect(out.map((f) => f.body)).toEqual([`${'漢'.repeat(33)}\n${IMPORT_TRUNCATED_MARKER}`])
+    expect(budget.bytes).toBe(1)
+  })
+
   it('is cycle-safe', () => {
     const dir = tempDir()
     writeFileSync(join(dir, 'a.md'), '@b.md')

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -109,6 +109,21 @@ describe('shadow-repo checkpoint lifecycle', () => {
     expect(t.appended[0].data.ref).toMatch(/^[0-9a-f]{40}$/)
   })
 
+  it('leaves files listed in the repo-local .git/info/exclude out of the snapshot', async () => {
+    // The shadow reads ignore rules from its own git dir, so the repo-local exclude
+    // file (where users hide secrets and scratch that must not be committed) would
+    // otherwise be copied under $HOME and restored by /rewind.
+    const t = setup()
+    writeFileSync(join(t.repo, '.git', 'info', 'exclude'), 'secret.txt\n')
+    writeFileSync(join(t.repo, 'secret.txt'), 'token\n')
+    await checkpointOneTurn(t)
+
+    const shadow = join(hoisted.home, '.pi', 'agent', 'checkpoints', 'session-test.jsonl')
+    const listed = execFileSync('git', ['--git-dir', shadow, 'ls-tree', '-r', '--name-only', t.appended[0].data.ref], { encoding: 'utf8' }).split('\n')
+    expect(listed).toContain('untracked.txt')
+    expect(listed).not.toContain('secret.txt')
+  })
+
   it('captures the tree even when the user global config forces commit signing', async () => {
     // A global commit.gpgsign=true (with no usable gpg) would fail the shadow commit;
     // the snapshot must isolate itself from the user config and still record the change.

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -82,7 +82,7 @@ function setup(options: { flag?: boolean; activeTools?: string[] } = {}) {
       select: async (_q: string, choices: string[]) => choices[0],
       editor: async () => '',
     },
-    sessionManager: { getEntries: () => [] as unknown[] },
+    sessionManager: { getEntries: () => [] as unknown[], getBranch: () => [] as unknown[] },
   }
 
   const emit = (name: string, event: unknown = {}, context: unknown = ctx) => handlers.get(name)?.(event as never, context as never)
@@ -435,7 +435,8 @@ describe('plan review prompt', () => {
 })
 
 describe('session restore', () => {
-  const restoreCtx = (s: ReturnType<typeof setup>, entries: unknown[]) => ({ ...s.ctx, sessionManager: { getEntries: () => entries } })
+  /** `entries` is the current branch (pi getBranch); `all` is every entry in the file (getEntries). */
+  const restoreCtx = (s: ReturnType<typeof setup>, entries: unknown[], all: unknown[] = entries) => ({ ...s.ctx, sessionManager: { getEntries: () => all, getBranch: () => entries } })
 
   it('enables plan mode from the --plan flag', async () => {
     const s = setup({ flag: true })
@@ -449,6 +450,16 @@ describe('session restore', () => {
     const entries = [{ type: 'custom', customType: 'plan-mode', data: { enabled: true, todos: [], executing: false } }]
     await s.emit('session_start', {}, restoreCtx(s, entries))
     expect(s.getActiveTools()).not.toContain('write')
+  })
+
+  it('ignores a plan-mode entry that lives on an abandoned branch', async () => {
+    // After a rewind past a plan the entry is still in the session file (getEntries lists
+    // every branch) but not on the current path (getBranch); only the path is state.
+    const s = setup()
+    const stale = { type: 'custom', customType: 'plan-mode', data: { enabled: true, todos: [{ step: 1, text: 'Old', completed: false }], executing: true } }
+    await s.emit('session_start', {}, restoreCtx(s, [], [stale]))
+    expect(s.getActiveTools()).toContain('write')
+    expect(s.widgets.at(-1)).toBeUndefined()
   })
 
   it('rebuilds completion state from [DONE:n] markers after the last execute marker', async () => {

--- a/tests/question.test.ts
+++ b/tests/question.test.ts
@@ -253,6 +253,10 @@ describe('question renderCall', () => {
   it('omits the option line when options is not an array', () => {
     expect(lines(setup().renderCall({ question: 'Pick one' }, theme))).toEqual(['question Pick one'])
   })
+
+  it('shows the header truncated to the same 12 characters as the dialog', () => {
+    expect(lines(setup().renderCall({ question: 'Pick one', header: 'A'.repeat(30) }, theme))).toEqual([`question [${'A'.repeat(12)}] Pick one`])
+  })
 })
 
 describe('question renderResult', () => {

--- a/tests/todo-more.test.ts
+++ b/tests/todo-more.test.ts
@@ -197,6 +197,16 @@ describe('session replay', () => {
     expect((await h.call({ action: 'list' })).content[0].text).toBe('[ ] #1: kept')
   })
 
+  it('replays the statuses recorded at an entry rather than later changes to the same objects', async () => {
+    const h = setup()
+    const first = await h.call({ action: 'add', text: 'a' })
+    await h.call({ action: 'start', id: 1 })
+    await h.call({ action: 'complete', id: 1 })
+    // A rewind to the first call replays the details object pi kept by reference.
+    await h.fire('session_tree', {}, branchCtx([{ type: 'message', message: { role: 'toolResult', toolName: 'todo', details: first.details } }], fakeUI()))
+    expect((await h.call({ action: 'list' })).content[0].text).toBe('[ ] #1: a')
+  })
+
   it('replaces existing todos on a session_tree replay', async () => {
     const h = setup()
     await h.call({ action: 'add', text: 'local' })

--- a/tests/todo.test.ts
+++ b/tests/todo.test.ts
@@ -85,6 +85,16 @@ describe('todo tool status machine', () => {
     expect(second.content[0].text).toContain('Added todo #2')
   })
 
+  it('keeps the statuses a result was created with when later calls change the list', async () => {
+    // pi stores a tool result's details by reference, so a result must hold its own
+    // snapshot: start/complete mutate the live todo objects.
+    const { call } = setup()
+    const added = await call({ action: 'add', text: 'a' })
+    await call({ action: 'start', id: 1 })
+    await call({ action: 'complete', id: 1 })
+    expect(added.details.todos).toEqual([{ id: 1, text: 'a', status: 'pending', activeForm: undefined }])
+  })
+
   it('rejects add without text', async () => {
     const result = await call({ action: 'add' })
     expect(result.details.error).toBe('text required for add')


### PR DESCRIPTION
Ten small product fixes, each with a test that fails without it:

- Plan mode restores from the current session branch (`getBranch`) instead of every entry in the file, so a rewind past a plan no longer resurrects the abandoned plan or its tool restriction.
- Todo tool results carry copies of the todo objects; pi keeps result details by reference, so in-place status changes leaked into earlier results on replay and in the TUI.
- A command span killed at the Bash timeout now aborts the invocation: pi reports the kill as `killed: true` with exit code 0, and the seam dropped the flag.
- Checkpoint snapshots mirror the repo's `.git/info/exclude` into the shadow repo, so locally excluded files are no longer copied under `~/.pi/agent/checkpoints` and restored by `/rewind`.
- A background resume resets `turns` and `partial`, and the temp dir holding a rebuilt system prompt is removed when the run leaves the registry (eviction, quit, reset).
- The question tool-call line truncates the header to the same 12 characters as the dialog.
- Rule frontmatter is recognized behind a UTF-8 BOM.
- The CLAUDE.md import budget is charged in bytes; the shared byte slicer no longer emits U+FFFD for a character straddling the cut.
- Both `@path` scanners share the CommonMark fence tracker (indented fences, same-character closers at least as long as the opener).

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change
