### PR TITLE
Fix eleven product defects from the round 4 scan

### DIFF
--- a/extensions/claude-rules.ts
+++ b/extensions/claude-rules.ts
@@ -39,12 +39,47 @@ function unquote(value: string): string {
   return value.replace(/^["']|["']$/g, '')
 }
 
+/** Split a YAML flow sequence on its top-level commas. A comma inside a brace group
+ * (`*.{ts,tsx}`, which Claude expands) or inside quotes belongs to its entry, so
+ * splitting on every comma produced patterns that match nothing. */
 function splitInline(value: string): string[] {
-  return value
-    .replace(/^\[|\]$/g, '')
-    .split(',')
-    .map((entry) => unquote(entry.trim()))
-    .filter(Boolean)
+  const entries: string[] = []
+  let current = ''
+  let depth = 0
+  let quote: string | undefined
+  for (const char of value.replace(/^\[/, '').replace(/\]$/, '')) {
+    if (quote !== undefined) {
+      if (char === quote) quote = undefined
+      current += char
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      current += char
+      continue
+    }
+    if (char === '{') depth++
+    else if (char === '}') depth = Math.max(0, depth - 1)
+    else if (char === ',' && depth === 0) {
+      entries.push(current)
+      current = ''
+      continue
+    }
+    current += char
+  }
+  entries.push(current)
+  return entries.map((entry) => unquote(entry.trim())).filter(Boolean)
+}
+
+/** A flow sequence that opens on the `paths:` line and closes on a later one, joined
+ * back into a single value. An unterminated list runs to the end of the frontmatter. */
+function joinFlowSequence(lines: string[], index: number, opening: string): string {
+  let joined = opening
+  for (let i = index + 1; i < lines.length; i++) {
+    joined += ` ${lines[i].trim()}`
+    if (lines[i].includes(']')) break
+  }
+  return joined
 }
 
 function parsePaths(frontmatter: string): string[] {
@@ -52,7 +87,7 @@ function parsePaths(frontmatter: string): string[] {
   const index = lines.findIndex((line) => /^\s*paths\s*:/.test(line))
   if (index === -1) return []
   const inline = lines[index].replace(/^\s*paths\s*:/, '').trim()
-  if (inline) return splitInline(inline)
+  if (inline) return splitInline(inline.startsWith('[') && !inline.includes(']') ? joinFlowSequence(lines, index, inline) : inline)
   const items: string[] = []
   // Matched with string ops rather than a regex: the equivalent pattern needs two
   // adjacent whitespace quantifiers, which backtracks super-linearly on long lines.

--- a/extensions/env-settings.ts
+++ b/extensions/env-settings.ts
@@ -40,7 +40,7 @@ import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-a
 import { claudeConfigDir } from './internal/config-dir.js'
 import { readManagedSettings } from './internal/managed-settings.js'
 import { isProjectApprovedSilently } from './internal/project-approval.js'
-import { findNearestFile } from './internal/project-root.js'
+import { claudeSettingsChain } from './internal/settings-chain.js'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -137,12 +137,14 @@ export function sanitizeProjectEnv(env: Record<string, string>, warn: (key: stri
   return kept
 }
 
-/** The project scope's env: .claude/settings.json with settings.local.json overlaid,
- * each the nearest of its name at or above cwd (matching the hooks settings chain). */
-function projectEnv(cwd: string): Record<string, string> {
-  const base = envFromSettings(readSettingsFile(findNearestFile(cwd, path.join('.claude', 'settings.json')) ?? path.join(cwd, '.claude', 'settings.json')))
-  const local = envFromSettings(readSettingsFile(findNearestFile(cwd, path.join('.claude', 'settings.local.json')) ?? path.join(cwd, '.claude', 'settings.local.json')))
-  return sanitizeProjectEnv({ ...base, ...local })
+/** The project scope's env, resolved through the shared settings chain so placement
+ * matches every other consumer: the shared settings.json comes from the session's own
+ * directory and never an ancestor, settings.local.json from the repository root. Later
+ * files win. */
+function projectEnv(cwd: string, home: string): Record<string, string> {
+  const merged: Record<string, string> = {}
+  for (const file of claudeSettingsChain(cwd, home, true).slice(1)) Object.assign(merged, envFromSettings(readSettingsFile(file)))
+  return sanitizeProjectEnv(merged)
 }
 
 export default function envSettingsExtension(pi: ExtensionAPI) {
@@ -157,6 +159,6 @@ export default function envSettingsExtension(pi: ExtensionAPI) {
   apply(os.homedir(), {})
 
   pi.on('session_start', async (_event, ctx: ExtensionContext) => {
-    apply(os.homedir(), isProjectApprovedSilently(ctx) ? projectEnv(ctx.cwd) : {})
+    apply(os.homedir(), isProjectApprovedSilently(ctx) ? projectEnv(ctx.cwd, os.homedir()) : {})
   })
 }

--- a/extensions/hooks/decisions.ts
+++ b/extensions/hooks/decisions.ts
@@ -147,7 +147,19 @@ function surfaceHookFailures(commands: HookCommand[], results: HookRunResult[], 
     // Claude shows a `<hook> hook error` notice when {..}-shaped stdout cannot be
     // read as JSON output (exit 2 still blocks and reads its own channels).
     const jsonError = result.code === 2 ? undefined : hookJsonError(result.stdout)
-    if (jsonError !== undefined) notify(`${commands[i].command} hook error: ${jsonError}`)
+    if (jsonError !== undefined) {
+      notify(`${commands[i].command} hook error: ${jsonError}`)
+      continue
+    }
+    // A non-zero exit that is neither a block (2) nor a timeout, with nothing parseable
+    // on stdout, is Claude's non-blocking error: the action proceeds and the notice
+    // carries the first line of stderr. Without it a mistyped path in settings.json
+    // leaves a policy hook silently disabled, since the shell exits 127 and says so only
+    // on stderr. A spawn failure is reported above and skipped here.
+    if (!result.spawnFailed && !result.timedOut && result.code !== 0 && result.code !== 2) {
+      const firstLine = result.stderr.trim().split('\n')[0]
+      notify(`${commands[i].command} hook error: Failed with non-blocking status code: ${firstLine || result.code}`)
+    }
   }
 }
 

--- a/extensions/internal/atomic-write.ts
+++ b/extensions/internal/atomic-write.ts
@@ -1,0 +1,14 @@
+/**
+ * Replace a file through a temp file and a rename, so a crash mid-write cannot leave the
+ * target truncated. Used wherever pi-code rewrites a file the user owns and would have to
+ * repair by hand: settings and the memory index.
+ */
+
+import * as fs from 'node:fs'
+
+/** The tmp name carries the pid so concurrent processes do not collide. */
+export function atomicWriteFile(filePath: string, content: string): void {
+  const tmp = `${filePath}.${process.pid}.tmp`
+  fs.writeFileSync(tmp, content)
+  fs.renameSync(tmp, filePath)
+}

--- a/extensions/internal/mcp-oauth.ts
+++ b/extensions/internal/mcp-oauth.ts
@@ -244,7 +244,12 @@ export function openBrowser(url: string): void {
   else if (process.platform === 'win32') command = 'cmd'
   const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url]
   try {
-    spawn(command, args, { stdio: 'ignore', detached: true }).unref()
+    const child = spawn(command, args, { stdio: 'ignore', detached: true })
+    // A missing launcher (a container or an SSH session with no xdg-open) reports itself
+    // asynchronously through 'error'; with no listener node raises it as an
+    // uncaughtException and pi exits. The caller has already shown the URL to open by hand.
+    child.on('error', () => {})
+    child.unref()
   } catch {
     // the notified URL is the fallback
   }

--- a/extensions/mcp/index.ts
+++ b/extensions/mcp/index.ts
@@ -563,8 +563,12 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // is why serverToolCount reads from `registered` to recover the true count here.
     status.clear()
     // A same-process session switch (/new, /resume) shut the last session down;
-    // this one may reconnect again.
+    // this one may reconnect again. projectConnected guards against connecting the project
+    // scope twice within one session, so it belongs to the session that set it: leaving it
+    // set here left every project server disconnected for the rest of the process, since
+    // the shutdown had already dropped their clients.
     shuttingDown = false
+    projectConnected = false
     // Claude answers roots/list with the session's launch directory and exports the
     // project root as CLAUDE_PROJECT_DIR to stdio servers; both derive from ctx.cwd.
     sessionDirs = { projectDir: repoRoot(ctx.cwd) ?? ctx.cwd, launchDir: ctx.cwd }

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -14,6 +14,7 @@ import * as path from 'node:path'
 import { StringEnum } from '@earendil-works/pi-ai'
 import { type ExtensionAPI, withFileMutationQueue } from '@earendil-works/pi-coding-agent'
 import { Type } from 'typebox'
+import { atomicWriteFile } from './internal/atomic-write.js'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { readManagedSettings } from './internal/managed-settings.js'
 import { capForContext } from './internal/output-guard.js'
@@ -320,14 +321,6 @@ function readIndexQuietly(dir: string): string {
   } catch {
     return ''
   }
-}
-
-/** Write through a temp file and rename onto the target, so a crash mid-write cannot
- * truncate it. The tmp name carries the pid so concurrent processes do not collide. */
-function atomicWriteFile(filePath: string, content: string): void {
-  const tmp = `${filePath}.${process.pid}.tmp`
-  fs.writeFileSync(tmp, content)
-  fs.renameSync(tmp, filePath)
 }
 
 /** Replace the index through a rename so a crash mid-write cannot truncate it. */

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -23,6 +23,7 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import { atomicWriteFile } from './internal/atomic-write.js'
 
 import { claudeConfigDir } from './internal/config-dir.js'
 import { readManagedSettings } from './internal/managed-settings.js'
@@ -173,16 +174,31 @@ export function styleForName(styles: OutputStyle[], name: string | undefined): O
   return name ? styles.find((style) => style.name === name) : undefined
 }
 
-function persistActiveStyle(file: string, name: string): void {
-  let config: Record<string, unknown> = {}
+/** Record the choice in the local settings file, returning a message to show when it
+ * cannot be recorded. The file also carries permissions, hooks and env, so a present but
+ * unparseable one is left alone rather than replaced by the style choice alone. */
+function persistActiveStyle(file: string, name: string): string | undefined {
+  const label = path.basename(file)
+  let raw: string | undefined
   try {
-    config = JSON.parse(fs.readFileSync(file, 'utf-8'))
-  } catch {
-    // start from an empty config when the file is missing or invalid
+    raw = fs.readFileSync(file, 'utf-8')
+  } catch (error) {
+    // Only a missing file means start fresh; anything else is the user's file to keep.
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return `${label} could not be read; the style applies to this session only`
+  }
+  let config: Record<string, unknown> = {}
+  if (raw !== undefined) {
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      if (parsed !== null && typeof parsed === 'object') config = parsed as Record<string, unknown>
+    } catch {
+      return `${label} is not valid JSON; the style applies to this session only`
+    }
   }
   config.outputStyle = name
   fs.mkdirSync(path.dirname(file), { recursive: true })
-  fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`)
+  atomicWriteFile(file, `${JSON.stringify(config, null, 2)}\n`)
+  return undefined
 }
 
 export default function outputStylesExtension(pi: ExtensionAPI) {
@@ -236,8 +252,8 @@ export default function outputStylesExtension(pi: ExtensionAPI) {
           return
         }
         activeName = picked.name
-        persistActiveStyle(localSettingsPath, picked.name)
-        ctx.ui.notify(`Output style set to ${picked.name} (applies next turn)`, 'info')
+        const failure = persistActiveStyle(localSettingsPath, picked.name)
+        ctx.ui.notify(failure ?? `Output style set to ${picked.name} (applies next turn)`, failure ? 'error' : 'info')
         return
       }
       if (!ctx.hasUI) {
@@ -253,8 +269,8 @@ export default function outputStylesExtension(pi: ExtensionAPI) {
       if (!choice) return
       const picked = styles[labels.indexOf(choice)]
       activeName = picked.name
-      persistActiveStyle(localSettingsPath, picked.name)
-      ctx.ui.notify(`Output style set to ${picked.name} (applies next turn)`, 'info')
+      const failure = persistActiveStyle(localSettingsPath, picked.name)
+      ctx.ui.notify(failure ?? `Output style set to ${picked.name} (applies next turn)`, failure ? 'error' : 'info')
     },
   })
 }

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -102,10 +102,10 @@ function isDirectory(target: string): boolean {
  */
 export function styleDirs(cwd: string, home: string, trusted: boolean): string[] {
   const dirs = [path.join(claudeConfigDir(home), 'output-styles')]
-  // Claude loads every .claude/output-styles between cwd and the repository root,
-  // using the one closest to cwd for a name clash: styleForName is first-match,
-  // so the nearest directory goes first.
-  if (trusted) dirs.push(...ancestorDirs(cwd, path.join('.claude', 'output-styles')))
+  // Claude loads every .claude/output-styles between cwd and the repository root, using
+  // the one closest to cwd for a name clash. loadStyles keys by name and later dirs win,
+  // so the ancestors go farthest first and the nearest lands last.
+  if (trusted) dirs.push(...ancestorDirs(cwd, path.join('.claude', 'output-styles')).reverse())
   return dirs.filter((dir) => isDirectory(dir))
 }
 

--- a/extensions/status-line.ts
+++ b/extensions/status-line.ts
@@ -457,14 +457,20 @@ export default function statusLine(pi: ExtensionAPI) {
     // Claude's disableAllHooks also turns off the custom statusLine command; the
     // built-in segment still renders as the fallback.
     config = readDisableAllHooks(files) ? undefined : readStatusLineConfig(files)
-    if (config?.refreshInterval) {
-      refreshTimer = setInterval(() => scheduleRefresh(), config.refreshInterval * 1000)
+    // Re-armed rather than armed once: a refreshInterval added or changed mid-session
+    // had no effect until the next session, though Claude applies a settings change as
+    // soon as the file is saved.
+    const armRefresh = (): void => {
+      clearInterval(refreshTimer)
+      refreshTimer = config?.refreshInterval ? setInterval(() => scheduleRefresh(), config.refreshInterval * 1000) : undefined
     }
+    armRefresh()
     // Claude re-runs the script when the statusLine settings change mid-session; a
     // command change re-resolves and re-runs.
     disposeSettingsWatch()
     disposeSettingsWatch = watchSettingsFiles(files, () => {
       config = readDisableAllHooks(files) ? undefined : readStatusLineConfig(files)
+      armRefresh()
       scheduleRefresh()
     })
     show(ctx, segmentText(ctx, ctx.ui.theme.fg('dim', '○')))

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -177,6 +177,13 @@ export function backgroundStatusText(): string {
   return formatStatus(runs.values())
 }
 
+/** Every run this process knows about, live and finished. The registry is module state
+ * that outlives a session switch; a per-session list is not, because pi re-invokes each
+ * extension factory per session. */
+export function allBackgroundRuns(): BackgroundRun[] {
+  return [...runs.values()]
+}
+
 /** A finished run, so a caller can continue its session with a follow-up task. */
 export function backgroundRun(id: string): BackgroundRun | undefined {
   return runs.get(id)

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -200,7 +200,10 @@ export function resumeBackgroundRun(id: string, task: string, onComplete: (run: 
   const rebuilt = withRebuiltPrompt(run.spawn)
   run.spawn = { ...run.spawn, args: rebuilt.args }
   if (rebuilt.dir) run.rebuiltPromptDir = rebuilt.dir
-  const args = rebuilt.args.map((arg) => (arg.startsWith('Task: ') ? `Task: ${task}` : arg))
+  // The task prompt is always the final argument: both spawn paths push it last and the
+  // invocation helper only prepends. Matching a 'Task: ' prefix missed it whenever
+  // SubagentStart hooks placed their context ahead of it, so the resume re-ran the old task.
+  const args = rebuilt.args.map((arg, index) => (index === rebuilt.args.length - 1 ? `Task: ${task}` : arg))
   run.state = 'running'
   run.task = task
   run.output = undefined

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -388,8 +388,11 @@ async function runSingleAgentInner(options: RunAgentOptions): Promise<SingleResu
         resolve(code ?? 0)
       })
 
-      proc.on('error', () => {
+      proc.on('error', (error: Error) => {
         cleanup()
+        // A child that never started leaves no stdout and no stderr, so this message is the
+        // only diagnostic; without it the failure reads as "(no output)".
+        if (!currentResult.stderr) currentResult.stderr = error.message
         resolve(1)
       })
 

--- a/extensions/subagent/index.ts
+++ b/extensions/subagent/index.ts
@@ -34,7 +34,7 @@ import { runSubagentStartHooks } from '../internal/subagent-hooks.js'
 import { autoMemoryEnabled, capIndexForPrompt, INDEX_MAX_BYTES, INDEX_MAX_LINES, memorySettingsFiles, readMemorySettings } from '../memory.js'
 import { skillDirs } from '../skills.js'
 import { type AgentConfig, type AgentMemoryScope, type AgentScope, type AgentSource, discoverAgents, expandMcpToolPatterns, resolveModelAlias, withPreloadedSkills } from './agents.js'
-import { activeBackgroundRuns, type BackgroundRun, backgroundRun, backgroundStatusText, cancelAllBackgroundRuns, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
+import { activeBackgroundRuns, allBackgroundRuns, type BackgroundRun, backgroundRun, backgroundStatusText, cancelAllBackgroundRuns, cancelBackgroundRun, MAX_BACKGROUND_RUNS, resumeBackgroundRun, startBackgroundRun } from './background.js'
 import { type DisplayItem, formatToolCall, formatUsageStats, getDisplayItems, getFinalOutput } from './render.js'
 import { type AgentWorktree, cleanupAgentWorktree, createAgentWorktree } from './worktree.js'
 
@@ -569,7 +569,7 @@ function runOutputTail(run: BackgroundRunView): string | undefined {
 /** The /tasks listing: one line per background run, plus the short output tail the
  * registry's own status lines omit. A pure formatter so it tests against a plain list. */
 export function tasksStatusText(runs: ReadonlyArray<BackgroundRunView>): string {
-  if (runs.length === 0) return 'No background subagent runs in this session.'
+  if (runs.length === 0) return 'No background subagent runs.'
   return runs
     .map((run) => {
       const plural = run.turns === 1 ? '' : 's'
@@ -861,7 +861,7 @@ interface BackgroundContext {
   projectApproved: boolean
 }
 
-async function runBackgroundMode(params: SubagentParamsStatic, context: BackgroundContext, onStarted?: (id: string) => void): Promise<ToolResult> {
+async function runBackgroundMode(params: SubagentParamsStatic, context: BackgroundContext): Promise<ToolResult> {
   const { agents, defaultCwd, pi, makeDetails, skillRoots, availableModels, projectApproved } = context
   const task = params.task
   const agentName = params.agent
@@ -958,7 +958,6 @@ async function runBackgroundMode(params: SubagentParamsStatic, context: Backgrou
     removeTmpPrompt(tmpPrompt)
     return backgroundCapResult(makeDetails)
   }
-  onStarted?.(id)
   pi.events.emit(SUBAGENT_CHANNEL, { phase: 'start', agentType: agent.name, agentId: id })
   return {
     content: [{ type: 'text', text: `Started background run ${id} (${agent.name}). A notification will arrive on completion; check progress with {status: true}.` }],
@@ -1440,21 +1439,6 @@ export default function subagentExtension(pi: ExtensionAPI) {
     if (isMcpToolAliases(data)) setKnownMcpAliases(data)
   })
 
-  // /tasks resolves these against the registry at print time. background.ts owns the
-  // run records but does not enumerate them, so the ids started here are remembered;
-  // a run the registry has since evicted simply drops out of the listing.
-  const startedBackgroundRuns = new Set<string>()
-
-  // The registry self-caps and evicts old runs, so an id kept here after its record is
-  // gone is dead weight. Drop those on every add, bounding the set to the registry's
-  // live capacity rather than letting it grow for the whole session.
-  const rememberBackgroundRun = (id: string): void => {
-    for (const known of startedBackgroundRuns) {
-      if (!backgroundRun(known)) startedBackgroundRuns.delete(known)
-    }
-    startedBackgroundRuns.add(id)
-  }
-
   const notifyBackgroundCompletion = (run: { id: string; agent: string; state: string; turns: number; output?: string; stderr?: string }): void => {
     // Runs through driveRun's guard, same as the background-mode callback above.
     // The stop event fires here too, so SubagentStop hooks see resumed runs end.
@@ -1588,7 +1572,6 @@ export default function subagentExtension(pi: ExtensionAPI) {
 
       if (params.resume) {
         const onResumed = (run: { id: string; agent: string }): void => {
-          rememberBackgroundRun(run.id)
           pi.events.emit(SUBAGENT_CHANNEL, { phase: 'start', agentType: run.agent, agentId: run.id })
         }
         return { content: [{ type: 'text', text: resumeResultText(params.resume, params.task, notifyBackgroundCompletion, onResumed) }], details: makeDetails('single')([]) }
@@ -1632,7 +1615,7 @@ export default function subagentExtension(pi: ExtensionAPI) {
       // unavailable tier still falls back to the session model.
       const availableModels = ctx.modelRegistry?.getAvailable?.() ?? []
 
-      if (wantsBackground(params, agents)) return runBackgroundMode(params, { agents, defaultCwd: ctx.cwd, pi, makeDetails, skillRoots, availableModels, projectApproved }, (id) => rememberBackgroundRun(id))
+      if (wantsBackground(params, agents)) return runBackgroundMode(params, { agents, defaultCwd: ctx.cwd, pi, makeDetails, skillRoots, availableModels, projectApproved })
 
       const mode: ModeContext = {
         agents,
@@ -1689,8 +1672,7 @@ export default function subagentExtension(pi: ExtensionAPI) {
   pi.registerCommand('tasks', {
     description: 'Show background subagent runs',
     handler: async (_args, ctx) => {
-      const runs = [...startedBackgroundRuns].map((id) => backgroundRun(id)).filter((run): run is BackgroundRun => run !== undefined)
-      ctx.ui.notify(tasksStatusText(runs), 'info')
+      ctx.ui.notify(tasksStatusText(allBackgroundRuns()), 'info')
     },
   })
 

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -193,6 +193,19 @@ describe('background run lifecycle', () => {
     for (const child of live) child.emit('close', 0)
   })
 
+  it('replaces the task on a resume even when start-hook context precedes it', () => {
+    // SubagentStart hooks put their context ahead of the prompt, so the argument reads
+    // "<context>\n\nTask: <task>". Matching a "Task: " prefix missed that shape and the
+    // resumed child re-ran the original task while the notice claimed the new one.
+    const id = startBackgroundRun('scout', 'one', spec({ args: ['--mode', 'json', 'HOOK CONTEXT\n\nTask: one'] }), () => {})
+    children.at(-1)?.emit('close', 0)
+
+    expect(resumeBackgroundRun(id ?? '', 'two', () => {})).toBe('resumed')
+
+    const args = spawnMock.mock.calls.at(-1)?.[1] as string[]
+    expect(args.at(-1)).toBe('Task: two')
+  })
+
   it('reports zero turns when a resume fails to spawn', () => {
     const id = startBackgroundRun('scout', 'one', spec(), () => {})
     children.at(-1)!.stdout.emit('data', assistantTurn('turn one'))

--- a/tests/claude-rules.test.ts
+++ b/tests/claude-rules.test.ts
@@ -41,6 +41,22 @@ describe('parseFrontmatter', () => {
     expect(parseFrontmatter('---\npaths: ["a.ts", "b.ts"]\n---\nbody').paths).toEqual(['a.ts', 'b.ts'])
   })
 
+  it('keeps a brace group whole when splitting an inline list', () => {
+    // Claude's rules support brace expansion in paths, so the comma inside {ts,tsx} is
+    // part of one pattern. Splitting on it produced two patterns that match nothing and
+    // the rule silently stopped attaching to anything.
+    expect(parseFrontmatter('---\npaths: ["src/**/*.{ts,tsx}", "lib/**"]\n---\nbody').paths).toEqual(['src/**/*.{ts,tsx}', 'lib/**'])
+    // Unquoted too: YAML does not require quotes, and the braces are what delimits the group.
+    expect(parseFrontmatter('---\npaths: [src/**/*.{ts,tsx}, lib/**]\n---\nbody').paths).toEqual(['src/**/*.{ts,tsx}', 'lib/**'])
+  })
+
+  it('parses an inline list spread over several lines', () => {
+    // A list written across lines read as an empty paths value, which makes a scoped rule
+    // unscoped: it was injected into every session instead of the files it names.
+    const md = '---\npaths: [\n  "src/**",\n  "docs/**"\n]\n---\nbody'
+    expect(parseFrontmatter(md).paths).toEqual(['src/**', 'docs/**'])
+  })
+
   it('parses a comma-separated inline paths value', () => {
     expect(parseFrontmatter('---\npaths: a.ts, b.ts\n---\nbody').paths).toEqual(['a.ts', 'b.ts'])
   })

--- a/tests/env-settings.test.ts
+++ b/tests/env-settings.test.ts
@@ -152,6 +152,24 @@ describe('env-settings extension', () => {
     expect(process.env.ENVTEST_PROJECT).toBeUndefined()
   })
 
+  it('ignores a parent directory settings.json, like every other settings consumer', async () => {
+    // Claude reads the shared settings.json from the session's own directory: "to use a
+    // file committed at the repository root, start Claude Code there". Walking up meant a
+    // subdirectory session inherited env the rest of pi-code would not read.
+    track('ENVTEST_ANCESTOR')
+    const repo = tempDir('env-repo-')
+    mkdirSync(join(repo, '.git'))
+    writeSettings(repo, 'settings.json', { ENVTEST_ANCESTOR: 'from-root' })
+    const sub = join(repo, 'packages', 'app')
+    mkdirSync(sub, { recursive: true })
+    hoisted.approved = true
+
+    const { handlers } = setup()
+    await handlers.get('session_start')?.({ reason: 'startup' }, { cwd: sub, isProjectTrusted: () => true })
+
+    expect(process.env.ENVTEST_ANCESTOR).toBeUndefined()
+  })
+
   it('adds approved project env at session_start', async () => {
     track('ENVTEST_PROJECT')
     const project = tempDir('env-proj-')

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -534,6 +534,22 @@ describe('interpretHookResult', () => {
 })
 
 describe('runPreToolUse', () => {
+  it('reports a hook that exits non-zero with no JSON to show for it', async () => {
+    // Claude: with plain-text or empty stdout a non-zero exit "is a non-blocking error
+    // ... the transcript shows a `<hook name> hook error` notice followed by the first
+    // line of stderr, prefixed with `Failed with non-blocking status code:`", and it
+    // singles out the typo case: "a mistyped path in settings.json leaves the gate
+    // silently disabled".
+    const notices: string[] = []
+    const runner: HookRunner = async () => ({ code: 127, stdout: '', stderr: '/bin/sh: /typo/guard.sh: No such file or directory\nmore detail', timedOut: false })
+
+    await runPreToolUse({ PreToolUse: [{ hooks: [{ command: '/typo/guard.sh' }] }] }, 'bash', {}, runner, undefined, (message) => notices.push(message))
+
+    expect(notices).toHaveLength(1)
+    expect(notices[0]).toContain('Failed with non-blocking status code: /bin/sh: /typo/guard.sh: No such file or directory')
+    expect(notices[0]).not.toContain('more detail')
+  })
+
   const config = { PreToolUse: [{ matcher: 'Bash', hooks: [{ command: 'guard.sh' }] }] }
 
   it('blocks the tool when a matching hook returns a blocking result', async () => {

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2364,6 +2364,21 @@ describe('mcp headersHelper environment', () => {
     expect(headers['X-T']).toBe('')
   })
 
+  it('reconnects project servers after a same-process session switch', async () => {
+    // /new, /resume and /fork run session_shutdown then session_start in one process. The
+    // shutdown drops every client, so the next session has to connect the project scope
+    // again; otherwise its tools are gone for the rest of the run.
+    withTools([{ name: 'go' }])
+    const harness = await setup({ project: { proj: { type: 'http', url: 'https://api.example/mcp' } } })
+    await harness.sessionStart(true)
+    expect(await statusLinesOf(harness)).toEqual(['proj: connected (1 tools)'])
+
+    await harness.shutdown()
+    await harness.sessionStart(true)
+
+    expect(await statusLinesOf(harness)).toEqual(['proj: connected (1 tools)'])
+  })
+
   it('does not run a project helper until the project is trusted, connecting with static headers alone', async () => {
     // A repository's helper is a command the user has not reviewed. Consent to the server
     // (enabledMcpjsonServers) is not consent to run its command in an untrusted folder.

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -6,15 +6,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Record spawn so openBrowser's per-platform launch can be asserted without opening a browser.
 // importOriginal keeps the rest of child_process intact for any other consumer in the graph.
-const spawnMock = vi.hoisted(() => ({ calls: [] as Array<{ command: string; args: string[] }>, throwOnCall: false }))
+const spawnMock = vi.hoisted(() => ({ calls: [] as Array<{ command: string; args: string[] }>, throwOnCall: false, emitErrorOnCall: false }))
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>()
+  const { EventEmitter } = await import('node:events')
   return {
     ...actual,
     spawn: (command: string, args: string[]) => {
       spawnMock.calls.push({ command, args })
       if (spawnMock.throwOnCall) throw new Error('spawn failed')
-      return { unref: () => {} }
+      const child = Object.assign(new EventEmitter(), { unref: () => {} })
+      // A launcher that is missing reports it here, one tick after spawn returns.
+      if (spawnMock.emitErrorOnCall) setTimeout(() => child.emit('error', new Error('spawn xdg-open ENOENT')), 0)
+      return child
     },
   }
 })
@@ -210,6 +214,7 @@ describe('openBrowser', () => {
     setPlatform(realPlatform)
     spawnMock.calls.length = 0
     spawnMock.throwOnCall = false
+    spawnMock.emitErrorOnCall = false
   })
 
   it('selects the launch command and args per platform', () => {
@@ -225,6 +230,27 @@ describe('openBrowser', () => {
       openBrowser(url)
       expect(spawnMock.calls).toEqual([{ command, args }])
     }
+  })
+
+  it('keeps a launcher that fails after spawn from taking the process down', async () => {
+    // A child that cannot start, as in a container with no xdg-open, reports it
+    // asynchronously through an 'error' event. With no listener node raises that as an
+    // uncaughtException, and pi exits from what is only a best-effort browser launch.
+    setPlatform('linux')
+    spawnMock.emitErrorOnCall = true
+    const uncaught: unknown[] = []
+    const capture = (error: unknown): void => {
+      uncaught.push(error)
+    }
+    process.on('uncaughtException', capture)
+    try {
+      openBrowser('https://auth.example/authorize')
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    } finally {
+      process.off('uncaughtException', capture)
+    }
+
+    expect(uncaught).toEqual([])
   })
 
   it('swallows a spawn failure so the notified url stays the only fallback', () => {

--- a/tests/output-styles.test.ts
+++ b/tests/output-styles.test.ts
@@ -90,6 +90,22 @@ describe('styleDirs', () => {
   })
 })
 
+it('lets the directory nearest the working directory win a name clash', () => {
+  // Claude: "When more than one of these nested directories defines a style with the
+  // same name, Claude Code uses the one closest to the working directory."
+  const repo = tempDir()
+  mkdirSync(join(repo, '.git'))
+  const sub = join(repo, 'pkg')
+  mkdirSync(join(repo, '.claude', 'output-styles'), { recursive: true })
+  mkdirSync(join(sub, '.claude', 'output-styles'), { recursive: true })
+  writeFileSync(join(repo, '.claude', 'output-styles', 'shared.md'), '---\nname: Shared\n---\nROOT BODY')
+  writeFileSync(join(sub, '.claude', 'output-styles', 'shared.md'), '---\nname: Shared\n---\nNEAREST BODY')
+
+  const resolved = styleForName(loadStyles(styleDirs(sub, tempDir(), true)), 'Shared')
+
+  expect(resolved?.body).toContain('NEAREST BODY')
+})
+
 describe('pluginStyleDirs', () => {
   // Lay down one enabled cached plugin with an optional manifest, as installedPlugins reads it.
   const installPlugin = (home: string, name: string, manifest: Record<string, unknown> = {}): string => {

--- a/tests/output-styles.test.ts
+++ b/tests/output-styles.test.ts
@@ -228,6 +228,35 @@ describe('extension wiring', () => {
     expect(notes.some((n) => n.includes('requires interactive mode'))).toBe(true)
   })
 
+  it('refuses to overwrite a settings file it cannot parse', async () => {
+    // settings.local.json also carries permissions, hooks and env. Starting from an empty
+    // object on a parse failure replaced all of that with the style choice alone.
+    const cwd = tempDir()
+    mkdirSync(join(cwd, '.claude'), { recursive: true })
+    const invalid = '{"permissions":{"allow":["Bash(npm test)"]},}'
+    writeFileSync(join(cwd, '.claude', 'settings.local.json'), invalid)
+    const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>()
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>()
+    const notes: Array<{ text: string; level: string }> = []
+    outputStyles({
+      on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn),
+      registerCommand: (name: string, opts: { handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, opts),
+    } as never)
+    const ctx = {
+      cwd,
+      hasUI: true,
+      isProjectTrusted: () => true,
+      ui: { notify: (text: string, level: string) => notes.push({ text, level }), confirm: async () => true, select: async () => undefined },
+    }
+    await handlers.get('session_start')?.({}, ctx)
+
+    await commands.get('output-style')?.handler('proactive', ctx)
+
+    expect(readFileSync(join(cwd, '.claude', 'settings.local.json'), 'utf-8')).toBe(invalid)
+    expect(notes.at(-1)?.level).toBe('error')
+    expect(notes.at(-1)?.text).toContain('not valid JSON')
+  })
+
   it('sets a style directly when /output-style is given a name', async () => {
     const cwd = projectWithStyle('Explain', 'Explain everything.')
     const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>()

--- a/tests/status-line-command.test.ts
+++ b/tests/status-line-command.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setManagedSettingsPath } from '../extensions/internal/managed-settings.ts'
 import statusLine, { readStatusLineConfig } from '../extensions/status-line.ts'
 
-const hoisted = vi.hoisted(() => ({ home: '', runs: [] as Array<{ command: string; payload: unknown }>, result: { code: 0, stdout: '', stderr: '', timedOut: false }, gate: undefined as Promise<void> | undefined, fsReads: [] as string[], kills: [] as number[] }))
+const hoisted = vi.hoisted(() => ({ home: '', runs: [] as Array<{ command: string; payload: unknown }>, result: { code: 0, stdout: '', stderr: '', timedOut: false }, gate: undefined as Promise<void> | undefined, settingsChanged: undefined as (() => void) | undefined, fsReads: [] as string[], kills: [] as number[] }))
 
 vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:os')>()
@@ -24,6 +24,17 @@ vi.mock('node:fs', async (importOriginal) => {
   }
   return { ...actual, readFileSync: readFileSync as typeof actual.readFileSync }
 })
+
+// The watcher polls on a real interval; capturing its callback lets a test drive a
+// settings change deterministically under fake timers.
+vi.mock('../extensions/internal/settings-watch.js', () => ({
+  watchSettingsFiles: (_files: string[], reload: () => void) => {
+    hoisted.settingsChanged = reload
+    return () => {
+      hoisted.settingsChanged = undefined
+    }
+  },
+}))
 
 vi.mock('../extensions/hooks/index.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../extensions/hooks/index.js')>()
@@ -116,6 +127,27 @@ const setup = (cwd: string) => {
 }
 
 describe('statusLine command contract', () => {
+  it('arms the refresh interval when the setting is added mid-session', async () => {
+    // Claude re-runs the script when the statusLine settings change mid-session. The
+    // interval was armed once at session start, so adding or changing refreshInterval had
+    // no effect until the next session.
+    const cwd = tempDir()
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh' } })
+    const { handlers, ctx } = setup(cwd)
+    vi.useFakeTimers()
+    await handlers.get('session_start')?.({}, ctx)
+    await vi.advanceTimersByTimeAsync(400)
+    expect(hoisted.runs).toHaveLength(1)
+
+    writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh', refreshInterval: 1 } })
+    hoisted.settingsChanged?.()
+    await vi.advanceTimersByTimeAsync(400)
+    const afterReload = hoisted.runs.length
+    await vi.advanceTimersByTimeAsync(1400)
+
+    expect(hoisted.runs.length).toBeGreaterThan(afterReload)
+  })
+
   it('runs the configured command with the session payload and shows its first line, padded', async () => {
     const cwd = tempDir()
     writeSettings(hoisted.home, 'settings.json', { statusLine: { type: 'command', command: 'seg.sh', padding: 1 } })

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -781,13 +781,15 @@ describe('runSingleAgent process handling', () => {
     expect(results(result)[0].stderr).toBe('warn: deprecated flag')
   })
 
-  it('treats a spawn error as exit code 1', async () => {
+  it('treats a spawn error as exit code 1 and reports what failed', async () => {
     script('inspect', { fail: true })
 
     const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
 
     expect(results(result)[0].exitCode).toBe(1)
-    expect(text(result)).toBe('Agent failed: (no output)')
+    // The spawn error is the only diagnostic a child that never started leaves; without it
+    // the model and the user get "(no output)" and nothing to act on.
+    expect(text(result)).toBe('Agent failed: spawn ENOENT')
   })
 
   it('maps a null exit code to zero', async () => {

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -25,6 +25,7 @@ const cancelAllBackgroundRunsMock = vi.hoisted(() => vi.fn(() => 0))
 const resumeBackgroundRunMock = vi.hoisted(() => vi.fn())
 const activeBackgroundRunsMock = vi.hoisted(() => vi.fn(() => 0))
 const backgroundRunMock = vi.hoisted(() => vi.fn())
+const allBackgroundRunsMock = vi.hoisted(() => vi.fn((): unknown[] => []))
 
 vi.mock('node:child_process', async (importOriginal) => ({ ...(await importOriginal<object>()), spawn: spawnMock }))
 vi.mock('../extensions/subagent/agents.js', async (importOriginal) => ({
@@ -39,6 +40,7 @@ vi.mock('../extensions/subagent/background.js', () => ({
   startBackgroundRun: startBackgroundRunMock,
   activeBackgroundRuns: activeBackgroundRunsMock,
   backgroundRun: backgroundRunMock,
+  allBackgroundRuns: allBackgroundRunsMock,
   MAX_BACKGROUND_RUNS: 8,
 }))
 
@@ -238,6 +240,8 @@ beforeEach(() => {
   resumeBackgroundRunMock.mockReset()
   activeBackgroundRunsMock.mockReturnValue(0)
   backgroundRunMock.mockReset()
+  allBackgroundRunsMock.mockReset()
+  allBackgroundRunsMock.mockReturnValue([])
   sendMessageMock.mockClear()
   notifyMock.mockClear()
   emittedEvents.length = 0
@@ -929,7 +933,7 @@ describe('backgroundCompletionText diagnostics', () => {
 
 describe('tasksStatusText', () => {
   it('notes when there are no background runs', () => {
-    expect(tasksStatusText([])).toBe('No background subagent runs in this session.')
+    expect(tasksStatusText([])).toBe('No background subagent runs.')
   })
 
   it('lists each run with id, agent, state, turns and a short output tail', () => {
@@ -1057,14 +1061,27 @@ describe('viewer commands', () => {
   it('/tasks notes the empty registry without running anything', async () => {
     await command('tasks').handler('', commandCtx())
 
-    expect(notifyMock).toHaveBeenCalledWith('No background subagent runs in this session.', 'info')
+    expect(notifyMock).toHaveBeenCalledWith('No background subagent runs.', 'info')
     expect(spawnMock).not.toHaveBeenCalled()
   })
 
-  it('/tasks lists runs started in this session, resolved against the live registry', async () => {
+  it('/tasks lists a run from the registry that this instance never started', async () => {
+    // pi re-invokes every extension factory per session while the run registry is module
+    // state that outlives the switch, so after /new the fresh instance must still list the
+    // runs the shutdown just warned were active.
+    allBackgroundRunsMock.mockReturnValue([{ id: 'bg-99999999', agent: 'scout', task: 'from an earlier session', state: 'running', turns: 1 }])
+
+    await command('tasks').handler('', commandCtx())
+
+    const out = notifyMock.mock.calls[0][0] as string
+    expect(out).toContain('bg-99999999 scout: running')
+    expect(out).toContain('from an earlier session')
+  })
+
+  it('/tasks renders a run with its state, turns, task and output', async () => {
     startBackgroundRunMock.mockReturnValue('bg-11111111')
     await execute('c1', { background: true, agent: 'scout', task: 'audit the API surface' }, undefined, undefined, trustedCtx)
-    backgroundRunMock.mockImplementation((id: string) => (id === 'bg-11111111' ? { id, agent: 'scout', task: 'audit the API surface', state: 'done', turns: 3, output: 'All clear.' } : undefined))
+    allBackgroundRunsMock.mockReturnValue([{ id: 'bg-11111111', agent: 'scout', task: 'audit the API surface', state: 'done', turns: 3, output: 'All clear.' }])
 
     await command('tasks').handler('', commandCtx())
 
@@ -1073,13 +1090,13 @@ describe('viewer commands', () => {
     expect(out).toContain('All clear.')
   })
 
-  it('/tasks drops runs the registry has evicted', async () => {
+  it('/tasks says so when the registry has evicted every run', async () => {
     await execute('c1', { background: true, agent: 'scout', task: 'audit' }, undefined, undefined, trustedCtx)
-    backgroundRunMock.mockReturnValue(undefined)
+    allBackgroundRunsMock.mockReturnValue([])
 
     await command('tasks').handler('', commandCtx())
 
-    expect(notifyMock).toHaveBeenCalledWith('No background subagent runs in this session.', 'info')
+    expect(notifyMock).toHaveBeenCalledWith('No background subagent runs.', 'info')
   })
 
   it('/agents lists the discovered agents for an approved project', async () => {


### PR DESCRIPTION
Each fix has a test that fails without it. Where the fix has an internal branch, a mutation check confirms the test catches it.

- **Project MCP servers went dead after `/new`, `/resume` or `/fork`.** The guard preventing a second connect within one session was never cleared, while the shutdown those run first drops every client, so the whole project scope was skipped for the rest of the process.
- **A browser launcher that fails after spawn ended the session.** A machine with no opener reports it asynchronously, and with no listener node raised it as an uncaught exception.
- **A foreground subagent that never started reported "(no output)".** The error message now fills in as the result's stderr, as the background path already did.
- **A background resume re-ran the original task** when SubagentStart hooks put their context ahead of the prompt, because the swap matched a `Task: ` prefix. The task is always the final argument, so that is what gets replaced.
- **`/tasks` went blind after a session switch.** It listed a per-instance set of ids while the registry is module state that outlives the switch, so it answered "none" right after the shutdown warned runs were active.
- **`/output-style` destroyed an unparseable `settings.local.json`.** Persisting started from an empty object on a parse failure, replacing permissions, hooks and env with the style alone. The file is now left untouched and the failure reported. The atomic write helper the memory index already had moved to its own module rather than being copied.
- **Output-style precedence was inverted.** Directories ran nearest-first while the loader lets later ones win, so a package's style lost to the repository root's.
- **Rule `paths:` parsing broke two shapes.** A brace group was split on its inner comma, producing patterns that match nothing, and a list written across several lines parsed as empty, which makes a scoped rule unscoped and injects it into every session.
- **Project `env` walked up to an ancestor directory** while every other settings consumer reads the shared file from the session's own directory. It now uses the same chain.
- **A hook that exited non-zero with no JSON said nothing.** Claude's example is a mistyped path in settings.json, where the shell exits 127 and explains itself only on stderr, leaving a policy hook silently disabled. Such a result now carries the documented notice.
- **The status line refresh interval never re-armed.** Adding or changing `refreshInterval` did nothing until the next session, although the watcher already re-read the config on save.

Three tests changed premise rather than expectation: two `/tasks` tests were built on the per-session scope, and one pinned the empty spawn-failure text.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change
