### PR TITLE
Close seven trust and permission gaps found in the round 4 scan

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,5 +5,5 @@ Loads installed marketplace plugins. Source: [`extensions/internal/plugins.ts`](
 - Reads the plugin cache at `~/.claude/plugins/cache`, active per `enabledPlugins` in user settings only: a checked-out repo cannot flip which code-bearing plugins run, so project settings never toggle them.
 - Contributes commands as `/plugin:name`, agents, hooks, MCP servers (tools aliased `mcp__plugin_<plugin>_<server>__<tool>`), and output styles.
 - Enablement follows Claude's precedence: a managed-settings `enabledPlugins` entry force-enables or blocks, then the user's `enabledPlugins` setting, then the manifest's `defaultEnabled` (default `true`: an installed plugin with no entry runs).
-- Substitutes `${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PLUGIN_DATA}`, and `${user_config.KEY}` (from `pluginConfigs[id].options` in user settings).
+- Substitutes `${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PLUGIN_DATA}`, and `${user_config.KEY}` (from `pluginConfigs[id].options` in user settings). Fields that reach a shell reject `${user_config.KEY}`, as Claude does: a shell-form hook command carrying one is dropped, and an MCP `headersHelper` carrying one skips its server.
 - Skill directories contribute too, though pi's loader names them without the plugin prefix.

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -50,7 +50,7 @@ import { claudeConfigDir } from './internal/config-dir.js'
 import { managedSettingsFile, readManagedSettings } from './internal/managed-settings.js'
 import { capForContext } from './internal/output-guard.js'
 import { matchesPathRules } from './internal/path-rules.js'
-import { type InstalledPlugin, installedPlugins } from './internal/plugins.js'
+import { type InstalledPlugin, installedPlugins, pluginComponentPath } from './internal/plugins.js'
 import { isProjectApproved } from './internal/project-approval.js'
 import { ancestorDirs, repoRoot } from './internal/project-root.js'
 import { claudeSettingsChain } from './internal/settings-chain.js'
@@ -146,7 +146,7 @@ function pluginCommands(plugins: InstalledPlugin[]): DiscoveredCommand[] {
   const found: DiscoveredCommand[] = []
   for (const plugin of plugins) {
     const declared = plugin.manifest.commands
-    const dirs = (Array.isArray(declared) ? declared : [typeof declared === 'string' ? declared : 'commands']).map((entry) => path.resolve(plugin.root, String(entry)))
+    const dirs = (Array.isArray(declared) ? declared : [typeof declared === 'string' ? declared : 'commands']).map((entry) => pluginComponentPath(plugin, String(entry))).filter((dir): dir is string => dir !== undefined)
     for (const dir of dirs) {
       for (const command of discoverCommandFiles(dir)) {
         found.push({ name: `${plugin.name}:${command.name}`, filePath: command.filePath, plugin: { root: plugin.root, dataDir: plugin.dataDir, ...(plugin.userConfig ? { userConfig: plugin.userConfig } : {}) } })

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -250,15 +250,16 @@ function withoutUserConfigShellCommands(raw: string, source: string): string {
   for (const matchers of Object.values(parsed?.hooks ?? {})) {
     if (!Array.isArray(matchers)) continue
     for (const entry of matchers) {
-      const hooks = (entry as { hooks?: unknown }).hooks
-      if (!Array.isArray(hooks)) continue
-      ;(entry as { hooks?: unknown }).hooks = hooks.filter((hook) => {
+      const record = entry as { hooks?: unknown }
+      if (!Array.isArray(record.hooks)) continue
+      const kept = record.hooks.filter((hook) => {
         const candidate = hook as { command?: unknown; args?: unknown }
         if (Array.isArray(candidate.args) || typeof candidate.command !== 'string' || !USER_CONFIG_REF.test(candidate.command)) return true
         console.warn(`pi-code-hooks: ignoring a hook in ${source}: a shell-form command cannot reference \${user_config.*}; use exec form with "args", or read CLAUDE_PLUGIN_OPTION_<KEY> from the environment`)
         dropped = true
         return false
       })
+      record.hooks = kept
     }
   }
   return dropped ? JSON.stringify(parsed) : raw

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -7,7 +7,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { readManagedSettings } from '../internal/managed-settings.js'
-import { type InstalledPlugin, substitutePluginVars } from '../internal/plugins.js'
+import { type InstalledPlugin, pluginComponentPath, substitutePluginVars } from '../internal/plugins.js'
 import { claudeSettingsChain } from '../internal/settings-chain.js'
 
 export interface HookCommand {
@@ -275,7 +275,8 @@ export function loadPluginHooks(config: HooksConfig, plugins: InstalledPlugin[],
       mergeHooksJson(config, substitutePluginVars(withoutUserConfigShellCommands(JSON.stringify({ hooks: declared }), inlineSource), plugin, jsonEscape), inlineSource, sources, `plugin:${plugin.name}`)
       continue
     }
-    const file = path.resolve(plugin.root, typeof declared === 'string' ? declared : path.join('hooks', 'hooks.json'))
+    const file = pluginComponentPath(plugin, typeof declared === 'string' ? declared : path.join('hooks', 'hooks.json'))
+    if (file === undefined) continue
     try {
       mergeHooksJson(config, substitutePluginVars(withoutUserConfigShellCommands(fs.readFileSync(file, 'utf-8'), file), plugin, jsonEscape), file, sources, `plugin:${plugin.name}`)
     } catch {

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -227,6 +227,43 @@ function mergeHooksJson(config: HooksConfig, raw: string, source: string, source
  * every hook the plugin declared silently vanished. */
 const jsonEscape = (value: string): string => JSON.stringify(value).slice(1, -1)
 
+/** A reference Claude refuses to substitute into anything that reaches a shell. */
+const USER_CONFIG_REF = /\$\{user_config\./
+
+/**
+ * Drop shell-form hook commands that reference `${user_config.*}`. Claude: "Fields that
+ * run in a shell reject `${user_config.*}`: substituting a configured value into a shell
+ * command would let the shell run whatever that value contains, so the component fails
+ * with an error instead." Exec form (`args`) and every other field still substitute, and
+ * the documented alternative is reading CLAUDE_PLUGIN_OPTION_<KEY> from the hook's
+ * environment. Sibling hooks in the same file are unaffected: one rejected component
+ * costs itself, not the plugin's other hooks.
+ */
+function withoutUserConfigShellCommands(raw: string, source: string): string {
+  let parsed: { hooks?: Record<string, unknown> }
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return raw // mergeHooksJson reports the parse failure
+  }
+  let dropped = false
+  for (const matchers of Object.values(parsed?.hooks ?? {})) {
+    if (!Array.isArray(matchers)) continue
+    for (const entry of matchers) {
+      const hooks = (entry as { hooks?: unknown }).hooks
+      if (!Array.isArray(hooks)) continue
+      ;(entry as { hooks?: unknown }).hooks = hooks.filter((hook) => {
+        const candidate = hook as { command?: unknown; args?: unknown }
+        if (Array.isArray(candidate.args) || typeof candidate.command !== 'string' || !USER_CONFIG_REF.test(candidate.command)) return true
+        console.warn(`pi-code-hooks: ignoring a hook in ${source}: a shell-form command cannot reference \${user_config.*}; use exec form with "args", or read CLAUDE_PLUGIN_OPTION_<KEY> from the environment`)
+        dropped = true
+        return false
+      })
+    }
+  }
+  return dropped ? JSON.stringify(parsed) : raw
+}
+
 export function loadPluginHooks(config: HooksConfig, plugins: InstalledPlugin[], sources?: Map<HookMatcher, string>): void {
   for (const plugin of plugins) {
     const declared = plugin.manifest.hooks
@@ -234,12 +271,13 @@ export function loadPluginHooks(config: HooksConfig, plugins: InstalledPlugin[],
     // numeric event keys), so it falls through to the default path rather than
     // silently registering nothing.
     if (declared !== null && typeof declared === 'object' && !Array.isArray(declared)) {
-      mergeHooksJson(config, substitutePluginVars(JSON.stringify({ hooks: declared }), plugin, jsonEscape), `${plugin.name} (plugin.json)`, sources, `plugin:${plugin.name}`)
+      const inlineSource = `${plugin.name} (plugin.json)`
+      mergeHooksJson(config, substitutePluginVars(withoutUserConfigShellCommands(JSON.stringify({ hooks: declared }), inlineSource), plugin, jsonEscape), inlineSource, sources, `plugin:${plugin.name}`)
       continue
     }
     const file = path.resolve(plugin.root, typeof declared === 'string' ? declared : path.join('hooks', 'hooks.json'))
     try {
-      mergeHooksJson(config, substitutePluginVars(fs.readFileSync(file, 'utf-8'), plugin, jsonEscape), file, sources, `plugin:${plugin.name}`)
+      mergeHooksJson(config, substitutePluginVars(withoutUserConfigShellCommands(fs.readFileSync(file, 'utf-8'), file), plugin, jsonEscape), file, sources, `plugin:${plugin.name}`)
     } catch {
       // a plugin without hooks contributes nothing
     }

--- a/extensions/internal/bash-rules.ts
+++ b/extensions/internal/bash-rules.ts
@@ -14,10 +14,20 @@ import { hasSubstitution, splitSegments } from './shell-split.js'
 
 const escapeRegExp = (text: string): string => text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 
+/**
+ * One rule against one command segment, per Claude's permission table:
+ * - `*` stands in for whatever text is in its place.
+ * - a trailing `*` with a space before it also matches the bare command, but only when
+ *   it is the rule's only wildcard (`* --help *` does not match `npm --help`).
+ * - that space is part of the rule, so `ls *` does not match `lsof` while `ls*` does.
+ * - `:*` is an equivalent spelling of a trailing ` *`, recognized only at the end; a
+ *   colon anywhere else is a literal character.
+ */
 function matchesRule(segment: string, rule: string): boolean {
-  if (rule.endsWith(':*')) return segment.startsWith(rule.slice(0, -2))
-  if (rule.includes('*')) return new RegExp(`^${rule.split('*').map(escapeRegExp).join('[^]*')}$`).test(segment)
-  return segment === rule
+  const normalized = rule.endsWith(':*') ? `${rule.slice(0, -2)} *` : rule
+  if (normalized.endsWith(' *') && normalized.indexOf('*') === normalized.length - 1 && segment === normalized.slice(0, -2)) return true
+  if (normalized.includes('*')) return new RegExp(`^${normalized.split('*').map(escapeRegExp).join('[^]*')}$`).test(segment)
+  return segment === normalized
 }
 
 export function matchesBashRules(command: string, rules: string[]): boolean {

--- a/extensions/internal/mcp-oauth.ts
+++ b/extensions/internal/mcp-oauth.ts
@@ -39,10 +39,26 @@ export interface OAuthServerConfig {
   authServerMetadataUrl?: string
 }
 
+/** The origin a sign-in belongs to, so the same server name at a different endpoint gets
+ * its own store. An unparseable url falls back to its raw text rather than to nothing. */
+function endpointKey(endpoint: string | undefined): string {
+  if (!endpoint) return ''
+  try {
+    return new URL(endpoint).origin
+  } catch {
+    return endpoint
+  }
+}
+
 /** A server name is config-controlled text; the digest keeps hostile names inside
- * the store directory and distinct names from colliding after sanitization. */
-function storeFileFor(serverName: string): string {
-  const digest = crypto.createHash('sha256').update(serverName).digest('hex').slice(0, 8)
+ * the store directory and distinct names from colliding after sanitization. The endpoint
+ * rides the digest so a second project reusing a name cannot read the first one's tokens. */
+function storeFileFor(serverName: string, endpoint?: string): string {
+  const digest = crypto
+    .createHash('sha256')
+    .update(`${serverName}\n${endpointKey(endpoint)}`)
+    .digest('hex')
+    .slice(0, 8)
   // Collapse disallowed runs to a single hyphen, then strip leading and trailing
   // hyphens by index. The old /^-+|-+$/g trim rescanned on every hyphen of a long run
   // (its trailing-anchored branch backtracks per start position), which is quadratic.
@@ -66,8 +82,8 @@ export class FileOAuthProvider implements OAuthClientProvider {
   // page cannot inject an authorization code into this login (RFC 8252 8.9).
   private readonly loginState = crypto.randomBytes(16).toString('hex')
 
-  constructor(serverName: string, onRedirect: (authorizationUrl: URL) => void, oauth?: OAuthServerConfig) {
-    this.storePath = storeFileFor(serverName)
+  constructor(serverName: string, onRedirect: (authorizationUrl: URL) => void, oauth?: OAuthServerConfig, endpoint?: string) {
+    this.storePath = storeFileFor(serverName, endpoint)
     this.onRedirect = onRedirect
     this.oauth = oauth
     try {

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -243,6 +243,20 @@ function resolvePlugin(home: string, cacheDir: string, marketplace: string, plug
  * substituting into text that is still raw JSON must pass an escapeValue that
  * JSON-escapes: a Windows root (C:\Users\...) inserted verbatim injects invalid
  * escape sequences and the subsequent parse throws. */
+/** A plugin component path, resolved inside the plugin root. Claude "rejects a component
+ * path that resolves outside the plugin root, such as `../shared-utils`", so an escaping
+ * entry yields undefined and its caller skips that component. The check is lexical, which
+ * is the rule as documented: a plugin's own root may itself be a symlink (link mode). */
+export function pluginComponentPath(plugin: Pick<InstalledPlugin, 'name' | 'root'>, declared: string): string | undefined {
+  const resolved = path.resolve(plugin.root, declared)
+  const inside = path.relative(plugin.root, resolved)
+  if (inside !== '' && (inside.startsWith(`..${path.sep}`) || inside === '..' || path.isAbsolute(inside))) {
+    console.warn(`pi-code-plugins: plugin ${plugin.name} declares the component path "${declared}", which resolves outside its root; ignoring it`)
+    return undefined
+  }
+  return resolved
+}
+
 export function substitutePluginVars(value: string, plugin: InstalledPlugin, escapeValue: (substituted: string) => string = (substituted) => substituted): string {
   return value
     .replaceAll('${CLAUDE_PLUGIN_ROOT}', escapeValue(plugin.root))

--- a/extensions/mcp/config.ts
+++ b/extensions/mcp/config.ts
@@ -8,7 +8,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { claudeConfigDir } from '../internal/config-dir.js'
 import type { OAuthServerConfig } from '../internal/mcp-oauth.js'
-import type { InstalledPlugin } from '../internal/plugins.js'
+import { type InstalledPlugin, pluginComponentPath } from '../internal/plugins.js'
 import { findNearestFile } from '../internal/project-root.js'
 
 export interface StdioServerConfig {
@@ -156,7 +156,9 @@ function rawPluginServerEntries(plugin: InstalledPlugin): Record<string, unknown
   const servers: Record<string, unknown> = {}
   for (const entry of paths) {
     try {
-      const parsed = JSON.parse(fs.readFileSync(path.resolve(plugin.root, entry), 'utf-8'))
+      const file = pluginComponentPath(plugin, entry)
+      if (file === undefined) continue
+      const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'))
       Object.assign(servers, parsed.mcpServers ?? {})
     } catch {
       // Malformed or missing JSON contributes no entries.

--- a/extensions/mcp/index.ts
+++ b/extensions/mcp/index.ts
@@ -494,6 +494,14 @@ export default async function mcpExtension(pi: ExtensionAPI) {
    * factory: pi runs the factory for invocations that never start a session. Names still
    * connected are filtered out, so a later session start only retries servers that failed
    * or whose transport dropped, without duplicate-name warnings. */
+  /** A project server's headersHelper, dropped while the project is unapproved. */
+  function withoutUntrustedHelper(name: string, config: ServerConfig): ServerConfig {
+    if (!('headersHelper' in config) || config.headersHelper === undefined) return config
+    console.warn(`pi-code-mcp: headersHelper not run for server ${name}: the project is not trusted yet; connecting with its static headers alone`)
+    const { headersHelper: _dropped, ...rest } = config
+    return rest as ServerConfig
+  }
+
   async function connectNormalScopes(ctx: ExtensionContext, policy: McpPolicy, authUi?: AuthUi): Promise<void> {
     // Plugin servers merge under the user scope (plugins are user-installed);
     // the user's own entry wins a name clash with a plugin's. A server toggled off
@@ -510,7 +518,8 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // a deliberate narrowing of Claude's rule to keep the safe default.
     // The stored project decision, read without prompting: consent recorded inside
     // the project only counts once the project itself has been approved.
-    const projectPolicy = projectServerPolicy(ctx.cwd, os.homedir(), isProjectApprovedSilently(ctx))
+    const projectApproved = isProjectApprovedSilently(ctx)
+    const projectPolicy = projectServerPolicy(ctx.cwd, os.homedir(), projectApproved)
     // Tag the scope on each project server: a repository-supplied headersHelper runs
     // with credential variables stripped, unlike a user-scope one.
     const projectServers = Object.fromEntries(Object.entries(loadConfigFrom(projectConfigPaths(ctx.cwd))).map(([name, config]) => [name, { ...config, projectScope: true }]))
@@ -519,7 +528,14 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // stays with the local (user-side) definition, so the project's entry is dropped
     // here rather than allowed to shadow it.
     const localNames = localScopeServerNames(os.homedir(), ctx.cwd)
-    const consented = Object.fromEntries(Object.entries(consentedRaw).filter(([name]) => !localNames.has(name)))
+    // Claude: until the folder is trusted, a project server connects with its static
+    // headers alone. Consenting to the server is not consenting to run the command it
+    // ships, so the helper is dropped (and named once) while the project is unapproved.
+    const consented = Object.fromEntries(
+      Object.entries(consentedRaw)
+        .filter(([name]) => !localNames.has(name))
+        .map(([name, config]) => [name, projectApproved ? config : withoutUntrustedHelper(name, config)]),
+    )
     const projectWinners = new Set(Object.keys(consented))
     const userServers = Object.fromEntries(Object.entries(scoped).filter(([name]) => !clients.has(name) && !projectWinners.has(name)))
     // The consented project servers carry no ordering dependency on the user scope:

--- a/extensions/mcp/oauth-flow.ts
+++ b/extensions/mcp/oauth-flow.ts
@@ -55,6 +55,7 @@ export async function runInteractiveOAuth(name: string, config: { url: string; o
       authUi.notify(`Authorize "${name}" in the browser. If it did not open: ${authorizationUrl}`, 'info')
     },
     config.oauth,
+    config.url,
   )
   const { server, port } = await startCallbackServer(provider.savedRedirectPort())
   provider.bindRedirectPort(port)

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -260,8 +260,13 @@ export async function connect(name: string, config: ServerConfig, authUi?: AuthU
   const token = resolveBearerToken(config)
   if (token) headers.Authorization = `Bearer ${token}`
   // A headersHelper generates connect-time headers for non-OAuth auth schemes; its
-  // JSON stdout merges over the static headers.
-  if (config.headersHelper) Object.assign(headers, await runHeadersHelper(fill(config.headersHelper), helperEnv(name, config)))
+  // JSON stdout merges over the static headers. The command text is NOT interpolated:
+  // Claude expands ${VAR} in command, args, env, url and headers, and expanding it here
+  // would read the parent environment, which is the credential set a repository- or
+  // plugin-supplied helper must not see. The helper's own shell expands it against the
+  // stripped environment instead. Plugin path variables are already substituted in
+  // mcp/config.ts, which also refuses ${user_config.*} in a helper.
+  if (config.headersHelper) Object.assign(headers, await runHeadersHelper(config.headersHelper, helperEnv(name, config)))
   warnMissing()
   // Claude: a configured Authorization header, whether static, a bearer token, or
   // helper output, is the server's authentication; there is no OAuth fallback for it.

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -367,7 +367,7 @@ async function connectHttpFamily(name: string, config: { url: string; oauth?: OA
   // dynamic registration, keeping it bound to the real callback port. A
   // pre-configured client (oauth.clientId) rides the silent provider too, so its
   // stored tokens refresh with the configured credentials.
-  const silent = hasConfiguredAuth ? undefined : new FileOAuthProvider(name, () => {}, config.oauth)
+  const silent = hasConfiguredAuth ? undefined : new FileOAuthProvider(name, () => {}, config.oauth, config.url)
   try {
     const client = newClient()
     await connectWithTimeout(client, makeTransport(silent?.hasTokens() ? silent : undefined), label)

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -26,7 +26,7 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
 import { claudeConfigDir } from './internal/config-dir.js'
 import { readManagedSettings } from './internal/managed-settings.js'
-import { installedPlugins } from './internal/plugins.js'
+import { installedPlugins, pluginComponentPath } from './internal/plugins.js'
 import { isProjectApproved } from './internal/project-approval.js'
 import { ancestorDirs, findNearestDir, findNearestFile } from './internal/project-root.js'
 import { claudeSettingsChain } from './internal/settings-chain.js'
@@ -118,7 +118,7 @@ export function pluginStyleDirs(home: string): string[] {
   return installedPlugins(home).flatMap((plugin) => {
     const declared = plugin.manifest.outputStyles
     const dirs = Array.isArray(declared) ? declared : [typeof declared === 'string' ? declared : 'output-styles']
-    return dirs.map((dir) => path.resolve(plugin.root, String(dir)))
+    return dirs.map((dir) => pluginComponentPath(plugin, String(dir))).filter((dir): dir is string => dir !== undefined)
   })
 }
 

--- a/extensions/skills.ts
+++ b/extensions/skills.ts
@@ -29,7 +29,7 @@ import { runAgent } from './internal/agent-run.js'
 import { parseCommandFile } from './internal/command-file.js'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { managedSettingsFile } from './internal/managed-settings.js'
-import { installedPlugins } from './internal/plugins.js'
+import { installedPlugins, pluginComponentPath } from './internal/plugins.js'
 import { isProjectApprovedSilently } from './internal/project-approval.js'
 import { ancestorDirs } from './internal/project-root.js'
 import { claudeSettingsChain } from './internal/settings-chain.js'
@@ -58,7 +58,7 @@ export function skillDirs(cwd: string, home: string, trusted: boolean): string[]
   for (const plugin of installedPlugins(home)) {
     const declared = plugin.manifest.skills
     const dirs = Array.isArray(declared) ? declared : [typeof declared === 'string' ? declared : 'skills']
-    candidates.push(...dirs.map((dir) => path.resolve(plugin.root, String(dir))))
+    candidates.push(...dirs.map((dir) => pluginComponentPath(plugin, String(dir))).filter((dir): dir is string => dir !== undefined))
   }
   // Claude loads skills from every .claude/skills between cwd and the repository
   // root; the list goes nearest-first so findClaudeSkill's first match is the

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -12,7 +12,7 @@ import { getAgentDir, parseFrontmatter, stripFrontmatter } from '@earendil-works
 // is not merely ignored, it narrows the child's registry.
 import { parseToolGrants } from '../internal/command-file.js'
 import { claudeConfigDir } from '../internal/config-dir.js'
-import { installedPlugins } from '../internal/plugins.js'
+import { installedPlugins, pluginComponentPath } from '../internal/plugins.js'
 import { ancestorDirs, findNearestDir } from '../internal/project-root.js'
 
 /**
@@ -353,7 +353,10 @@ function pluginAgentDirs(home: string): Array<{ dir: string; pluginName: string 
   return installedPlugins(home).flatMap((plugin) => {
     const declared = plugin.manifest.agents
     const dirs = Array.isArray(declared) ? declared : [typeof declared === 'string' ? declared : 'agents']
-    return dirs.map((dir) => ({ dir: path.resolve(plugin.root, String(dir)), pluginName: plugin.name }))
+    return dirs
+      .map((dir) => pluginComponentPath(plugin, String(dir)))
+      .filter((dir): dir is string => dir !== undefined)
+      .map((dir) => ({ dir, pluginName: plugin.name }))
   })
 }
 

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -1465,6 +1465,10 @@ export default function subagentExtension(pi: ExtensionAPI) {
   // available model list are captured per session so a hook run lands in the right repo.
   let hookCwd = process.cwd()
   let hookModels: ReadonlyArray<{ id: string }> = []
+  // Captured per session like cwd: a named agent resolved for a fork skill or an agent
+  // hook must respect project trust the way the tool path does, or an unapproved repo's
+  // .claude/agents entry (which wins a name clash) would run on its own say-so.
+  let hookAgentScope: AgentScope = 'user'
 
   // Discovery walks the plugin cache, the builtin dir, and every agent dir, parsing
   // each file: dozens of fs ops per call. The roster injection below runs every turn
@@ -1476,6 +1480,7 @@ export default function subagentExtension(pi: ExtensionAPI) {
   pi.on('session_start', async (_event, ctx) => {
     rosterCache = null
     hookCwd = ctx.cwd
+    hookAgentScope = isProjectApprovedSilently(ctx) ? 'both' : 'user'
     try {
       hookModels = ctx.modelRegistry?.getAvailable?.() ?? []
     } catch {
@@ -1487,7 +1492,7 @@ export default function subagentExtension(pi: ExtensionAPI) {
       if (process.env.PI_CODE_SUBAGENT) throw new Error('agent hooks do not run inside a subagent')
       // A context: fork skill names its agent, or runs with the full toolset;
       // agent hooks keep the read-only hook shape.
-      const named = request.agent ? discoverAgents(hookCwd, 'both').agents.find((a) => a.name === request.agent) : undefined
+      const named = request.agent ? discoverAgents(hookCwd, hookAgentScope).agents.find((a) => a.name === request.agent) : undefined
       const agent = named ?? (request.fullTools ? forkAgent(request) : buildHookAgent(request))
       const result = await runSingleAgent({
         defaultCwd: hookCwd,

--- a/tests/bash-rules.test.ts
+++ b/tests/bash-rules.test.ts
@@ -9,12 +9,45 @@ describe('matchesBashRules', () => {
     expect(matchesBashRules('npm run build --watch', ['npm run build'])).toBe(false)
   })
 
-  it('treats a :* suffix as a string prefix, as Claude documents', () => {
-    expect(matchesBashRules('git add -A', ['git add:*'])).toBe(true)
-    expect(matchesBashRules('git add', ['git add:*'])).toBe(true)
-    // A string prefix, not a word boundary: npm run test:* covers npm run test:unit.
-    expect(matchesBashRules('npm run test:unit', ['npm run test:*'])).toBe(true)
-    expect(matchesBashRules('git commit -m x', ['git add:*'])).toBe(false)
+  // Oracle: the wildcard table and the three rules stated beneath it in Claude's
+  // permissions reference, plus its ":*" equivalence sentence.
+  it.each([
+    ['npm run build', 'npm run build', true],
+    ['npm run build', 'npm run build --watch', false],
+    ['npm run *', 'npm run build', true],
+    ['npm run *', 'npm run test --watch', true],
+    ['npm run *', 'npm run', true],
+    ['npm run *', 'npm install', false],
+    ['git log * main', 'git log --oneline main', true],
+    ['git log * main', 'git log -5 main', true],
+    ['git log * main', 'git log main', false],
+    ['git log * main', 'git push origin main', false],
+    ['git * main', 'git merge main', true],
+    ['git * main', 'git push origin main', true],
+    ['git * main', 'git log', false],
+    ['* --version', 'node --version', true],
+    ['* --version', 'node -v', false],
+    ['ls *', 'ls -la', true],
+    ['ls *', 'ls', true],
+    ['ls *', 'lsof', false],
+    ['ls*', 'ls -la', true],
+    ['ls*', 'lsof', true],
+    ['* --help *', 'npm --help x', true],
+    ['* --help *', 'npm --help', false],
+  ])('rule %s against %s', (rule, command, expected) => {
+    expect(matchesBashRules(command, [rule])).toBe(expected)
+  })
+
+  it('reads a trailing :* as the equivalent trailing wildcard, not a string prefix', () => {
+    // Claude: "The :* suffix is an equivalent way to write a trailing wildcard, so
+    // Bash(ls:*) matches the same commands as Bash(ls *)", and the space in that form is
+    // part of the rule.
+    expect(matchesBashRules('ls -la', ['ls:*'])).toBe(true)
+    expect(matchesBashRules('ls', ['ls:*'])).toBe(true)
+    expect(matchesBashRules('lsof', ['ls:*'])).toBe(false)
+    expect(matchesBashRules('git addx -A', ['git add:*'])).toBe(false)
+    // Recognized only at the end: elsewhere the colon is a literal character.
+    expect(matchesBashRules('git push', ['git:* push'])).toBe(false)
   })
 
   it('treats * elsewhere as a wildcard', () => {

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -1185,6 +1185,31 @@ describe('hooks extension notify-style events', () => {
     expect(commandsRun()).toEqual([`${root}/scripts/format.sh`])
   })
 
+  it('refuses a shell-form plugin hook that references user config, keeping its siblings', async () => {
+    // Claude: "Fields that run in a shell reject ${user_config.*}: substituting a
+    // configured value into a shell command would let the shell run whatever that value
+    // contains, so the component fails with an error instead." The documented alternatives
+    // are exec form or reading CLAUDE_PLUGIN_OPTION_<KEY> from the environment.
+    const root = join(hoisted.home, '.claude', 'plugins', 'cache', 'market', 'deployer', '1.0.0')
+    mkdirSync(join(root, 'hooks'), { recursive: true })
+    writeFileSync(
+      join(root, 'hooks', 'hooks.json'),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [{ matcher: 'Write', hooks: [{ command: 'deploy --token ${user_config.api_key}' }, { command: 'plain-audit' }] }],
+        },
+      }),
+    )
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { deployer: true }, pluginConfigs: { deployer: { options: { api_key: 'sk-live; rm -rf /' } } } }))
+
+    const ext = setupExtension()
+    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+    await ext.toolResult('write', { input: { path: 'a.ts' } })
+
+    expect(commandsRun()).toEqual(['plain-audit'])
+  })
+
   it('bridges Notification hooks for idle_prompt on agent end, matcher-filtered', async () => {
     // Claude: idle_prompt fires when "Claude finished responding about 60 seconds
     // ago and you haven't typed since". Observational only, like Claude documents.

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -352,6 +352,13 @@ const defaultControl = (): typeof hoisted.control => ({
 })
 
 const savedEnv: Record<string, string | undefined> = {}
+/** Record the project-trust decision a previous session's approval dialog would have stored,
+ * so a test can describe an already-trusted project. */
+const rememberApproved = async (cwd: string): Promise<void> => {
+  const { ProjectTrustStore, getAgentDir } = await import('@earendil-works/pi-coding-agent')
+  new ProjectTrustStore(getAgentDir()).set(cwd, true)
+}
+
 const setEnv = (key: string, value: string): void => {
   savedEnv[key] = process.env[key]
   process.env[key] = value
@@ -2330,6 +2337,8 @@ describe('mcp headersHelper environment', () => {
     const harness = await setup({ project: { proj: { type: 'http', url: 'https://api.example/mcp', headersHelper: helper } } })
     mkdirSync(join(harness.home, '.claude'), { recursive: true })
     writeFileSync(join(harness.home, '.claude', 'settings.json'), JSON.stringify({ enabledMcpjsonServers: ['proj'] }))
+    // A repository helper only runs once the project is trusted.
+    await rememberApproved(harness.cwd)
     await harness.sessionStart(true)
 
     const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
@@ -2347,10 +2356,27 @@ describe('mcp headersHelper environment', () => {
     const harness = await setup({ project: { proj: { type: 'http', url: 'https://api.example/mcp', headersHelper: helper } } })
     mkdirSync(join(harness.home, '.claude'), { recursive: true })
     writeFileSync(join(harness.home, '.claude', 'settings.json'), JSON.stringify({ enabledMcpjsonServers: ['proj'] }))
+    // A repository helper only runs once the project is trusted.
+    await rememberApproved(harness.cwd)
     await harness.sessionStart(true)
 
     const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
     expect(headers['X-T']).toBe('')
+  })
+
+  it('does not run a project helper until the project is trusted, connecting with static headers alone', async () => {
+    // A repository's helper is a command the user has not reviewed. Consent to the server
+    // (enabledMcpjsonServers) is not consent to run its command in an untrusted folder.
+    withTools([{ name: 'go' }])
+    const helper = 'printf \'{"X-Helper":"ran"}\''
+    const harness = await setup({ project: { proj: { type: 'http', url: 'https://api.example/mcp', headers: { 'X-Static': 'kept' }, headersHelper: helper } } })
+    mkdirSync(join(harness.home, '.claude'), { recursive: true })
+    writeFileSync(join(harness.home, '.claude', 'settings.json'), JSON.stringify({ enabledMcpjsonServers: ['proj'] }))
+    await harness.sessionStart(false)
+
+    const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
+    expect(headers['X-Static']).toBe('kept')
+    expect(headers['X-Helper']).toBeUndefined()
   })
 
   it('keeps credential variables for a user-scope helper, which the user wrote', async () => {

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2336,6 +2336,23 @@ describe('mcp headersHelper environment', () => {
     expect(headers['X-T']).toBe('absent')
   })
 
+  it('leaves ${VAR} in a project helper for the stripped shell, not the parent environment', async () => {
+    // The stripping only works if the expansion happens inside the helper's own shell:
+    // interpolating the command text first reads the parent environment, which is exactly
+    // the set the helper must not see. Claude expands ${VAR} in command, args, env, url
+    // and headers, not in the helper command.
+    setEnv('PROBE_HELPER_TOKEN', 'leaked-secret')
+    withTools([{ name: 'go' }])
+    const helper = 'printf \'{"X-T":"%s"}\' "${PROBE_HELPER_TOKEN}"'
+    const harness = await setup({ project: { proj: { type: 'http', url: 'https://api.example/mcp', headersHelper: helper } } })
+    mkdirSync(join(harness.home, '.claude'), { recursive: true })
+    writeFileSync(join(harness.home, '.claude', 'settings.json'), JSON.stringify({ enabledMcpjsonServers: ['proj'] }))
+    await harness.sessionStart(true)
+
+    const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
+    expect(headers['X-T']).toBe('')
+  })
+
   it('keeps credential variables for a user-scope helper, which the user wrote', async () => {
     setEnv('MY_USER_TOKEN', 'mine')
     withTools([{ name: 'go' }])

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -83,6 +83,18 @@ describe('FileOAuthProvider', () => {
     expect(new FileOAuthProvider('github', () => {}).hasTokens()).toBe(true)
   })
 
+  it('keeps tokens for one endpoint out of a same-named server at another endpoint', async () => {
+    // A sign-in belongs to the endpoint it was granted for. Two repositories can each
+    // define a server called "notion"; the second must not inherit the first one's bearer
+    // token just by reusing the name.
+    const real = new FileOAuthProvider('notion', () => {}, undefined, 'https://mcp.notion.com/mcp')
+    await real.saveTokens({ access_token: 'at-real', token_type: 'bearer' })
+
+    expect(new FileOAuthProvider('notion', () => {}, undefined, 'https://evil.example/mcp').hasTokens()).toBe(false)
+    // Same endpoint, a later session: the sign-in is still there (no forced re-login).
+    expect(new FileOAuthProvider('notion', () => {}, undefined, 'https://mcp.notion.com/other').tokens()).toEqual({ access_token: 'at-real', token_type: 'bearer' })
+  })
+
   it('generates a distinct, stable CSRF state per login attempt', () => {
     const a = new FileOAuthProvider('srv-a', () => {})
     const b = new FileOAuthProvider('srv-b', () => {})

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -16,7 +16,7 @@ vi.mock('node:fs', async (importOriginal) => {
   return { ...actual, readFileSync }
 })
 
-import { installedPlugins, resetInstalledPluginsCache, substitutePluginVars } from '../extensions/internal/plugins.ts'
+import { installedPlugins, pluginComponentPath, resetInstalledPluginsCache, substitutePluginVars } from '../extensions/internal/plugins.ts'
 
 describe('substitutePluginVars user_config', () => {
   const plugin = { name: 'p', root: '/r', dataDir: '/d', manifest: {}, userConfig: { token: 'secret-x', region: 'eu' } }
@@ -44,6 +44,25 @@ const enable = (root: string, entries: Record<string, boolean>): void => {
   mkdirSync(join(root, '.claude'), { recursive: true })
   writeFileSync(join(root, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: entries }))
 }
+
+describe('pluginComponentPath', () => {
+  // Claude: a plugin's component path "rejects a component path that resolves outside the
+  // plugin root, such as ../shared-utils".
+  const root = join(tmpdir(), 'plugins', 'p')
+  const plugin = { name: 'p', root, dataDir: join(tmpdir(), 'd'), manifest: {} }
+
+  it('resolves a declared path inside the plugin root', () => {
+    expect(pluginComponentPath(plugin, 'skills')).toBe(join(root, 'skills'))
+    expect(pluginComponentPath(plugin, 'nested/dir')).toBe(join(root, 'nested', 'dir'))
+    expect(pluginComponentPath(plugin, './commands')).toBe(join(root, 'commands'))
+  })
+
+  it('rejects a declared path that escapes the plugin root', () => {
+    expect(pluginComponentPath(plugin, '../shared-utils')).toBeUndefined()
+    expect(pluginComponentPath(plugin, 'skills/../../elsewhere')).toBeUndefined()
+    expect(pluginComponentPath(plugin, join(tmpdir(), 'elsewhere'))).toBeUndefined()
+  })
+})
 
 describe('installedPlugins', () => {
   it('loads an enabled cached plugin with its root and data dir', () => {

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -66,6 +66,23 @@ describe('skillDirs', () => {
     writeFileSync(join(home, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { kit: true } }))
 
     expect(skillDirs(cwd, home, false)).toEqual([join(root, 'skills')])
+  })
+
+  it('skips a plugin skills directory declared outside the plugin root', () => {
+    const cwd = tempDir('cs-proj-')
+    const home = tempDir('cs-home-')
+    const root = join(home, '.claude', 'plugins', 'cache', 'market', 'kit', '1.0.0')
+    mkdirSync(join(root, 'skills'), { recursive: true })
+    mkdirSync(join(root, '.claude-plugin'), { recursive: true })
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    // A real directory outside the plugin: without the guard it would be scanned, since
+    // the only other thing standing between a declared path and the loader is existence.
+    const outside = join(home, 'outside-skills')
+    mkdirSync(outside, { recursive: true })
+    writeFileSync(join(root, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'kit', skills: relative(root, outside) }))
+    writeFileSync(join(home, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { kit: true } }))
+
+    expect(skillDirs(cwd, home, false)).toEqual([])
   })
 
   it('finds project skills at the repository root from a subdirectory session', () => {

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -282,6 +282,29 @@ describe('agent hook runner', () => {
     expect(spawnCalls[0].promptFile?.content).toContain('permissionDecision')
   })
 
+  it('resolves a named agent within user scope until the project is approved', async () => {
+    // The tool path narrows to 'user' on an unapproved project (agentScope, below); a
+    // context: fork skill naming an agent must not become the way a repo-controlled agent
+    // definition runs anyway, since project agents win a name clash.
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ name: 'reviewer' })], projectAgentsDir: null })
+    await eventHandlers.get('session_start')?.({}, { cwd: '/repo', isProjectTrusted: () => false, modelRegistry: { getAvailable: () => [] } })
+    script('look', { stdout: [say('done')], exitCode: 0 })
+
+    await runAgent({ prompt: 'look', agent: 'reviewer' })
+
+    expect(discoverAgentsMock).toHaveBeenCalledWith('/repo', 'user')
+  })
+
+  it('resolves a named agent across both scopes once the project is approved', async () => {
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({ name: 'reviewer' })], projectAgentsDir: null })
+    await eventHandlers.get('session_start')?.({}, { cwd: '/repo', isProjectTrusted: () => true, modelRegistry: { getAvailable: () => [] } })
+    script('look', { stdout: [say('done')], exitCode: 0 })
+
+    await runAgent({ prompt: 'look', agent: 'reviewer' })
+
+    expect(discoverAgentsMock).toHaveBeenCalledWith('/repo', 'both')
+  })
+
   it('refuses to run inside a subagent session', async () => {
     await eventHandlers.get('session_start')?.({}, { cwd: '/repo', modelRegistry: { getAvailable: () => [] } })
     const saved = process.env.PI_CODE_SUBAGENT


### PR DESCRIPTION
Each fix has a test that fails without it, and each guard is checked in both directions (it rejects what it must, and still admits ordinary use).

- **Fork-runner trust gate.** A `context: fork` skill or agent hook naming an agent resolved it across user and project scope unconditionally, while the subagent tool narrows to user scope until the project is approved. Project agents win a name clash, so an unapproved repository's `.claude/agents` entry ran on its own say-so. The scope is captured at session start from the same approval check.
- **MCP sign-ins keyed by endpoint.** The token store was digested from the server name alone, so a second project reusing a name the user had signed into elsewhere received the real bearer token, sent to whatever URL that config names. Existing stores stop matching and prompt one re-login per server.
- **Headers-helper credential leak.** The helper command was interpolated against the full parent environment before running in the environment the stripping had cleaned, so `${SOME_TOKEN}` handed over exactly what the stripping withholds. The command now reaches the shell verbatim; plugin path variables are still substituted in the config layer.
- **Helper before trust.** A consented project server connected at session start with no approval check, and connecting runs the repository's command. Until the project is approved the helper is dropped and named once, and the server connects with its static headers alone, as Claude documents.
- **Plugin user config in shell commands.** Option values were substituted into shell-form hook commands, where the value becomes shell code. Claude rejects the reference in any field that reaches a shell; such a hook is now dropped with a message naming the two documented alternatives, and its siblings are unaffected.
- **Plugin component paths.** Six readers resolved manifest-declared directories against the plugin root without checking where they landed, so `../shared-utils` or an absolute path was scanned wherever it pointed. One shared helper now confines all six.
- **Bash permission wildcards.** `Bash(ls:*)` allowed `lsof` and `Bash(git add:*)` allowed `git addx`, wider than the documented equivalence to `Bash(ls *)`; a trailing ` *` did not match the bare command; and `:*` was honored anywhere rather than only at the end. The matcher now follows the documented table, spelled out row by row in the tests. One consequence: `npm run test:*` no longer covers `npm run test:unit`.

Two existing tests changed premise rather than expectation. The two MCP helper-environment tests now record the approval a prior session would have stored, since their subject is what a trusted project's helper receives. The `:*` test asserted string-prefix semantics that the current permissions reference contradicts.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change
