### PR TITLE
Run hooks, status line, headers helpers, and spans through the platform shell on Windows

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -19,7 +19,7 @@ Registers `.claude/commands/**/*.md` as slash commands with Claude's command con
 - `allowed-tools` (space- or comma-separated, or a YAML list) with `Bash(...)` and `Read`/`Edit`/`Write` path scopes enforced at call time (gitignore anchors, Edit governs writes). Divergence: pi has no permission system, so this restricts the turn's tool set instead of pre-approving calls.
 - `disallowed-tools`, `argument-hint`.
 - `model`: switches the session model for the command's turn, restored after; `effort`: raises reasoning for the turn, restored after.
-- `shell: powershell`: injected spans run through PowerShell when a `pwsh` binary is present, else `/bin/sh`.
+- Injected spans run through `/bin/sh`; on Windows through Git Bash, else PowerShell (a `shell: bash` skill fails before any command runs when Git Bash is missing, as Claude documents). `shell: powershell`: PowerShell when one is installed, else the bash path.
 - `when_to_use` steers model invocation; `disable-model-invocation` opts a file out; `user-invocable: false` hides a command from the menu while still exposing it to the model.
 
 ## Model invocation

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -19,7 +19,7 @@ Hook locations (settings.json from the session's primary working directory, sett
 
 ## Hook types
 
-- `type: "command"` (default): runs via `sh -c` with the event JSON on stdin, or exec form (`command` as an argv array, no shell); executes with `CLAUDECODE=1` and `CLAUDE_PROJECT_DIR` set.
+- `type: "command"` (default): runs the command string through a shell (`sh -c`; on Windows Git Bash, or PowerShell when Git Bash is absent; `shell: "powershell"` forces PowerShell and rewrites `${CLAUDE_*}` placeholders to `${env:NAME}`) with the event JSON on stdin, or exec form (`command` as an argv array, no shell); executes with `CLAUDECODE=1` and `CLAUDE_PROJECT_DIR` set.
 - `type: "http"`: POSTs the payload; a 2xx JSON body renders the decision, everything else is non-blocking per Claude's contract. Targets are gated by `allowedHttpHookUrls` (union of managed and settings scopes; unset allows all, `[]` blocks every http hook).
 - `type: "prompt"`: evaluates in-process against the session model.
 - `type: "mcp_tool"`: calls a connected server's tool. String values in `input` support `${path}` substitution from the hook's JSON input (`${tool_input.file_path}`); without `input` the tool is called with no arguments.

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -16,6 +16,10 @@ export interface HookCommand {
   /** exec-form: spawn `command` directly with these args and no shell (shell-form when
    * absent). $ARGUMENTS in each arg is replaced with the event JSON. */
   args?: string[]
+  /** Claude's `shell`: "bash" (the default) or "powershell". The default is /bin/sh off
+   * Windows; on Windows Git Bash, then PowerShell when Git Bash is absent. Ignored when
+   * `args` is set. */
+  shell?: string
   timeout?: number
   /** Claude's background contract, honored on `type: "command"` hooks only: `async` runs
    * without blocking its event and with no timeout enforced; `asyncRewake` also runs in

--- a/extensions/hooks/index.ts
+++ b/extensions/hooks/index.ts
@@ -72,7 +72,9 @@
  * agent-frontmatter hooks arrive via PI_CODE_AGENT_HOOKS (Stop pre-converted to
  * SubagentStop, fired at the child's own agent end) and die with the process.
  *
- * Hook commands run via `sh -c` with the event JSON on stdin. A PreToolUse
+ * Hook commands run through the platform shell (`sh -c`; on Windows Git Bash, or
+ * PowerShell when Git Bash is absent, see internal/shell-resolve) with the event JSON
+ * on stdin. A PreToolUse
  * hook blocks the tool by exiting 2 (stderr becomes the reason) or by printing
  * `{"hookSpecificOutput": {"permissionDecision": "deny", ...}}` (or the older
  * `{"decision": "block"}`).
@@ -271,7 +273,7 @@ export default function hooksExtension(pi: ExtensionAPI) {
         if (hook.type === 'prompt') return runPromptHook(hook, merged, resolveHookModel(ctx, hook.model), ms)
         if (hook.type === 'agent') return runAgentHook(hook, merged, ms, (ctx.model as { id?: string } | undefined)?.id)
         if (hook.type === 'mcp_tool') return runMcpToolHook(hook, merged, ms)
-        return runHookCommand(hook.command, merged, ms, projectDir, hook.args, onChild)
+        return runHookCommand(hook.command, merged, ms, projectDir, hook.args, onChild, hook.shell)
       }
       // Claude's `once` (skill-frontmatter hooks only): removed after the first
       // successful run; a failure, block, or timeout leaves it in place.

--- a/extensions/hooks/runners.ts
+++ b/extensions/hooks/runners.ts
@@ -81,6 +81,13 @@ const TIMEOUT_EXIT_CODE = 124
  * direct child alone leaves a grandchild alive holding stdout/stderr.
  */
 function killTree(child: ChildProcess): void {
+  if (process.platform === 'win32') {
+    // Windows has no process groups: taskkill /T ends the shell's whole tree. If
+    // taskkill itself cannot start, the direct kill is all that is left.
+    if (child.pid) spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true }).on('error', () => child.kill('SIGKILL'))
+    else child.kill('SIGKILL')
+    return
+  }
   try {
     // Negative pid targets the whole process group, which `detached` gave the shell.
     if (child.pid) {

--- a/extensions/hooks/runners.ts
+++ b/extensions/hooks/runners.ts
@@ -9,6 +9,7 @@ import type { Api, Model } from '@earendil-works/pi-ai'
 import { runAgent } from '../internal/agent-run.js'
 import { callMcpTool } from '../internal/mcp-call.js'
 import { completeText } from '../internal/model-complete.js'
+import { resolveShell } from '../internal/shell-resolve.js'
 import { type HookCommand, httpUrlAllowed, isBackgroundHook } from './config.js'
 
 // Claude's defaults vary by type and event (600s for command/http/mcp_tool, 30s
@@ -41,7 +42,7 @@ export type HookRunner = (hook: HookCommand, payload: unknown, timeoutMs: number
  * `args` array it becomes the exec path: `command` is spawned directly with those args.
  * `onChild` hands the caller a kill for the spawned tree, so a background hook that is
  * still running at session end can be reaped (Claude kills async hooks at teardown). */
-export type HookCommandRunner = (command: string, payload: unknown, timeoutMs: number, projectDir?: string, args?: string[], onChild?: (kill: () => void) => void) => Promise<HookRunResult>
+export type HookCommandRunner = (command: string, payload: unknown, timeoutMs: number, projectDir?: string, args?: string[], onChild?: (kill: () => void) => void, shell?: string) => Promise<HookRunResult>
 
 /** Above 2^31-1 ms Node clamps a timer to 1ms, which would kill the hook instantly. */
 const MAX_TIMEOUT_S = 2_147_483
@@ -92,11 +93,19 @@ function killTree(child: ChildProcess): void {
   child.kill('SIGKILL')
 }
 
-export const runHookCommand: HookCommandRunner = (command, payload, timeoutMs, projectDir, args, onChild) =>
+/** The shell invocation for a shell-form command, or undefined when this machine has no
+ * shell for it (Windows with neither Git Bash nor PowerShell). */
+function shellInvocation(command: string, shell: string | undefined): { file: string; spawnArgs: string[] } | undefined {
+  const resolved = resolveShell(shell)
+  return resolved ? { file: resolved.file, spawnArgs: resolved.argsFor(command) } : undefined
+}
+
+export const runHookCommand: HookCommandRunner = (command, payload, timeoutMs, projectDir, args, onChild, shell) =>
   new Promise((resolve) => {
-    // Absolute path so the shell can't be resolved through an attacker-controlled PATH.
-    // `detached` makes the shell its own process group leader so the timeout can kill
-    // the descendants too. CLAUDE_PROJECT_DIR is Claude's documented way for a hook to
+    // /bin/sh by absolute path off Windows, so the shell can't be resolved through an
+    // attacker-controlled PATH; on Windows the resolver follows Claude's documented Git
+    // Bash lookup. `detached` makes the shell its own process group leader so the
+    // timeout can kill the descendants too. CLAUDE_PROJECT_DIR is Claude's documented way for a hook to
     // reference project files regardless of the shell's cwd. CLAUDECODE=1 marks every
     // subprocess Claude spawns, so it is set on the child unconditionally.
     // CLAUDE_CODE_CHILD_SESSION marks per-call children (hook and status line
@@ -110,11 +119,18 @@ export const runHookCommand: HookCommandRunner = (command, payload, timeoutMs, p
     // An exec-form hook (an `args` array) spawns the executable directly with those args
     // and no shell, so shell metacharacters in the args arrive literally; $ARGUMENTS in
     // each arg is replaced with the event JSON by a replacer function (so $$/$& in the
-    // payload survive verbatim). Without args it stays the shell path. Both share the
+    // payload survive verbatim). Without args the command string goes to the platform's
+    // shell, or to PowerShell when the hook says `shell: "powershell"`. Both share the
     // same detached process group, so killTree reaches the descendants either way.
-    const file = Array.isArray(args) ? command : '/bin/sh'
-    const spawnArgs = Array.isArray(args) ? args.map((arg) => substituteArguments(arg, payload)) : ['-c', command]
-    const child = spawn(file, spawnArgs, { stdio: ['pipe', 'pipe', 'pipe'], detached: true, env })
+    const target = Array.isArray(args) ? { file: command, spawnArgs: args.map((arg) => substituteArguments(arg, payload)) } : shellInvocation(command, shell)
+    if (!target) {
+      // Marked like a spawn failure so a gated event fails closed rather than reading as an allow.
+      resolve({ code: 0, stdout: '', stderr: 'no shell found: install Git for Windows or PowerShell', timedOut: false, spawnFailed: true })
+      return
+    }
+    // On Windows `detached` means DETACHED_PROCESS, which gives a console child its own
+    // window; windowsHide keeps every hook invisible (a no-op elsewhere).
+    const child = spawn(target.file, target.spawnArgs, { stdio: ['pipe', 'pipe', 'pipe'], detached: true, windowsHide: true, env })
     onChild?.(() => killTree(child))
     let stdout = ''
     let stderr = ''

--- a/extensions/hooks/runners.ts
+++ b/extensions/hooks/runners.ts
@@ -5,6 +5,7 @@
  */
 
 import { type ChildProcess, spawn } from 'node:child_process'
+import * as path from 'node:path'
 import type { Api, Model } from '@earendil-works/pi-ai'
 import { runAgent } from '../internal/agent-run.js'
 import { callMcpTool } from '../internal/mcp-call.js'
@@ -82,9 +83,11 @@ const TIMEOUT_EXIT_CODE = 124
  */
 function killTree(child: ChildProcess): void {
   if (process.platform === 'win32') {
-    // Windows has no process groups: taskkill /T ends the shell's whole tree. If
-    // taskkill itself cannot start, the direct kill is all that is left.
-    if (child.pid) spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true }).on('error', () => child.kill('SIGKILL'))
+    // Windows has no process groups: taskkill /T ends the shell's whole tree. By
+    // absolute path, so a writable PATH entry cannot stand in for it. If taskkill itself
+    // cannot start, the direct kill is all that is left.
+    const taskkill = path.join(process.env.SystemRoot ?? String.raw`C:\Windows`, 'System32', 'taskkill.exe')
+    if (child.pid) spawn(taskkill, ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true }).on('error', () => child.kill('SIGKILL'))
     else child.kill('SIGKILL')
     return
   }

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -433,6 +433,8 @@ export function powershellQuote(value: string): string {
   return value.replaceAll(/['‘’‚‛]/g, '$&$&')
 }
 
+import { bashBinary } from './shell-resolve.js'
+
 export { resolvePowershellBinary } from './shell-resolve.js'
 
 export interface SpanExec {
@@ -445,42 +447,55 @@ export interface SpanExec {
   mergeStreams?: boolean
 }
 
+/** The sh invocation for a span: CLAUDE_PROJECT_DIR and CLAUDECODE=1 exported in-script
+ * (pi.exec takes no env; CLAUDECODE marks every subprocess Claude spawns), stderr merged
+ * with 2>&1. The group opens with a `:` null command: `{ }` around an empty or
+ * comment-only span is a hard sh syntax error (exit 2) that aborted the whole
+ * invocation, and `:` keeps such a span the harmless no-op it was on HEAD while the
+ * group still merges stderr for real spans. */
+function shSpan(binary: string, projectDir: string, script: string): SpanExec {
+  const quoted = projectDir.replaceAll("'", String.raw`'\''`)
+  return { command: binary, args: ['-c', `export CLAUDE_PROJECT_DIR='${quoted}'\nexport CLAUDECODE=1\n{ :\n${script}\n} 2>&1`] }
+}
+
+/** The PowerShell invocation for a span. No in-script 2>&1: under pwsh 7 it does not
+ * merge a native command's stderr on a script block, so mergeStreams has the caller
+ * append it. The trailing exit forwards a failed native command's code, which pwsh
+ * -Command otherwise swallows (the process exited 0 and a failure never aborted the
+ * invocation). An empty or cmdlet-only span leaves $LASTEXITCODE unset and exits 0.
+ * Residual gap vs sh: a failing cmdlet sets no exit code, so it cannot abort; its
+ * error text still reaches the model through the merged stderr. */
+function powershellSpan(binary: string, projectDir: string, script: string): SpanExec {
+  const preamble = `$ErrorActionPreference='Continue'\n$env:CLAUDE_PROJECT_DIR='${powershellQuote(projectDir)}'\n$env:CLAUDECODE='1'`
+  return { command: binary, args: ['-NoProfile', '-NonInteractive', '-Command', `${preamble}\n& {\n${script}\n}\nexit $LASTEXITCODE`], mergeStreams: true }
+}
+
 /**
- * The exec invocation for one injected span, honoring the `shell:` frontmatter.
- * The default (absent or `bash`) runs through /bin/sh; `powershell` resolves a
- * PowerShell binary and runs the span with -Command, falling back to /bin/sh when
- * none is installed so the command still works, per Claude's shell matrix. Both
- * paths export CLAUDE_PROJECT_DIR (each shell's own quoting) and merge stderr
- * into stdout, as the Bash tool does when it runs these for Claude: the sh script
- * in-line with 2>&1, the pwsh path via mergeStreams in the caller.
+ * The exec invocation for one injected span, honoring the `shell:` frontmatter per
+ * Claude's shell matrix (skills.md). `powershell` runs through a PowerShell binary when
+ * one resolves. Otherwise the span runs through bash: /bin/sh off Windows, Git Bash on
+ * Windows. Without Git Bash, a skill that declared `shell: bash` fails before any
+ * command runs ("requires bash"), an undeclared one falls to PowerShell, and with
+ * neither shell the invocation fails. Both paths export CLAUDE_PROJECT_DIR (each
+ * shell's own quoting) and merge stderr into stdout, as the Bash tool does when it
+ * runs these for Claude: the sh script in-line with 2>&1, the pwsh path via
+ * mergeStreams in the caller.
  *
- * The resolver is a parameter rather than a default so the caller passes its own
- * imported binding, which keeps the lookup mockable in tests.
+ * The resolvers are parameters so a caller (or test) controls the lookups: the
+ * PowerShell one is passed as an imported binding, the bash one defaults to the
+ * platform rule.
  */
-export function spanExec(shell: string | undefined, projectDir: string, script: string, resolveBinary: () => string | undefined): SpanExec {
+export function spanExec(shell: string | undefined, projectDir: string, script: string, resolveBinary: () => string | undefined, resolveBash: () => string | undefined = bashBinary): SpanExec {
   if (shell === 'powershell') {
     const binary = resolveBinary()
-    if (binary !== undefined) {
-      // CLAUDECODE=1 marks every subprocess Claude spawns; pi.exec takes no env, so
-      // it is exported in the script alongside CLAUDE_PROJECT_DIR.
-      const preamble = `$ErrorActionPreference='Continue'\n$env:CLAUDE_PROJECT_DIR='${powershellQuote(projectDir)}'\n$env:CLAUDECODE='1'`
-      // No in-script 2>&1: under pwsh 7 it does not merge a native command's
-      // stderr on a script block, so mergeStreams has the caller append it. The
-      // trailing exit forwards a failed native command's code, which pwsh
-      // -Command otherwise swallows (the process exited 0 and a failure never
-      // aborted the invocation). An empty or cmdlet-only span leaves
-      // $LASTEXITCODE unset and exits 0. Residual gap vs sh: a failing cmdlet
-      // sets no exit code, so it cannot abort; its error text still reaches the
-      // model through the merged stderr.
-      return { command: binary, args: ['-NoProfile', '-NonInteractive', '-Command', `${preamble}\n& {\n${script}\n}\nexit $LASTEXITCODE`], mergeStreams: true }
-    }
+    if (binary !== undefined) return powershellSpan(binary, projectDir, script)
   }
-  const quoted = projectDir.replaceAll("'", String.raw`'\''`)
-  // The group opens with a `:` null command: `{ }` around an empty or
-  // comment-only span is a hard sh syntax error (exit 2) that aborted the whole
-  // invocation, and `:` keeps such a span the harmless no-op it was on HEAD
-  // while the group still merges stderr for real spans.
-  return { command: '/bin/sh', args: ['-c', `export CLAUDE_PROJECT_DIR='${quoted}'\nexport CLAUDECODE=1\n{ :\n${script}\n} 2>&1`] }
+  const bash = resolveBash()
+  if (bash !== undefined) return shSpan(bash, projectDir, script)
+  if (shell === 'bash') throw new Error('shell: bash requires Git Bash, which was not found (install Git for Windows or set CLAUDE_CODE_GIT_BASH_PATH)')
+  const binary = resolveBinary()
+  if (binary !== undefined) return powershellSpan(binary, projectDir, script)
+  throw new Error('no shell found for the injected commands: install Git for Windows or PowerShell')
 }
 
 interface FenceBlock {

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -433,26 +433,7 @@ export function powershellQuote(value: string): string {
   return value.replaceAll(/['‘’‚‛]/g, '$&$&')
 }
 
-/** The PowerShell names worth trying: pwsh everywhere it installs, plus the
- * Windows spellings on win32, where powershell.exe ships with the OS. */
-const powershellCandidates = (platform: string): string[] => (platform === 'win32' ? ['pwsh', 'pwsh.exe', 'powershell.exe'] : ['pwsh'])
-
-/** First PowerShell binary found on PATH, or undefined when none is installed. */
-export function resolvePowershellBinary(platform: string = process.platform, env: Record<string, string | undefined> = process.env): string | undefined {
-  const dirs = (env.PATH ?? '').split(path.delimiter).filter(Boolean)
-  for (const candidate of powershellCandidates(platform)) {
-    for (const dir of dirs) {
-      const full = path.join(dir, candidate)
-      try {
-        fs.accessSync(full, fs.constants.X_OK)
-        if (fs.statSync(full).isFile()) return full
-      } catch {
-        // not here; keep looking
-      }
-    }
-  }
-  return undefined
-}
+export { resolvePowershellBinary } from './shell-resolve.js'
 
 export interface SpanExec {
   command: string

--- a/extensions/internal/shell-resolve.ts
+++ b/extensions/internal/shell-resolve.ts
@@ -1,0 +1,114 @@
+/**
+ * Which shell runs a command string, per Claude's contract. hooks.md: a shell-form
+ * command is "passed to a shell: `sh -c` on macOS and Linux, Git Bash on Windows, or
+ * PowerShell when Git Bash isn't installed", and a hook's `shell: "powershell"` runs it
+ * via PowerShell (pwsh, then Windows PowerShell 5.1). statusline.md applies the same
+ * Git Bash-then-PowerShell rule to statusLine commands. troubleshoot-install.md: when
+ * CLAUDE_CODE_GIT_BASH_PATH is unset, Git Bash is looked for in `C:\Program Files\Git`
+ * and `C:\Program Files (x86)\Git`, then through the `git` on PATH (the `bin\bash.exe`
+ * of that installation), skipping a git in the launch directory or below it under
+ * node_modules or a virtual environment. env-vars.md: the override is ignored unless
+ * the file exists and is named bash.exe, sh.exe, bash, or sh.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+export interface ResolvedShell {
+  kind: 'bash' | 'powershell'
+  file: string
+  /** The argv that runs `command` through this shell. */
+  argsFor: (command: string) => string[]
+}
+
+const GIT_BASH_NAMES = new Set(['bash.exe', 'sh.exe', 'bash', 'sh'])
+const DEFAULT_GIT_ROOTS = [String.raw`C:\Program Files\Git`, String.raw`C:\Program Files (x86)\Git`]
+const PROJECT_TOOLING_DIRS = new Set(['node_modules', '.venv', 'venv'])
+
+const isFile = (file: string): boolean => {
+  try {
+    return fs.statSync(file).isFile()
+  } catch {
+    return false
+  }
+}
+
+/** The PowerShell names worth trying: pwsh everywhere it installs, plus the
+ * Windows spellings on win32, where powershell.exe ships with the OS. */
+const powershellCandidates = (platform: string): string[] => (platform === 'win32' ? ['pwsh', 'pwsh.exe', 'powershell.exe'] : ['pwsh'])
+
+/** First PowerShell binary found on PATH, or undefined when none is installed. */
+export function resolvePowershellBinary(platform: string = process.platform, env: Record<string, string | undefined> = process.env): string | undefined {
+  const dirs = (env.PATH ?? '').split(path.delimiter).filter(Boolean)
+  for (const candidate of powershellCandidates(platform)) {
+    for (const dir of dirs) {
+      const full = path.join(dir, candidate)
+      try {
+        fs.accessSync(full, fs.constants.X_OK)
+        if (fs.statSync(full).isFile()) return full
+      } catch {
+        // not here; keep looking
+      }
+    }
+  }
+  return undefined
+}
+
+/** A git in the launch directory itself, or below it under node_modules or a virtual
+ * environment, is a project's own tooling rather than the user's Git installation. */
+function isProjectTooling(dir: string, cwd: string): boolean {
+  const relative = path.relative(cwd, dir)
+  if (relative === '') return true
+  if (relative.startsWith('..') || path.isAbsolute(relative)) return false
+  return relative.split(path.sep).some((segment) => PROJECT_TOOLING_DIRS.has(segment))
+}
+
+/** Git Bash in Claude's documented order, or undefined when none is installed. */
+export function resolveGitBash(env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): string | undefined {
+  const override = env.CLAUDE_CODE_GIT_BASH_PATH
+  if (override && GIT_BASH_NAMES.has(path.basename(override).toLowerCase()) && isFile(override)) return override
+  for (const root of DEFAULT_GIT_ROOTS) {
+    const bash = path.join(root, 'bin', 'bash.exe')
+    if (isFile(bash)) return bash
+  }
+  for (const dir of (env.PATH ?? env.Path ?? '').split(path.delimiter).filter(Boolean)) {
+    if (!isFile(path.join(dir, 'git.exe')) || isProjectTooling(dir, cwd)) continue
+    // Git for Windows puts git.exe in cmd\ (or bin\); bash.exe lives in bin\ of the same install.
+    const bash = path.join(path.dirname(dir), 'bin', 'bash.exe')
+    if (isFile(bash)) return bash
+  }
+  return undefined
+}
+
+/** Claude rewrites these three placeholders in a PowerShell shell-form command to
+ * PowerShell's `${env:NAME}` form; the bare `$NAME` spelling is left alone (PowerShell
+ * reads it as an undefined variable, which Claude only warns about). */
+export const toPowershellPlaceholders = (command: string): string => command.replace(/\$\{(CLAUDE_PROJECT_DIR|CLAUDE_PLUGIN_ROOT|CLAUDE_PLUGIN_DATA)\}/g, (_match, name: string) => `\${env:${name}}`)
+
+const bashShell = (file: string): ResolvedShell => ({ kind: 'bash', file, argsFor: (command) => ['-c', command] })
+
+const powershellShell = (file: string): ResolvedShell => ({
+  kind: 'powershell',
+  file,
+  // -Command swallows a native command's exit code unless it is forwarded; a script
+  // that calls `exit` itself never reaches the trailer, so its own code stands.
+  argsFor: (command) => ['-NoProfile', '-NonInteractive', '-Command', `${toPowershellPlaceholders(command)}\nexit $LASTEXITCODE`],
+})
+
+/**
+ * The shell for a command string. `preferred` is a hook's `shell` field: "powershell"
+ * runs through PowerShell where one is installed. Otherwise /bin/sh off Windows; on
+ * Windows Git Bash, then PowerShell. Undefined means nothing on this machine can run
+ * it (Windows with neither Git Bash nor PowerShell installed).
+ */
+export function resolveShell(preferred: string | undefined, platform: string = process.platform, env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): ResolvedShell | undefined {
+  if (preferred === 'powershell') {
+    const powershell = resolvePowershellBinary(platform, env)
+    if (powershell) return powershellShell(powershell)
+  }
+  if (platform !== 'win32') return bashShell('/bin/sh')
+  const gitBash = resolveGitBash(env, cwd)
+  if (gitBash) return bashShell(gitBash)
+  const powershell = resolvePowershellBinary(platform, env)
+  return powershell ? powershellShell(powershell) : undefined
+}

--- a/extensions/internal/shell-resolve.ts
+++ b/extensions/internal/shell-resolve.ts
@@ -63,11 +63,13 @@ function isProjectTooling(dir: string, cwd: string): boolean {
   return relative.split(path.sep).some((segment) => PROJECT_TOOLING_DIRS.has(segment))
 }
 
-/** Git Bash in Claude's documented order, or undefined when none is installed. */
-export function resolveGitBash(env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): string | undefined {
+/** Git Bash in Claude's documented order, or undefined when none is installed.
+ * `installRoots` is the default install location list, a parameter so tests on a
+ * Windows host that has Git there can still exercise the later rules. */
+export function resolveGitBash(env: Record<string, string | undefined> = process.env, cwd: string = process.cwd(), installRoots: string[] = DEFAULT_GIT_ROOTS): string | undefined {
   const override = env.CLAUDE_CODE_GIT_BASH_PATH
   if (override && GIT_BASH_NAMES.has(path.basename(override).toLowerCase()) && isFile(override)) return override
-  for (const root of DEFAULT_GIT_ROOTS) {
+  for (const root of installRoots) {
     const bash = path.join(root, 'bin', 'bash.exe')
     if (isFile(bash)) return bash
   }
@@ -87,8 +89,8 @@ export const toPowershellPlaceholders = (command: string): string => command.rep
 
 /** The bash for an injected command span: /bin/sh off Windows, Git Bash on Windows
  * (undefined when it is not installed). */
-export function bashBinary(platform: string = process.platform, env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): string | undefined {
-  return platform === 'win32' ? resolveGitBash(env, cwd) : '/bin/sh'
+export function bashBinary(platform: string = process.platform, env: Record<string, string | undefined> = process.env, cwd: string = process.cwd(), installRoots?: string[]): string | undefined {
+  return platform === 'win32' ? resolveGitBash(env, cwd, installRoots) : '/bin/sh'
 }
 
 const bashShell = (file: string): ResolvedShell => ({ kind: 'bash', file, argsFor: (command) => ['-c', command] })
@@ -107,12 +109,12 @@ const powershellShell = (file: string): ResolvedShell => ({
  * Windows Git Bash, then PowerShell. Undefined means nothing on this machine can run
  * it (Windows with neither Git Bash nor PowerShell installed).
  */
-export function resolveShell(preferred: string | undefined, platform: string = process.platform, env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): ResolvedShell | undefined {
+export function resolveShell(preferred: string | undefined, platform: string = process.platform, env: Record<string, string | undefined> = process.env, cwd: string = process.cwd(), installRoots?: string[]): ResolvedShell | undefined {
   if (preferred === 'powershell') {
     const powershell = resolvePowershellBinary(platform, env)
     if (powershell) return powershellShell(powershell)
   }
-  const bash = bashBinary(platform, env, cwd)
+  const bash = bashBinary(platform, env, cwd, installRoots)
   if (bash) return bashShell(bash)
   const powershell = resolvePowershellBinary(platform, env)
   return powershell ? powershellShell(powershell) : undefined

--- a/extensions/internal/shell-resolve.ts
+++ b/extensions/internal/shell-resolve.ts
@@ -85,6 +85,12 @@ export function resolveGitBash(env: Record<string, string | undefined> = process
  * reads it as an undefined variable, which Claude only warns about). */
 export const toPowershellPlaceholders = (command: string): string => command.replace(/\$\{(CLAUDE_PROJECT_DIR|CLAUDE_PLUGIN_ROOT|CLAUDE_PLUGIN_DATA)\}/g, (_match, name: string) => `\${env:${name}}`)
 
+/** The bash for an injected command span: /bin/sh off Windows, Git Bash on Windows
+ * (undefined when it is not installed). */
+export function bashBinary(platform: string = process.platform, env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): string | undefined {
+  return platform === 'win32' ? resolveGitBash(env, cwd) : '/bin/sh'
+}
+
 const bashShell = (file: string): ResolvedShell => ({ kind: 'bash', file, argsFor: (command) => ['-c', command] })
 
 const powershellShell = (file: string): ResolvedShell => ({
@@ -106,9 +112,8 @@ export function resolveShell(preferred: string | undefined, platform: string = p
     const powershell = resolvePowershellBinary(platform, env)
     if (powershell) return powershellShell(powershell)
   }
-  if (platform !== 'win32') return bashShell('/bin/sh')
-  const gitBash = resolveGitBash(env, cwd)
-  if (gitBash) return bashShell(gitBash)
+  const bash = bashBinary(platform, env, cwd)
+  if (bash) return bashShell(bash)
   const powershell = resolvePowershellBinary(platform, env)
   return powershell ? powershellShell(powershell) : undefined
 }

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -16,6 +16,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/websocket.js'
 import { ListRootsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { FileOAuthProvider, type OAuthServerConfig } from '../internal/mcp-oauth.js'
+import { resolveShell } from '../internal/shell-resolve.js'
 import { expandCwd, type HttpServerConfig, interpolateEnv, type ServerConfig, type StdioServerConfig } from './config.js'
 import { runInteractiveOAuth, serializeInteractiveOAuth } from './oauth-flow.js'
 
@@ -306,11 +307,17 @@ export async function connectWithRetries(name: string, config: ServerConfig, aut
 }
 
 /** Run a headersHelper command and parse its JSON stdout into headers, under the
- * environment helperEnv built. A failure or a 10s timeout yields no extra headers
- * rather than blocking the connection. */
+ * environment helperEnv built. It runs through the platform shell (/bin/sh; Git Bash
+ * or PowerShell on Windows). A failure, a 10s timeout, or a machine with no shell
+ * yields no extra headers rather than blocking the connection. */
 function runHeadersHelper(command: string, env: NodeJS.ProcessEnv): Promise<Record<string, string>> {
   return new Promise((resolve) => {
-    execFile('/bin/sh', ['-c', command], { timeout: 10_000, env }, (error, stdout) => {
+    const shell = resolveShell(undefined)
+    if (!shell) {
+      resolve({})
+      return
+    }
+    execFile(shell.file, shell.argsFor(command), { timeout: 10_000, env }, (error, stdout) => {
       resolve(error ? {} : parseHelperHeaders(stdout))
     })
   })

--- a/tests/command-parse.test.ts
+++ b/tests/command-parse.test.ts
@@ -293,13 +293,14 @@ describe('powershellQuote', () => {
 describe('spanExec', () => {
   const found = () => '/usr/local/bin/pwsh'
   const missing = () => undefined
+  const sh = () => '/bin/sh'
   const runSh = (script: string) => {
     const run = spanExec(undefined, '/proj', script, missing)
     return spawnSync(run.command, run.args, { encoding: 'utf8' })
   }
 
   it('runs the default shell through /bin/sh with the project dir exported and stderr merged', () => {
-    const run = spanExec(undefined, '/proj', 'git status', found)
+    const run = spanExec(undefined, '/proj', 'git status', found, sh)
     expect(run.command).toBe('/bin/sh')
     expect(run.args[0]).toBe('-c')
     expect(run.args[1]).toContain("export CLAUDE_PROJECT_DIR='/proj'")
@@ -312,7 +313,7 @@ describe('spanExec', () => {
   })
 
   // POSIX-only: this spawns the constructed /bin/sh invocation, which does not exist on Windows.
-  it.skipIf(process.platform === 'win32')('runs an empty or comment-only span as a no-op, not an sh syntax error', () => {
+  it('runs an empty or comment-only span as a no-op, not an sh syntax error', () => {
     // `{ }` around an empty span is a hard sh syntax error (exit 2), which
     // aborted the whole invocation; the group opens with a `:` null command so
     // these degenerate spans stay harmless while real ones keep the merge.
@@ -324,8 +325,7 @@ describe('spanExec', () => {
     }
   })
 
-  // POSIX-only: this spawns the constructed /bin/sh invocation, which does not exist on Windows.
-  it.skipIf(process.platform === 'win32')('keeps a real span exit code and its stderr merge on the sh path', () => {
+  it('keeps a real span exit code and its stderr merge on the sh path', () => {
     const result = runSh('echo out; echo err >&2; exit 3')
     expect(result.status).toBe(3)
     expect(result.stdout).toBe('out\nerr\n')
@@ -333,7 +333,7 @@ describe('spanExec', () => {
   })
 
   it('keeps shell: bash on the sh path even when pwsh is installed', () => {
-    expect(spanExec('bash', '/proj', 'x', found).command).toBe('/bin/sh')
+    expect(spanExec('bash', '/proj', 'x', found, sh).command).toBe('/bin/sh')
   })
 
   it('runs shell: powershell through the resolved binary with -Command', () => {
@@ -367,8 +367,30 @@ describe('spanExec', () => {
     expect(run.args[3]).not.toContain('2>&1')
   })
 
+  // Oracle: skills.md shell matrix. Spans run through bash (/bin/sh, or Git Bash on
+  // Windows); without Git Bash a skill that declared `shell: bash` fails before any
+  // command runs, an undeclared one runs through PowerShell, and with neither shell
+  // the invocation fails.
+  it('runs the default arm through the resolved bash binary', () => {
+    const run = spanExec(undefined, '/proj', 'x', missing, () => 'C:/Git/bin/bash.exe')
+    expect(run.command).toBe('C:/Git/bin/bash.exe')
+    expect(run.args[0]).toBe('-c')
+  })
+
+  it('falls back to PowerShell when no bash exists and the skill did not ask for bash', () => {
+    expect(spanExec(undefined, '/proj', 'x', found, missing).command).toBe('/usr/local/bin/pwsh')
+  })
+
+  it('fails a shell: bash skill before any command runs when Git Bash is missing', () => {
+    expect(() => spanExec('bash', '/proj', 'x', found, missing)).toThrow(/requires Git Bash/)
+  })
+
+  it('fails when neither bash nor PowerShell exists', () => {
+    expect(() => spanExec(undefined, '/proj', 'x', missing, missing)).toThrow(/no shell/)
+  })
+
   it('falls back to /bin/sh when no PowerShell binary resolves', () => {
-    const run = spanExec('powershell', '/proj', 'Get-ChildItem', missing)
+    const run = spanExec('powershell', '/proj', 'Get-ChildItem', missing, sh)
     expect(run.command).toBe('/bin/sh')
     expect(run.args[0]).toBe('-c')
     expect(run.args[1]).toContain('Get-ChildItem')

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -690,6 +690,12 @@ describe('claude variables and skill frontmatter wiring', () => {
 })
 
 describe('shell frontmatter', () => {
+  // The bash path is /bin/sh off Windows; the Windows runners have Git for Windows, so Git Bash.
+  const expectBashPath = (file: string): void => {
+    if (process.platform === 'win32') expect(file).toMatch(/\\Git\\bin\\bash\.exe$/)
+    else expect(file).toBe('/bin/sh')
+  }
+
   it('runs a powershell command span through the resolved pwsh binary with -Command', async () => {
     const cwd = tempDir()
     hoisted.pwshBinary = '/opt/homebrew/bin/pwsh'
@@ -738,7 +744,7 @@ describe('shell frontmatter', () => {
     expect(s.sent[0]).not.toContain('stray noise')
   })
 
-  it('falls back to /bin/sh when no PowerShell binary is installed', async () => {
+  it('falls back to the bash path when no PowerShell binary is installed', async () => {
     const cwd = tempDir()
     // hoisted.pwshBinary stays undefined: the resolver finds nothing, as on this mac.
     writeCommand(cwd, 'ps.md', '---\nshell: powershell\n---\nfiles: !`Get-ChildItem`')
@@ -746,7 +752,7 @@ describe('shell frontmatter', () => {
     await s.handlers.get('session_start')?.({}, s.ctx)
     await s.commands.get('ps')?.handler('', s.ctx)
 
-    expect(s.execCalls[0].file).toBe('/bin/sh')
+    expectBashPath(s.execCalls[0].file)
     expect(s.execCalls[0].args[0]).toBe('-c')
     expect(s.execCalls[0].args[1]).toContain('Get-ChildItem')
     expect(s.execCalls[0].args[1]).toContain(`export CLAUDE_PROJECT_DIR='${cwd}'`)
@@ -761,7 +767,7 @@ describe('shell frontmatter', () => {
     await s.handlers.get('session_start')?.({}, s.ctx)
     await s.commands.get('sh')?.handler('', s.ctx)
 
-    expect(s.execCalls[0].file).toBe('/bin/sh')
+    expectBashPath(s.execCalls[0].file)
     expect(s.execCalls[0].args[0]).toBe('-c')
   })
 })

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -24,6 +24,8 @@ interface Behavior {
   error?: Error
   stdinError?: Error
   hang?: boolean
+  /** A pid for the fake child; far above any real pid so a group kill can only fail. */
+  pid?: number
 }
 
 interface SpawnRecord {
@@ -59,6 +61,7 @@ vi.mock('node:child_process', async (importOriginal) => {
       hoisted.calls.push(record)
 
       const child = new EventEmitter() as Emitter & Record<string, unknown>
+      if (behavior.pid !== undefined) child.pid = behavior.pid
       // Real streams, so setEncoding decodes multi-byte characters split across chunks
       // exactly as it does in production.
       child.stdout = new PassThrough()
@@ -364,6 +367,27 @@ describe('runHookCommand shell selection', () => {
   it('hides the console window a detached child would otherwise open on Windows', async () => {
     await runHookCommand('true', {}, 5000)
     expect(recordFor('true').options as { detached?: boolean; windowsHide?: boolean }).toMatchObject({ detached: true, windowsHide: true })
+  })
+
+  it('ends the whole process tree with taskkill on Windows, where process groups do not exist', async () => {
+    // A fake Git install so the Windows resolution finds a bash; the spawn mock runs nothing.
+    const root = tempDir('gitbash-')
+    mkdirSync(join(root, 'cmd'), { recursive: true })
+    mkdirSync(join(root, 'bin'), { recursive: true })
+    writeFileSync(join(root, 'cmd', 'git.exe'), 'MZ')
+    writeFileSync(join(root, 'bin', 'bash.exe'), 'MZ')
+    process.env.PATH = join(root, 'cmd')
+    script('slow-win', { hang: true, pid: 2_000_000_000 })
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      await runHookCommand('slow-win', {}, 20)
+    } finally {
+      if (platform) Object.defineProperty(process, 'platform', platform)
+    }
+    const taskkill = hoisted.calls.find((call) => call.file === 'taskkill')
+    expect(taskkill?.args).toEqual(['/pid', '2000000000', '/T', '/F'])
+    expect(recordFor('slow-win').killSignals).toEqual([])
   })
 
   it('passes the shell field of a settings hook through to the runner', async () => {

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -385,7 +385,8 @@ describe('runHookCommand shell selection', () => {
     } finally {
       if (platform) Object.defineProperty(process, 'platform', platform)
     }
-    const taskkill = hoisted.calls.find((call) => call.file === 'taskkill')
+    // By absolute path under SystemRoot, never a PATH lookup a writable directory could hijack.
+    const taskkill = hoisted.calls.find((call) => /System32[\\/]taskkill\.exe$/.test(call.file))
     expect(taskkill?.args).toEqual(['/pid', '2000000000', '/T', '/F'])
     expect(recordFor('slow-win').killSignals).toEqual([])
   })

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -230,7 +230,7 @@ describe('runHookCommand process wiring', () => {
     const expectedEnv: NodeJS.ProcessEnv = { ...process.env, CLAUDECODE: '1', CLAUDE_CODE_CHILD_SESSION: '1' }
     if (process.stdout.columns) expectedEnv.COLUMNS = String(process.stdout.columns)
     if (process.stdout.rows) expectedEnv.LINES = String(process.stdout.rows)
-    expect(record.options).toEqual({ stdio: ['pipe', 'pipe', 'pipe'], detached: true, env: expectedEnv })
+    expect(record.options).toEqual({ stdio: ['pipe', 'pipe', 'pipe'], detached: true, windowsHide: true, env: expectedEnv })
   })
 
   it('marks the hook child with CLAUDECODE=1 even when the parent env lacks it', async () => {
@@ -330,6 +330,47 @@ describe('runHookCommand exec form', () => {
     await vi.advanceTimersByTimeAsync(1000)
     const record = hoisted.calls.find((call) => call.file === '/bin/tool')
     expect(record?.killSignals).toEqual(['SIGKILL'])
+  })
+})
+
+describe('runHookCommand shell selection', () => {
+  // A PowerShell on PATH is enough for the resolver; the spawn mock never runs it.
+  const pwshOnPath = (): string => {
+    const bin = tempDir('pwsh-')
+    const pwsh = join(bin, 'pwsh')
+    writeFileSync(pwsh, '#!/bin/sh\n', { mode: 0o755 })
+    process.env.PATH = bin
+    return pwsh
+  }
+
+  it('runs a shell: powershell hook through the PowerShell on PATH with the documented argv', async () => {
+    const pwsh = pwshOnPath()
+    await runHookCommand('echo ${CLAUDE_PROJECT_DIR}', {}, 5000, '/proj', undefined, undefined, 'powershell')
+    const record = hoisted.calls[hoisted.calls.length - 1]
+    expect(record.file).toBe(pwsh)
+    expect(record.args).toEqual(['-NoProfile', '-NonInteractive', '-Command', 'echo ${env:CLAUDE_PROJECT_DIR}\nexit $LASTEXITCODE'])
+  })
+
+  it('ignores shell for an exec-form hook, which spawns its executable directly', async () => {
+    pwshOnPath()
+    await runHookCommand('/bin/echo', {}, 5000, undefined, ['x'], undefined, 'powershell')
+    const record = hoisted.calls[hoisted.calls.length - 1]
+    expect(record.file).toBe('/bin/echo')
+    expect(record.args).toEqual(['x'])
+  })
+
+  it('hides the console window a detached child would otherwise open on Windows', async () => {
+    await runHookCommand('true', {}, 5000)
+    expect(recordFor('true').options as { detached?: boolean; windowsHide?: boolean }).toMatchObject({ detached: true, windowsHide: true })
+  })
+
+  it('passes the shell field of a settings hook through to the runner', async () => {
+    const pwsh = pwshOnPath()
+    writeSettings(hoisted.home, 'settings.json', { SessionStart: [{ matcher: 'startup', hooks: [{ command: 'home-session', shell: 'powershell' }] }] })
+    await setupExtension().sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    const record = hoisted.calls[hoisted.calls.length - 1]
+    expect(record.file).toBe(pwsh)
+    expect(record.args[3]).toContain('home-session')
   })
 })
 

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -218,10 +218,12 @@ const setupExtension = () => {
 }
 
 describe('runHookCommand process wiring', () => {
-  it('runs the command through /bin/sh by absolute path, streams piped and detached into its own group', async () => {
+  it('runs the command through the platform shell by absolute path, streams piped and detached into its own group', async () => {
     await runHookCommand('guard.sh', {}, 5000)
     const record = recordFor('guard.sh')
-    expect(record.file).toBe('/bin/sh')
+    // /bin/sh off Windows; on the Windows runners Git for Windows is installed, so Git Bash.
+    if (process.platform === 'win32') expect(record.file).toMatch(/\\Git\\bin\\bash\.exe$/)
+    else expect(record.file).toBe('/bin/sh')
     expect(record.args).toEqual(['-c', 'guard.sh'])
     // `detached` is what makes the shell a process-group leader, so a timeout can kill
     // the grandchildren a compound command forks. Claude marks every subprocess it

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -578,8 +578,7 @@ describe('runPreToolUse', () => {
 })
 
 describe('runHookCommand (real shell)', () => {
-  // POSIX-only: runHookCommand's shell path spawns /bin/sh, which does not exist on Windows.
-  it.skipIf(process.platform === 'win32')('decodes multi-byte output split across stream chunks', async () => {
+  it('decodes multi-byte output split across stream chunks', async () => {
     // 100KB of two-byte characters crosses many 64KB pipe boundaries. Concatenating raw
     // Buffers would mangle every code point that straddles one, and a mangled byte in a
     // hook's deny decision makes it unparseable, which reads as an allow.
@@ -589,15 +588,13 @@ describe('runHookCommand (real shell)', () => {
     expect(result.stdout.length).toBeGreaterThan(50_000)
   })
 
-  // POSIX-only: runHookCommand's shell path spawns /bin/sh, which does not exist on Windows.
-  it.skipIf(process.platform === 'win32')('captures a non-zero exit code and stderr', async () => {
+  it('captures a non-zero exit code and stderr', async () => {
     const result = await runHookCommand('echo boom >&2; exit 2', {}, 5000)
     expect(result.code).toBe(2)
     expect(result.stderr).toContain('boom')
   })
 
-  // POSIX-only: runHookCommand's shell path spawns /bin/sh, which does not exist on Windows.
-  it.skipIf(process.platform === 'win32')('delivers the payload as JSON on stdin', async () => {
+  it('delivers the payload as JSON on stdin', async () => {
     const result = await runHookCommand('cat', { tool_name: 'bash' }, 5000)
     expect(result.code).toBe(0)
     expect(result.stdout).toContain('"tool_name":"bash"')
@@ -884,8 +881,7 @@ describe('hook stdout parsing rule', () => {
 })
 
 describe('hook command child environment', () => {
-  // POSIX-only: the probe runs sh variable expansion through runHookCommand's /bin/sh path.
-  it.skipIf(process.platform === 'win32')('marks hook commands with CLAUDE_CODE_CHILD_SESSION and passes terminal dimensions', async () => {
+  it('marks hook commands with CLAUDE_CODE_CHILD_SESSION and passes terminal dimensions', async () => {
     // Claude sets CLAUDE_CODE_CHILD_SESSION=1 in hook and status line commands
     // (not stdio MCP servers), and COLUMNS/LINES to the terminal dimensions.
     const savedColumns = Object.getOwnPropertyDescriptor(process.stdout, 'columns')

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2302,7 +2302,9 @@ describe('mcp headersHelper environment', () => {
     expect(String(hoisted.transports[0].url)).toBe('https://api.example/sekret/mcp')
   })
 
-  it('runs the helper through Git Bash on Windows', async () => {
+  // Off Windows only: a real Windows host resolves its Git install ahead of the PATH shim,
+  // and there the un-skipped helper tests above run through the real Git Bash.
+  it.skipIf(process.platform === 'win32')('runs the helper through Git Bash on Windows', async () => {
     // A Git for Windows layout on PATH whose bash.exe is a shim: on this host it marks
     // the environment and hands the command to /bin/sh, so the header says which shell ran.
     const root = mkdtempSync(join(tmpdir(), 'mcp-gitbash-'))

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2287,8 +2287,7 @@ describe('mcp stdio session context', () => {
 })
 
 describe('mcp headersHelper environment', () => {
-  // POSIX-only: production runs the headersHelper through /bin/sh -c, and these helpers are sh scripts.
-  it.skipIf(process.platform === 'win32')('passes the server name and a credential-redacted url to the helper', async () => {
+  it('passes the server name and a credential-redacted url to the helper', async () => {
     // Claude sets CLAUDE_CODE_MCP_SERVER_NAME and CLAUDE_CODE_MCP_SERVER_URL when
     // executing the helper; a url part expanded from a credential-named variable
     // reaches the helper as REDACTED while the transport gets the real value.
@@ -2303,8 +2302,30 @@ describe('mcp headersHelper environment', () => {
     expect(String(hoisted.transports[0].url)).toBe('https://api.example/sekret/mcp')
   })
 
-  // POSIX-only: production runs the headersHelper through /bin/sh -c, and this helper is an sh script.
-  it.skipIf(process.platform === 'win32')('strips credential-named variables from a project server helper environment', async () => {
+  it('runs the helper through Git Bash on Windows', async () => {
+    // A Git for Windows layout on PATH whose bash.exe is a shim: on this host it marks
+    // the environment and hands the command to /bin/sh, so the header says which shell ran.
+    const root = mkdtempSync(join(tmpdir(), 'mcp-gitbash-'))
+    tempDirs.push(root)
+    mkdirSync(join(root, 'cmd'), { recursive: true })
+    mkdirSync(join(root, 'bin'), { recursive: true })
+    writeFileSync(join(root, 'cmd', 'git.exe'), 'MZ')
+    writeFileSync(join(root, 'bin', 'bash.exe'), '#!/bin/sh\nPI_CODE_TEST_SHELL=git-bash exec /bin/sh "$@"\n', { mode: 0o755 })
+    setEnv('PATH', `${join(root, 'cmd')}:${process.env.PATH ?? ''}`)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      withTools([{ name: 'go' }])
+      await setupStarted({ user: { srv: { type: 'http', url: 'https://api.example/mcp', headersHelper: 'echo "{\\"X-Shell\\":\\"${PI_CODE_TEST_SHELL-sh}\\"}"' } } })
+    } finally {
+      if (platform) Object.defineProperty(process, 'platform', platform)
+    }
+
+    const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
+    expect(headers['X-Shell']).toBe('git-bash')
+  })
+
+  it('strips credential-named variables from a project server helper environment', async () => {
     // A helper a repository supplies runs without credential variables such as
     // ANTHROPIC_API_KEY: any name with TOKEN/SECRET/PASSWORD/KEY/AUTH in it.
     setEnv('MY_PROJ_TOKEN', 'leak')
@@ -2319,8 +2340,7 @@ describe('mcp headersHelper environment', () => {
     expect(headers['X-T']).toBe('absent')
   })
 
-  // POSIX-only: production runs the headersHelper through /bin/sh -c, and this helper is an sh script.
-  it.skipIf(process.platform === 'win32')('keeps credential variables for a user-scope helper, which the user wrote', async () => {
+  it('keeps credential variables for a user-scope helper, which the user wrote', async () => {
     setEnv('MY_USER_TOKEN', 'mine')
     withTools([{ name: 'go' }])
     const helper = `echo "{\\"X-T\\":\\"\${MY_USER_TOKEN-absent}\\"}"`
@@ -2330,8 +2350,7 @@ describe('mcp headersHelper environment', () => {
     expect(headers['X-T']).toBe('mine')
   })
 
-  // POSIX-only: production runs the headersHelper through /bin/sh -c, and this helper is an sh script.
-  it.skipIf(process.platform === 'win32')('gives a plugin server helper CLAUDE_PLUGIN_ROOT and the credential stripping', async () => {
+  it('gives a plugin server helper CLAUDE_PLUGIN_ROOT and the credential stripping', async () => {
     setEnv('MY_PLUGIN_TOKEN', 'leak')
     withTools([{ name: 'go' }])
     const helper = `echo "{\\"X-R\\":\\"$CLAUDE_PLUGIN_ROOT\\",\\"X-T\\":\\"\${MY_PLUGIN_TOKEN-absent}\\"}"`
@@ -2367,8 +2386,7 @@ describe('mcp configured authorization', () => {
     expect(line.startsWith('locked: failed: ')).toBe(true)
   })
 
-  // POSIX-only: the premise (helper output supplies Authorization) needs the /bin/sh helper to run.
-  it.skipIf(process.platform === 'win32')('fails a 401 server whose helper supplied Authorization instead of starting OAuth', async () => {
+  it('fails a 401 server whose helper supplied Authorization instead of starting OAuth', async () => {
     withTools([{ name: 'go' }])
     hoisted.control.connect = async () => {
       throw Object.assign(new Error('denied'), { code: 401 })

--- a/tests/shell-resolve.test.ts
+++ b/tests/shell-resolve.test.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { resolveGitBash, resolveShell, toPowershellPlaceholders } from '../extensions/internal/shell-resolve.ts'
+
+const dirs: string[] = []
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+const tempDir = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'shell-resolve-'))
+  dirs.push(dir)
+  return dir
+}
+
+/** A Git for Windows layout: `<root>/cmd/git.exe` is what PATH carries, `<root>/bin/bash.exe` is Git Bash. Returns the PATH entry. */
+const gitInstall = (root: string): string => {
+  mkdirSync(join(root, 'cmd'), { recursive: true })
+  mkdirSync(join(root, 'bin'), { recursive: true })
+  writeFileSync(join(root, 'cmd', 'git.exe'), 'MZ')
+  writeFileSync(join(root, 'bin', 'bash.exe'), 'MZ')
+  return join(root, 'cmd')
+}
+
+const powershellAt = (dir: string, name: string): string => {
+  const file = join(dir, name)
+  writeFileSync(file, 'MZ', { mode: 0o755 })
+  return file
+}
+
+// Oracle: Claude's documented lookup (troubleshoot-install.md, env-vars.md): the override
+// only when it exists and is named bash.exe/sh.exe/bash/sh, then the default install
+// dirs, then bin\bash.exe beside the git on PATH, skipping a git in the launch dir or
+// below it under node_modules or a virtual environment.
+describe('resolveGitBash', () => {
+  it('honors CLAUDE_CODE_GIT_BASH_PATH when it names an existing bash.exe', () => {
+    const bash = join(tempDir(), 'bash.exe')
+    writeFileSync(bash, 'MZ')
+    expect(resolveGitBash({ CLAUDE_CODE_GIT_BASH_PATH: bash, PATH: '' }, tempDir())).toBe(bash)
+  })
+
+  it('ignores an override that is missing or not named bash.exe, sh.exe, bash, or sh', () => {
+    const dir = tempDir()
+    const gitBashLauncher = join(dir, 'git-bash.exe')
+    writeFileSync(gitBashLauncher, 'MZ')
+    expect(resolveGitBash({ CLAUDE_CODE_GIT_BASH_PATH: gitBashLauncher, PATH: '' }, tempDir())).toBeUndefined()
+    expect(resolveGitBash({ CLAUDE_CODE_GIT_BASH_PATH: join(dir, 'bash.exe'), PATH: '' }, tempDir())).toBeUndefined()
+  })
+
+  it('finds bin\\bash.exe beside the git on PATH', () => {
+    const root = tempDir()
+    const onPath = gitInstall(root)
+    expect(resolveGitBash({ PATH: onPath }, tempDir())).toBe(join(root, 'bin', 'bash.exe'))
+  })
+
+  it('skips a git below the launch directory under node_modules or a virtual environment', () => {
+    const cwd = tempDir()
+    const local = gitInstall(join(cwd, 'node_modules', 'git'))
+    const venv = gitInstall(join(cwd, '.venv', 'git'))
+    const real = tempDir()
+    const realOnPath = gitInstall(real)
+    expect(resolveGitBash({ PATH: [local, venv, realOnPath].join(delimiter) }, cwd)).toBe(join(real, 'bin', 'bash.exe'))
+    expect(resolveGitBash({ PATH: [local, venv].join(delimiter) }, cwd)).toBeUndefined()
+  })
+
+  it('skips a git sitting in the launch directory itself', () => {
+    const root = tempDir()
+    const cwd = gitInstall(root)
+    expect(resolveGitBash({ PATH: cwd }, cwd)).toBeUndefined()
+  })
+
+  it('returns undefined when no git is on PATH', () => {
+    expect(resolveGitBash({ PATH: tempDir() }, tempDir())).toBeUndefined()
+  })
+})
+
+// Oracle: hooks.md ("sh -c on macOS and Linux, Git Bash on Windows, or PowerShell when
+// Git Bash isn't installed"; `shell: "powershell"` runs via PowerShell; the ${CLAUDE_*}
+// placeholders are rewritten to ${env:NAME} for PowerShell, the bare $NAME is not).
+describe('resolveShell', () => {
+  it('runs through /bin/sh -c off Windows', () => {
+    const shell = resolveShell(undefined, 'darwin', { PATH: '' })
+    expect(shell?.file).toBe('/bin/sh')
+    expect(shell?.argsFor('echo hi')).toEqual(['-c', 'echo hi'])
+  })
+
+  it('prefers Git Bash on Windows', () => {
+    const root = tempDir()
+    const shell = resolveShell(undefined, 'win32', { PATH: gitInstall(root) }, tempDir())
+    expect(shell?.kind).toBe('bash')
+    expect(shell?.file).toBe(join(root, 'bin', 'bash.exe'))
+    expect(shell?.argsFor('echo hi')).toEqual(['-c', 'echo hi'])
+  })
+
+  it('falls back to PowerShell on Windows without Git Bash and rewrites the documented placeholders', () => {
+    const dir = tempDir()
+    const powershell = powershellAt(dir, 'powershell.exe')
+    const shell = resolveShell(undefined, 'win32', { PATH: dir }, tempDir())
+    expect(shell?.kind).toBe('powershell')
+    expect(shell?.file).toBe(powershell)
+    expect(shell?.argsFor('echo ${CLAUDE_PROJECT_DIR} $CLAUDE_PROJECT_DIR')).toEqual(['-NoProfile', '-NonInteractive', '-Command', 'echo ${env:CLAUDE_PROJECT_DIR} $CLAUDE_PROJECT_DIR\nexit $LASTEXITCODE'])
+  })
+
+  it('runs shell: powershell through pwsh wherever one is installed', () => {
+    const dir = tempDir()
+    const pwsh = powershellAt(dir, 'pwsh')
+    expect(resolveShell('powershell', 'darwin', { PATH: dir })?.file).toBe(pwsh)
+  })
+
+  it('keeps shell: powershell on /bin/sh off Windows when no PowerShell is installed', () => {
+    expect(resolveShell('powershell', 'darwin', { PATH: tempDir() })?.file).toBe('/bin/sh')
+  })
+
+  it('resolves nothing on Windows with neither Git Bash nor PowerShell', () => {
+    expect(resolveShell(undefined, 'win32', { PATH: tempDir() }, tempDir())).toBeUndefined()
+  })
+})
+
+describe('toPowershellPlaceholders', () => {
+  it('rewrites the three documented placeholders and nothing else', () => {
+    expect(toPowershellPlaceholders('${CLAUDE_PROJECT_DIR} ${CLAUDE_PLUGIN_ROOT} ${CLAUDE_PLUGIN_DATA} ${OTHER} $CLAUDE_PROJECT_DIR')).toBe('${env:CLAUDE_PROJECT_DIR} ${env:CLAUDE_PLUGIN_ROOT} ${env:CLAUDE_PLUGIN_DATA} ${OTHER} $CLAUDE_PROJECT_DIR')
+  })
+})

--- a/tests/shell-resolve.test.ts
+++ b/tests/shell-resolve.test.ts
@@ -39,21 +39,21 @@ describe('resolveGitBash', () => {
   it('honors CLAUDE_CODE_GIT_BASH_PATH when it names an existing bash.exe', () => {
     const bash = join(tempDir(), 'bash.exe')
     writeFileSync(bash, 'MZ')
-    expect(resolveGitBash({ CLAUDE_CODE_GIT_BASH_PATH: bash, PATH: '' }, tempDir())).toBe(bash)
+    expect(resolveGitBash({ CLAUDE_CODE_GIT_BASH_PATH: bash, PATH: '' }, tempDir(), [])).toBe(bash)
   })
 
   it('ignores an override that is missing or not named bash.exe, sh.exe, bash, or sh', () => {
     const dir = tempDir()
     const gitBashLauncher = join(dir, 'git-bash.exe')
     writeFileSync(gitBashLauncher, 'MZ')
-    expect(resolveGitBash({ CLAUDE_CODE_GIT_BASH_PATH: gitBashLauncher, PATH: '' }, tempDir())).toBeUndefined()
-    expect(resolveGitBash({ CLAUDE_CODE_GIT_BASH_PATH: join(dir, 'bash.exe'), PATH: '' }, tempDir())).toBeUndefined()
+    expect(resolveGitBash({ CLAUDE_CODE_GIT_BASH_PATH: gitBashLauncher, PATH: '' }, tempDir(), [])).toBeUndefined()
+    expect(resolveGitBash({ CLAUDE_CODE_GIT_BASH_PATH: join(dir, 'bash.exe'), PATH: '' }, tempDir(), [])).toBeUndefined()
   })
 
   it('finds bin\\bash.exe beside the git on PATH', () => {
     const root = tempDir()
     const onPath = gitInstall(root)
-    expect(resolveGitBash({ PATH: onPath }, tempDir())).toBe(join(root, 'bin', 'bash.exe'))
+    expect(resolveGitBash({ PATH: onPath }, tempDir(), [])).toBe(join(root, 'bin', 'bash.exe'))
   })
 
   it('skips a git below the launch directory under node_modules or a virtual environment', () => {
@@ -62,18 +62,24 @@ describe('resolveGitBash', () => {
     const venv = gitInstall(join(cwd, '.venv', 'git'))
     const real = tempDir()
     const realOnPath = gitInstall(real)
-    expect(resolveGitBash({ PATH: [local, venv, realOnPath].join(delimiter) }, cwd)).toBe(join(real, 'bin', 'bash.exe'))
-    expect(resolveGitBash({ PATH: [local, venv].join(delimiter) }, cwd)).toBeUndefined()
+    expect(resolveGitBash({ PATH: [local, venv, realOnPath].join(delimiter) }, cwd, [])).toBe(join(real, 'bin', 'bash.exe'))
+    expect(resolveGitBash({ PATH: [local, venv].join(delimiter) }, cwd, [])).toBeUndefined()
   })
 
   it('skips a git sitting in the launch directory itself', () => {
     const root = tempDir()
     const cwd = gitInstall(root)
-    expect(resolveGitBash({ PATH: cwd }, cwd)).toBeUndefined()
+    expect(resolveGitBash({ PATH: cwd }, cwd, [])).toBeUndefined()
+  })
+
+  // Real-host oracle: the windows-latest runners install Git for Windows in the default
+  // location, which is the first rule after the override.
+  it.skipIf(process.platform !== 'win32')('finds Git for Windows in its default install directory on this host', () => {
+    expect(resolveGitBash({ PATH: '' }, tempDir())).toMatch(/\\Git\\bin\\bash\.exe$/)
   })
 
   it('returns undefined when no git is on PATH', () => {
-    expect(resolveGitBash({ PATH: tempDir() }, tempDir())).toBeUndefined()
+    expect(resolveGitBash({ PATH: tempDir() }, tempDir(), [])).toBeUndefined()
   })
 })
 
@@ -89,7 +95,7 @@ describe('resolveShell', () => {
 
   it('prefers Git Bash on Windows', () => {
     const root = tempDir()
-    const shell = resolveShell(undefined, 'win32', { PATH: gitInstall(root) }, tempDir())
+    const shell = resolveShell(undefined, 'win32', { PATH: gitInstall(root) }, tempDir(), [])
     expect(shell?.kind).toBe('bash')
     expect(shell?.file).toBe(join(root, 'bin', 'bash.exe'))
     expect(shell?.argsFor('echo hi')).toEqual(['-c', 'echo hi'])
@@ -98,7 +104,7 @@ describe('resolveShell', () => {
   it('falls back to PowerShell on Windows without Git Bash and rewrites the documented placeholders', () => {
     const dir = tempDir()
     const powershell = powershellAt(dir, 'powershell.exe')
-    const shell = resolveShell(undefined, 'win32', { PATH: dir }, tempDir())
+    const shell = resolveShell(undefined, 'win32', { PATH: dir }, tempDir(), [])
     expect(shell?.kind).toBe('powershell')
     expect(shell?.file).toBe(powershell)
     expect(shell?.argsFor('echo ${CLAUDE_PROJECT_DIR} $CLAUDE_PROJECT_DIR')).toEqual(['-NoProfile', '-NonInteractive', '-Command', 'echo ${env:CLAUDE_PROJECT_DIR} $CLAUDE_PROJECT_DIR\nexit $LASTEXITCODE'])
@@ -115,7 +121,7 @@ describe('resolveShell', () => {
   })
 
   it('resolves nothing on Windows with neither Git Bash nor PowerShell', () => {
-    expect(resolveShell(undefined, 'win32', { PATH: tempDir() }, tempDir())).toBeUndefined()
+    expect(resolveShell(undefined, 'win32', { PATH: tempDir() }, tempDir(), [])).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
Shell-form hook commands, the `statusLine` command, MCP `headersHelper` commands, and the default arm of `!` command spans all spawned `/bin/sh`, which does not exist on Windows. For hooks the spawn error settled as `spawnFailed`, which blocks PreToolUse and UserPromptSubmit, so a gated hook bricked the tool there; everything else silently never ran.

- New `extensions/internal/shell-resolve.ts`: the shell Claude documents for a command string. `/bin/sh` off Windows; on Windows Git Bash (the `CLAUDE_CODE_GIT_BASH_PATH` override when it names an existing `bash.exe`/`sh.exe`/`bash`/`sh`, then the default Git for Windows install dirs, then `bin\bash.exe` beside the `git` on PATH, skipping a project's own tooling under `node_modules` or a virtual environment), then PowerShell. `shell: "powershell"` forces PowerShell where one is installed, with `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_ROOT}`, and `${CLAUDE_PLUGIN_DATA}` rewritten to `${env:NAME}` and the exit code forwarded. The PowerShell lookup moves here from the command-file module.
- Hooks: the runner resolves the shell per hook; `HookCommand` gains `shell` (ignored with `args`); a machine with no shell still fails closed; children spawn with `windowsHide`. On Windows a timed-out hook's tree is ended with `taskkill /T /F` (no process groups there).
- MCP `headersHelper` runs through the same resolver and still yields no headers when no shell exists.
- Command spans run through the platform bash; without Git Bash a `shell: bash` skill fails before any command runs (as Claude documents), an undeclared one runs through PowerShell, and with neither shell the invocation fails naming the fix.
- Eleven tests that only needed a POSIX shell now also run on the Windows leg under Git Bash; the resolver tests take the default install roots as a parameter so they stay hermetic on a host that has Git there, and one Windows-only test asserts the real default directory is found.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change
