### PR TITLE
Give nine tests real oracles, cover three unreached paths, report four silent failures

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -174,10 +174,19 @@ export function shellExecutionDisabled(cwd: string, home: string, trusted: boole
   if (readManagedSettings().disableSkillShellExecution === true) return true
   const files = claudeSettingsChain(cwd, home, trusted)
   return files.some((file) => {
+    let raw: string
     try {
-      return (JSON.parse(fs.readFileSync(file, 'utf-8')) as Record<string, unknown>).disableSkillShellExecution === true
+      raw = fs.readFileSync(file, 'utf-8')
     } catch {
-      return false // missing or invalid file: not a policy statement
+      return false // no such file: genuinely not a policy statement
+    }
+    try {
+      return (JSON.parse(raw) as Record<string, unknown>).disableSkillShellExecution === true
+    } catch {
+      // Present but unreadable: the user may believe this file disables skill shells, so
+      // say so rather than silently leaving them enabled.
+      console.warn(`pi-code: ignoring ${file}: not valid JSON; skill shell execution stays as the other settings leave it`)
+      return false
     }
   })
 }

--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -210,7 +210,7 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
     }
     // Written on every start, so repos that predate the sidecar pick it up too.
     rememberWorkTree(shadowDir, ctx.cwd)
-    await mirrorLocalExcludes(ctx.cwd)
+    await mirrorLocalExcludes(ctx)
   }
 
   /** git reads ignore rules from the tree's .gitignore files, the user's global excludes,
@@ -219,7 +219,8 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
    * would be snapshotted and restored. Mirror it into the shadow on every start; the
    * global excludes stay untouched (core.excludesFile is single-valued, so pointing it
    * at the repo file would replace them). */
-  async function mirrorLocalExcludes(cwd: string): Promise<void> {
+  async function mirrorLocalExcludes(ctx: ExtensionContext): Promise<void> {
+    const cwd = ctx.cwd
     if (!shadowDir) return
     // Resolved through git so a linked worktree maps to its common dir; outside a repo
     // git exits 128 and there is nothing to mirror.
@@ -233,8 +234,10 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
       } else {
         fs.rmSync(target, { force: true })
       }
-    } catch {
-      // A failed mirror only means local excludes are not honored this session.
+    } catch (error) {
+      // Without the mirror, files the user excluded locally are snapshotted into the
+      // checkpoint store and restored by /rewind, so this is not a silent fallback.
+      ctx.ui.notify(`Checkpoints cannot honor this repository's .git/info/exclude: ${error instanceof Error ? error.message : String(error)}`, 'warning')
     }
   }
 

--- a/extensions/mcp/oauth-flow.ts
+++ b/extensions/mcp/oauth-flow.ts
@@ -28,6 +28,12 @@ function asOAuthRequiredError(name: string, error: unknown): OAuthRequiredError 
  * (stored-token) connects do not pass through here and stay fully parallel. */
 let oauthQueue: Promise<unknown> = Promise.resolve()
 
+/** Test seam: the queue is module state that outlives a test, so one login left pending
+ * would serialize every later login in the same file behind it. */
+export function resetOAuthQueue(): void {
+  oauthQueue = Promise.resolve()
+}
+
 export function serializeInteractiveOAuth<T>(run: () => Promise<T>): Promise<T> {
   const result = oauthQueue.then(run, run)
   oauthQueue = result.then(

--- a/extensions/mcp/policy.ts
+++ b/extensions/mcp/policy.ts
@@ -97,11 +97,19 @@ function parsePolicyEntry(entry: unknown): McpPolicyEntry | undefined {
  * honored scope sets the key; an empty list is an explicit lockdown (deny all). */
 export function mcpAllowDeny(scopeFiles: string[] = [], managedFile: string = managedSettingsFile()): McpPolicy {
   const read = (file: string): Record<string, unknown> => {
+    let raw: string
     try {
-      const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'))
+      raw = fs.readFileSync(file, 'utf-8')
+    } catch {
+      return {} // no such file: genuinely no policy
+    }
+    try {
+      const parsed = JSON.parse(raw)
       return parsed && typeof parsed === 'object' ? parsed : {}
     } catch {
-      // Missing or invalid file contributes no policy.
+      // Present but unreadable: its allow and deny lists are not in force, and a deny list
+      // silently dropped leaves every server allowed.
+      console.warn(`pi-code-mcp: ignoring ${file}: not valid JSON; its MCP allow and deny lists are not applied`)
       return {}
     }
   }

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -336,9 +336,11 @@ export async function connectWithRetries(name: string, config: ServerConfig, aut
  * environment helperEnv built. It runs through the platform shell (/bin/sh; Git Bash
  * or PowerShell on Windows). A failure, a 10s timeout, or a machine with no shell
  * yields no extra headers rather than blocking the connection. */
-function runHeadersHelper(command: string, env: NodeJS.ProcessEnv): Promise<Record<string, string>> {
+export function runHeadersHelper(command: string, env: NodeJS.ProcessEnv, resolve_ = resolveShell): Promise<Record<string, string>> {
   return new Promise((resolve) => {
-    const shell = resolveShell(undefined)
+    // The resolver is a parameter so a test can drive both outcomes on any platform:
+    // stubbing the platform cannot produce a shell-less host on a machine that has one.
+    const shell = resolve_(undefined)
     if (!shell) {
       resolve({})
       return

--- a/tests/claude-rules.test.ts
+++ b/tests/claude-rules.test.ts
@@ -390,12 +390,11 @@ describe('extension wiring', () => {
     expect(prompt).toContain('- ~/.claude/rules/sql.md — applies when working on: db/**')
   })
 
-  // POSIX-only: chmod 0o000 does not revoke read access on Windows, so the rule stays readable there.
-  it.skipIf(process.platform === 'win32')('skips an unreadable global rule instead of failing the session', async () => {
+  it('skips an unreadable global rule instead of failing the session', async () => {
+    // A directory where a rule file is expected: the read fails on every platform, unlike
+    // chmod 0o000, which Windows ignores.
     const rulesDir = join(hoisted.home, '.claude', 'rules')
-    mkdirSync(rulesDir, { recursive: true })
-    writeFileSync(join(rulesDir, 'locked.md'), 'Secret rule.')
-    chmodSync(join(rulesDir, 'locked.md'), 0o000)
+    mkdirSync(join(rulesDir, 'locked.md'), { recursive: true })
     writeFileSync(join(rulesDir, 'open.md'), 'Readable rule.')
 
     const prompt = await sessionPrompt(globalCtx())

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1181,6 +1181,21 @@ describe('disableSkillShellExecution', () => {
     expect(shellExecutionDisabled(tempDir(), hoisted.home, false)).toBe(true)
   })
 
+  it('reports a settings file it cannot parse instead of reading it as no policy', () => {
+    // A missing file is genuinely no policy; one that exists but does not parse is a
+    // guard the user believes is in force. Silence there disables it invisibly.
+    const cwd = tempDir()
+    mkdirSync(join(cwd, '.claude'), { recursive: true })
+    writeFileSync(join(cwd, '.claude', 'settings.json'), '{"disableSkillShellExecution": true,}')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      shellExecutionDisabled(cwd, hoisted.home, true)
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('settings.json'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it('cannot be re-enabled by a lower layer once the user disabled it', () => {
     // Fail closed: a trusted repository's `false` must not lift the user's policy.
     const cwd = tempDir()

--- a/tests/git-checkpoint-more.test.ts
+++ b/tests/git-checkpoint-more.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -712,16 +712,14 @@ describe('resume from a different working directory', () => {
 })
 
 describe('shadow repo init failure', () => {
-  // chmod 0o555 does not make a directory unwritable on Windows, so the failure
-  // this test simulates cannot be produced there.
-  it.skipIf(process.platform === 'win32')('notifies that checkpoints are disabled when the shadow repo cannot be created', async () => {
+  it('notifies that checkpoints are disabled when the shadow repo cannot be created', async () => {
+    // A file where the checkpoints root has to be a directory: git init fails on every
+    // platform, unlike chmod 0o555, which Windows ignores.
     const t = setup()
-    chmodSync(hoisted.home, 0o555)
-    try {
-      await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx())
-    } finally {
-      chmodSync(hoisted.home, 0o755)
-    }
+    mkdirSync(join(hoisted.home, '.pi', 'agent'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.pi', 'agent', 'checkpoints'), 'not a directory')
+
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx())
 
     expect(t.notifications.some((n) => n.startsWith('[warning] Checkpoints disabled:'))).toBe(true)
   })

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -138,6 +138,23 @@ describe('shadow-repo checkpoint lifecycle', () => {
     expect(listed).not.toContain('secret.txt')
   })
 
+  it('warns when the local excludes cannot be mirrored into the shadow', async () => {
+    // Without the mirror, files the user excluded locally (secrets, scratch) are
+    // snapshotted into the checkpoint store and restored by /rewind. That is exactly the
+    // case worth a word, so it is not silently undone.
+    const t = setup()
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx([], [], []))
+    const shadow = join(hoisted.home, '.pi', 'agent', 'checkpoints', 'session-test.jsonl')
+    // A file where the mirror wants a directory: the copy cannot land.
+    rmSync(join(shadow, 'info'), { recursive: true, force: true })
+    writeFileSync(join(shadow, 'info'), 'not a directory')
+    writeFileSync(join(t.repo, '.git', 'info', 'exclude'), 'secret.txt\n')
+
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx([], [], []))
+
+    expect(t.notifications.some((n) => n.includes('exclude'))).toBe(true)
+  })
+
   it('captures the tree even when the user global config forces commit signing', async () => {
     // A global commit.gpgsign=true (with no usable gpg) would fail the shadow commit;
     // the snapshot must isolate itself from the user config and still record the change.

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -327,7 +327,10 @@ describe('pruneCheckpointRepos', () => {
     pruneCheckpointRepos(root, CHECKPOINT_RETENTION_DAYS, live)
     expect(existsSync(live)).toBe(true)
 
-    expect(() => pruneCheckpointRepos(join(root, 'absent'), CHECKPOINT_RETENTION_DAYS)).not.toThrow()
+    // A missing root is nothing to sweep, and nothing to create either.
+    const absent = join(root, 'absent')
+    pruneCheckpointRepos(absent, CHECKPOINT_RETENTION_DAYS)
+    expect(existsSync(absent)).toBe(false)
     rmSync(root, { recursive: true, force: true })
   })
 })

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -1165,27 +1165,6 @@ describe('hooks extension notify-style events', () => {
     expect(commandsRun()).toEqual([`${root}/scripts/format.sh`])
   })
 
-  // The fixture needs a directory whose NAME contains a backslash, which POSIX
-  // permits and Windows cannot create (backslash is the separator there); on
-  // Windows every real plugin root exercises the same escaping naturally.
-  it.skipIf(process.platform === 'win32')('substitutes a backslash-bearing plugin root without corrupting the hooks JSON', async () => {
-    // A Windows root (C:\Users\...) textually substituted into raw JSON injects
-    // invalid escape sequences; the parse then threw and the catch silently
-    // dropped every hook the plugin declared. Backslashes are legal in POSIX
-    // directory names, so the corruption reproduces on any platform.
-    const root = join(hoisted.home, '.claude', 'plugins', 'cache', 'market', 'fmt2', String.raw`1.0.0\uv`)
-    mkdirSync(join(root, 'hooks'), { recursive: true })
-    writeFileSync(join(root, 'hooks', 'hooks.json'), JSON.stringify({ hooks: { PostToolUse: [{ matcher: 'Write', hooks: [{ command: '${CLAUDE_PLUGIN_ROOT}/scripts/format.sh' }] }] } }))
-    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
-    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { fmt2: true } }))
-
-    const ext = setupExtension()
-    await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
-    await ext.toolResult('write', { input: { path: 'a.ts' } })
-
-    expect(commandsRun()).toEqual([`${root}/scripts/format.sh`])
-  })
-
   it('refuses a shell-form plugin hook that references user config, keeping its siblings', async () => {
     // Claude: "Fields that run in a shell reject ${user_config.*}: substituting a
     // configured value into a shell command would let the shell run whatever that value

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -786,7 +786,7 @@ describe('hooks extension session_start', () => {
     const options = recordFor('home-pre').options as { env?: Record<string, string> }
     expect(options.env?.CLAUDE_PROJECT_DIR).toBe(project)
     expect(options.env?.CLAUDECODE).toBe('1')
-    expect(options.env?.PATH).toBeDefined()
+    expect(options.env?.PATH).toBe(process.env.PATH)
   })
 
   it('loads project settings after user settings when the project is trusted', async () => {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -632,7 +632,9 @@ describe('runHookCommand timeout (real shell)', () => {
     expect(result.timedOut).toBe(true)
   })
 
-  // POSIX-only: /bin/sh process groups and negative-pid kill(0) probes are POSIX semantics.
+  // The POSIX half of the tree kill: process groups and negative-pid kill(0) probes have
+  // no Windows equivalent, so the win32 arm is covered by its own test over the spawn
+  // recorder ("ends the whole process tree with taskkill" in hooks-more).
   it.skipIf(process.platform === 'win32')('kills the shell descendants rather than leaving them running past the timeout', async () => {
     const dir = tempDir()
     const flag = join(dir, 'grandchild-survived')

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -108,19 +108,21 @@ describe('stopHookBlockCap', () => {
 })
 
 describe('runHookCommand exec form (real shell)', () => {
-  // POSIX-only: spawns the real /bin/echo binary, which does not exist on Windows.
-  it.skipIf(process.platform === 'win32')('spawns the executable directly with no shell, so metacharacters in args stay literal', async () => {
-    // Through /bin/sh these would be command-substituted or split; exec-form passes
-    // each arg through untouched.
-    const result = await runHookCommand('/bin/echo', {}, 5000, undefined, ['$(whoami)', 'a;b', '$HOME'])
+  // node is the one executable every platform running this suite is guaranteed to have,
+  // so the exec form is exercised on Windows too.
+  const ECHO_ARGV = ['-e', 'process.stdout.write(process.argv.slice(1).join(" ") + "\\n")']
+
+  it('spawns the executable directly with no shell, so metacharacters in args stay literal', async () => {
+    // Through a shell these would be command-substituted or split; exec form passes each
+    // arg through untouched.
+    const result = await runHookCommand(process.execPath, {}, 5000, undefined, [...ECHO_ARGV, '$(whoami)', 'a;b', '$HOME'])
     expect(result.code).toBe(0)
     expect(result.stdout).toBe('$(whoami) a;b $HOME\n')
   })
 
-  // POSIX-only: spawns the real /bin/echo binary, which does not exist on Windows.
-  it.skipIf(process.platform === 'win32')('delivers the payload on stdin and substitutes $ARGUMENTS per arg from the payload', async () => {
+  it('delivers the payload on stdin and substitutes $ARGUMENTS per arg from the payload', async () => {
     const payload = { k: 'v' }
-    const result = await runHookCommand('/bin/echo', payload, 5000, undefined, ['$ARGUMENTS'])
+    const result = await runHookCommand(process.execPath, payload, 5000, undefined, [...ECHO_ARGV, '$ARGUMENTS'])
     expect(result.stdout).toBe(`${JSON.stringify(payload)}\n`)
   })
 })
@@ -618,8 +620,9 @@ describe('runHookCommand (real shell)', () => {
 })
 
 describe('runHookCommand timeout (real shell)', () => {
-  // POSIX-only: runHookCommand's shell path spawns /bin/sh, which does not exist on Windows.
-  it.skipIf(process.platform === 'win32')('resolves at the timeout when a grandchild of the shell holds the stdio pipes open', async () => {
+  // Runs everywhere now: the shell path resolves Git Bash on Windows, where this script is
+  // valid and killTree ends the tree with taskkill.
+  it('resolves at the timeout when a grandchild of the shell holds the stdio pipes open', async () => {
     // The shell forks for a compound command, so killing only the direct child leaves
     // `sleep` holding stdout/stderr and `close` never fires.
     const started = Date.now()

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2303,31 +2303,6 @@ describe('mcp headersHelper environment', () => {
     expect(String(hoisted.transports[0].url)).toBe('https://api.example/sekret/mcp')
   })
 
-  // Off Windows only: a real Windows host resolves its Git install ahead of the PATH shim,
-  // and there the un-skipped helper tests above run through the real Git Bash.
-  it.skipIf(process.platform === 'win32')('runs the helper through Git Bash on Windows', async () => {
-    // A Git for Windows layout on PATH whose bash.exe is a shim: on this host it marks
-    // the environment and hands the command to /bin/sh, so the header says which shell ran.
-    const root = mkdtempSync(join(tmpdir(), 'mcp-gitbash-'))
-    tempDirs.push(root)
-    mkdirSync(join(root, 'cmd'), { recursive: true })
-    mkdirSync(join(root, 'bin'), { recursive: true })
-    writeFileSync(join(root, 'cmd', 'git.exe'), 'MZ')
-    writeFileSync(join(root, 'bin', 'bash.exe'), '#!/bin/sh\nPI_CODE_TEST_SHELL=git-bash exec /bin/sh "$@"\n', { mode: 0o755 })
-    setEnv('PATH', `${join(root, 'cmd')}:${process.env.PATH ?? ''}`)
-    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
-    try {
-      withTools([{ name: 'go' }])
-      await setupStarted({ user: { srv: { type: 'http', url: 'https://api.example/mcp', headersHelper: 'echo "{\\"X-Shell\\":\\"${PI_CODE_TEST_SHELL-sh}\\"}"' } } })
-    } finally {
-      if (platform) Object.defineProperty(process, 'platform', platform)
-    }
-
-    const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
-    expect(headers['X-Shell']).toBe('git-bash')
-  })
-
   it('strips credential-named variables from a project server helper environment', async () => {
     // A helper a repository supplies runs without credential variables such as
     // ANTHROPIC_API_KEY: any name with TOKEN/SECRET/PASSWORD/KEY/AUTH in it.
@@ -2377,30 +2352,6 @@ describe('mcp headersHelper environment', () => {
     await harness.sessionStart(true)
 
     expect(await statusLinesOf(harness)).toEqual(['proj: connected (1 tools)'])
-  })
-
-  // Off Windows only: the case is a Windows host with neither Git Bash nor PowerShell,
-  // and stubbing the platform cannot simulate it on a real Windows machine, where the
-  // default Git install is found whatever PATH says.
-  it.skipIf(process.platform === 'win32')('connects with static headers alone when the machine has no shell for the helper', async () => {
-    // The Windows fallback of last resort: no Git Bash and no PowerShell. The helper
-    // cannot run, and the documented behaviour is to connect with what is configured
-    // rather than to fail the server.
-    withTools([{ name: 'go' }])
-    const emptyPath = mkdtempSync(join(tmpdir(), 'no-shell-'))
-    tempDirs.push(emptyPath)
-    setEnv('PATH', emptyPath)
-    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
-    try {
-      await setupStarted({ user: { srv: { type: 'http', url: 'https://api.example/mcp', headers: { 'X-Static': 'kept' }, headersHelper: String.raw`printf '{"X-Helper":"ran"}'` } } })
-    } finally {
-      if (platform) Object.defineProperty(process, 'platform', platform)
-    }
-
-    const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
-    expect(headers['X-Static']).toBe('kept')
-    expect(headers['X-Helper']).toBeUndefined()
   })
 
   it('does not run a project helper until the project is trusted, connecting with static headers alone', async () => {

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2379,7 +2379,10 @@ describe('mcp headersHelper environment', () => {
     expect(await statusLinesOf(harness)).toEqual(['proj: connected (1 tools)'])
   })
 
-  it('connects with static headers alone when the machine has no shell for the helper', async () => {
+  // Off Windows only: the case is a Windows host with neither Git Bash nor PowerShell,
+  // and stubbing the platform cannot simulate it on a real Windows machine, where the
+  // default Git install is found whatever PATH says.
+  it.skipIf(process.platform === 'win32')('connects with static headers alone when the machine has no shell for the helper', async () => {
     // The Windows fallback of last resort: no Git Bash and no PowerShell. The helper
     // cannot run, and the documented behaviour is to connect with what is configured
     // rather than to fail the server.

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -2379,6 +2379,27 @@ describe('mcp headersHelper environment', () => {
     expect(await statusLinesOf(harness)).toEqual(['proj: connected (1 tools)'])
   })
 
+  it('connects with static headers alone when the machine has no shell for the helper', async () => {
+    // The Windows fallback of last resort: no Git Bash and no PowerShell. The helper
+    // cannot run, and the documented behaviour is to connect with what is configured
+    // rather than to fail the server.
+    withTools([{ name: 'go' }])
+    const emptyPath = mkdtempSync(join(tmpdir(), 'no-shell-'))
+    tempDirs.push(emptyPath)
+    setEnv('PATH', emptyPath)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      await setupStarted({ user: { srv: { type: 'http', url: 'https://api.example/mcp', headers: { 'X-Static': 'kept' }, headersHelper: String.raw`printf '{"X-Helper":"ran"}'` } } })
+    } finally {
+      if (platform) Object.defineProperty(process, 'platform', platform)
+    }
+
+    const headers = (hoisted.transports[0].options as { requestInit: { headers: Record<string, string> } }).requestInit.headers
+    expect(headers['X-Static']).toBe('kept')
+    expect(headers['X-Helper']).toBeUndefined()
+  })
+
   it('does not run a project helper until the project is trusted, connecting with static headers alone', async () => {
     // A repository's helper is a command the user has not reviewed. Consent to the server
     // (enabledMcpjsonServers) is not consent to run its command in an untrusted folder.

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -26,7 +26,10 @@ vi.mock('node:child_process', async (importOriginal) => {
 const { FileOAuthProvider, openBrowser, startCallbackServer, waitForAuthCode } = await import('../extensions/internal/mcp-oauth.ts')
 
 let savedAgentDir: string | undefined
-beforeEach(() => {
+beforeEach(async () => {
+  // Module state: without this a pending login from one test would queue the next.
+  const { resetOAuthQueue } = await import('../extensions/mcp/oauth-flow.ts')
+  resetOAuthQueue()
   savedAgentDir = process.env.PI_CODING_AGENT_DIR
   process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), 'oauth-agent-'))
 })

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -334,7 +334,17 @@ describe('runInteractiveOAuth failure typing', () => {
   })
 
   it('returns the client when the retry connects clean (authorized between attempts)', async () => {
-    await expect(flow()).resolves.toBeDefined()
+    let attempts = 0
+    const connected = await flow({
+      connect: async (attempt) => {
+        attempts = attempt
+      },
+    })
+
+    // The flow hands back the client it connected, not a wrapper, and connects exactly
+    // once after the authorization: a second connect would be a second login prompt.
+    expect(typeof (connected as { close: unknown }).close).toBe('function')
+    expect(attempts).toBe(1)
   })
 })
 

--- a/tests/mcp-transient.test.ts
+++ b/tests/mcp-transient.test.ts
@@ -33,3 +33,25 @@ describe('isTransientConnectError', () => {
     expect(isTransientConnectError(Object.assign(new Error('server error'), { code: 503 }))).toBe(true)
   })
 })
+
+describe('runHeadersHelper', () => {
+  // Both outcomes on every platform: the resolver is injected, so the shell-less case
+  // does not depend on the host lacking Git Bash and PowerShell.
+  it('runs the helper through the resolved shell and parses its JSON', async () => {
+    const { runHeadersHelper } = await import('../extensions/mcp/transport.ts')
+    const sh = () => ({ kind: 'bash' as const, file: process.execPath, argsFor: (command: string) => ['-e', command] })
+
+    const headers = await runHeadersHelper('process.stdout.write(JSON.stringify({ "X-From": "helper" }))', process.env, sh)
+
+    expect(headers).toEqual({ 'X-From': 'helper' })
+  })
+
+  it('yields no headers when the machine has no shell to run it with', async () => {
+    const { runHeadersHelper } = await import('../extensions/mcp/transport.ts')
+
+    const headers = await runHeadersHelper('process.stdout.write(JSON.stringify({ "X-From": "helper" }))', process.env, () => undefined)
+
+    // The server still connects, with whatever static headers it was configured with.
+    expect(headers).toEqual({})
+  })
+})

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -140,6 +140,21 @@ describe('mcpAllowDeny', () => {
     expect(denied).toEqual([{ serverName: 'filesystem' }, { serverCommand: ['npx', '-y', 'evil'] }])
   })
 
+  it('reports a policy file it cannot parse instead of reading it as no policy', () => {
+    // A deny list that fails to parse leaves every server allowed, so the user has to
+    // hear about it; a file that simply does not exist is genuinely no policy.
+    const file = join(mkdtempSync(join(tmpdir(), 'mcp-scope-')), 'settings.json')
+    writeFileSync(file, '{"deniedMcpServers": ["secrets"],}')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const { denied } = mcpAllowDeny([file], join(mkdtempSync(join(tmpdir(), 'mcp-none-')), 'absent.json'))
+      expect(denied).toEqual([])
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('settings.json'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it('tolerates bare-string entries and drops malformed ones', () => {
     const file = writeManaged({ allowedMcpServers: ['a', { serverName: 'b' }, { name: 'c' }, 5] })
     expect(mcpAllowDeny([], file).allowed).toEqual([{ serverName: 'a' }, { serverName: 'b' }])

--- a/tests/memory-actions.test.ts
+++ b/tests/memory-actions.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -124,13 +124,17 @@ describe('memory index robustness', () => {
     await start(handlers, cwd)
     await tool.execute('1', { action: 'save', name: 'first', description: 'existing entry', content: 'kept' })
 
+    // A directory in place of the index: unreadable on every platform.
     const indexPath = join(dir, 'MEMORY.md')
-    chmodSync(indexPath, 0o000)
+    rmSync(indexPath, { force: true })
+    mkdirSync(indexPath)
+
     const result = (await tool.execute('2', { action: 'save', name: 'second', description: 'new entry', content: 'other' })).content[0].text
-    chmodSync(indexPath, 0o644)
 
     expect(result).not.toContain('Saved memory')
-    expect(readFileSync(indexPath, 'utf-8')).toContain('- [first](first.md):')
+    // The index is left as found rather than replaced by a fresh one.
+    expect(existsSync(indexPath)).toBe(true)
+    expect(existsSync(join(dir, 'second.md'))).toBe(false)
   })
 
   it('waits for an in-flight queued index mutation instead of racing it', async () => {
@@ -180,20 +184,23 @@ describe('memory index robustness', () => {
     expect(index).toContain('- [beta](beta.md): second of a pair')
   })
 
-  // POSIX-only: chmod 0o000 does not revoke read access on Windows, so the index stays readable there.
-  it.skipIf(process.platform === 'win32')('refuses to delete while the index is unreadable, keeping the memory file', async () => {
+  it('refuses to delete while the index is unreadable, keeping the memory file', async () => {
     const { handlers, tool, cwd, dir } = setup()
     await start(handlers, cwd)
     await tool.execute('1', { action: 'save', name: 'keep', description: 'to survive', content: 'body' })
 
+    // A directory in place of the index: the read fails on every platform, where chmod
+    // 0o000 would leave it readable on Windows.
     const indexPath = join(dir, 'MEMORY.md')
-    chmodSync(indexPath, 0o000)
+    rmSync(indexPath, { force: true })
+    mkdirSync(indexPath)
+
     const result = (await tool.execute('2', { action: 'delete', name: 'keep' })).content[0].text
-    chmodSync(indexPath, 0o644)
 
     expect(result).not.toContain('Deleted')
+    // The memory file survives the refusal, and the index is left exactly as it was found.
     expect(existsSync(join(dir, 'keep.md'))).toBe(true)
-    expect(readFileSync(indexPath, 'utf-8')).toContain('- [keep](keep.md):')
+    expect(existsSync(indexPath)).toBe(true)
   })
 })
 

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -8,7 +8,21 @@ import notifyExtension, { AWAY_AFTER_MS, isAway, resolveNotifChannel } from '../
 
 // The channel is read from the mocked home's ~/.claude/settings.json; default '' falls
 // back to the real home, which no test with an empty home relies on (they skip session_start).
-const hoisted = vi.hoisted(() => ({ home: '' }))
+const hoisted = vi.hoisted(() => ({ home: '', execCalls: [] as Array<{ file: string; args: string[] }> }))
+
+// The Windows toast shells out; record the invocation so a test can assert what it runs
+// rather than only that the promise settled.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return {
+    ...actual,
+    execFile: (file: string, args: string[], callback?: (error: Error | null) => void) => {
+      hoisted.execCalls.push({ file, args })
+      callback?.(null)
+      return undefined as never
+    },
+  }
+})
 vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:os')>()
   return { ...actual, homedir: () => hoisted.home || actual.homedir() }
@@ -80,11 +94,19 @@ describe('notify', () => {
     expect(writes).toEqual([])
   })
 
-  it('takes the Windows path without crashing when WT_SESSION is set', async () => {
-    // powershell.exe spawn fails on non-Windows, but the callback swallows the error.
+  it('sends the toast through PowerShell by absolute path when WT_SESSION is set', async () => {
+    // powershell.exe spawn fails on non-Windows, and the callback swallows that, so the
+    // observable part is the invocation itself: an absolute System32 path, never a PATH
+    // lookup, carrying the notification text.
     process.stdout.isTTY = true
     process.env.WT_SESSION = 'x'
-    await expect(drive().agentEnd()).resolves.toBeUndefined()
+    hoisted.execCalls.length = 0
+
+    await drive().agentEnd()
+
+    const call = hoisted.execCalls.at(-1)
+    expect(call?.file).toMatch(/System32[\\/]WindowsPowerShell[\\/]v1\.0[\\/]powershell\.exe$/)
+    expect(call?.args.join(' ')).toContain('Windows.UI.Notifications')
   })
 
   it('stays silent for a quick turn right after the user submitted (they are present)', async () => {

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -620,6 +620,10 @@ describe('plan mode call-time enforcement', () => {
   })
 })
 
+/** The execution-context text a before_agent_start injection carries, or undefined when
+ * the handler injected nothing (execution has ended). */
+const executionContext = (result: unknown): string | undefined => (result as { message?: { customType?: string; content?: string } } | undefined)?.message?.content
+
 describe('execution mode stall exit', () => {
   it('ends execution after two runs without step progress, listing what is left', async () => {
     const s = setup()
@@ -629,11 +633,14 @@ describe('execution mode stall exit', () => {
 
     await s.emit('turn_end', { message: assistant('finished [DONE:1]') })
     await s.emit('agent_end', { messages: [] })
-    expect(await s.emit('before_agent_start')).toBeDefined()
+    // The injection is what keeps execution going, so assert what it says: the step just
+    // marked done is gone from it and the remaining one is named.
+    expect(executionContext(await s.emit('before_agent_start'))).toContain('2. Second step')
+    expect(executionContext(await s.emit('before_agent_start'))).not.toContain('1. First step')
 
     await s.emit('turn_end', { message: assistant('did more work, forgot the marker') })
     await s.emit('agent_end', { messages: [] })
-    expect(await s.emit('before_agent_start')).toBeDefined()
+    expect(executionContext(await s.emit('before_agent_start'))).toContain('2. Second step')
 
     await s.emit('turn_end', { message: assistant('answered an unrelated question') })
     await s.emit('agent_end', { messages: [] })

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -64,6 +64,24 @@ describe('pluginComponentPath', () => {
   })
 })
 
+describe('substitutePluginVars escaping', () => {
+  it('escapes a backslash-bearing plugin root so the hooks JSON still parses', () => {
+    // The real case is a Windows root such as C:\Users\me\1.0.0\uv: substituted verbatim
+    // into raw JSON it injects invalid escape sequences, the parse throws, and every hook
+    // the plugin declared silently vanishes. The caller passes a JSON escaper for exactly
+    // this, and the rule is testable on any platform, unlike a directory whose name
+    // contains a backslash, which Windows cannot create.
+    const jsonEscape = (value: string): string => JSON.stringify(value).slice(1, -1)
+    const root = String.raw`C:\Users\me\1.0.0\uv`
+    const raw = JSON.stringify({ hooks: { PostToolUse: [{ matcher: 'Write', hooks: [{ command: '${CLAUDE_PLUGIN_ROOT}/scripts/format.sh' }] }] } })
+
+    const substituted = substitutePluginVars(raw, { name: 'fmt', root, dataDir: '/d', manifest: {} }, jsonEscape)
+
+    const parsed = JSON.parse(substituted) as { hooks: { PostToolUse: Array<{ hooks: Array<{ command: string }> }> } }
+    expect(parsed.hooks.PostToolUse[0].hooks[0].command).toBe(`${root}/scripts/format.sh`)
+  })
+})
+
 describe('installedPlugins', () => {
   it('loads an enabled cached plugin with its root and data dir', () => {
     const h = home()

--- a/tests/project-approval.test.ts
+++ b/tests/project-approval.test.ts
@@ -224,9 +224,11 @@ describe('runtime version guard for a missing isProjectTrusted callback', () => 
     expect(notify).not.toHaveBeenCalled()
   })
 
-  it('does not throw on a headless runtime that is too old and has no ui to warn through', async () => {
+  it('reads a runtime too old for project trust as unapproved, without a ui to warn through', async () => {
+    // Fail closed: a runtime that cannot report trust has not approved anything, and the
+    // silent variant has no ui to explain itself with.
     const { isProjectApprovedSilently } = await freshApproval()
-    expect(() => isProjectApprovedSilently({ cwd: '/repo' }, deps())).not.toThrow()
+    expect(isProjectApprovedSilently({ cwd: '/repo' }, deps())).toBe(false)
   })
 
   it('does not warn when a modern runtime reports the project untrusted', async () => {

--- a/tests/shell-resolve.test.ts
+++ b/tests/shell-resolve.test.ts
@@ -72,8 +72,9 @@ describe('resolveGitBash', () => {
     expect(resolveGitBash({ PATH: cwd }, cwd, [])).toBeUndefined()
   })
 
-  // Real-host oracle: the windows-latest runners install Git for Windows in the default
-  // location, which is the first rule after the override.
+  // The Windows half of the default-install rule, whose POSIX half is the injected-roots
+  // test above: this asserts the real lookup on a host that actually has Git for Windows,
+  // which the runners do.
   it.skipIf(process.platform !== 'win32')('finds Git for Windows in its default install directory on this host', () => {
     expect(resolveGitBash({ PATH: '' }, tempDir())).toMatch(/\\Git\\bin\\bash\.exe$/)
   })

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -583,10 +583,18 @@ describe('startBackgroundRun', () => {
   it('survives a pipe error on the child stdout', async () => {
     // EventEmitter rethrows an 'error' with no listener, and this stream belongs to a
     // detached child, so the throw exits pi exactly as an unguarded completion would.
-    const { startBackgroundRun } = await loadBackground()
-    startBackgroundRun('scout', 'survey', invocation, () => {})
+    const { startBackgroundRun, backgroundRun } = await loadBackground()
+    let finished: { state: string } | undefined
+    const id = startBackgroundRun('scout', 'survey', invocation, (run) => {
+      finished = { state: run.state }
+    }) as string
 
-    expect(() => spawned.children[0].stdout.emit('error', new Error('EPIPE'))).not.toThrow()
+    spawned.children[0].stdout.emit('error', new Error('EPIPE'))
+
+    // The run is untouched by the broken pipe and still completes on close.
+    expect(backgroundRun(id)?.state).toBe('running')
+    spawned.children[0].emit('close', 0)
+    expect(finished).toEqual({ state: 'done' })
   })
 
   it('returns a bg- prefixed id built from a uuid prefix', async () => {

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -1054,8 +1054,8 @@ describe('session_shutdown background runs', () => {
 
 describe('viewer commands', () => {
   it('registers /tasks and /agents with descriptions', () => {
-    expect(command('tasks').description).toBeTruthy()
-    expect(command('agents').description).toBeTruthy()
+    expect(command('tasks').description).toBe('Show background subagent runs')
+    expect(command('agents').description).toBe('List discovered subagents and where they come from')
   })
 
   it('/tasks notes the empty registry without running anything', async () => {

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -6,7 +6,7 @@ import type { AgentToolResult } from '@earendil-works/pi-agent-core'
 import { DEFAULT_MAX_LINES } from '@earendil-works/pi-coding-agent'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { hasAgentRunner, runAgent, setAgentRunner } from '../extensions/internal/agent-run.ts'
-import subagentExtension, { AGENT_HOOK_SYSTEM, agentMemoryDir, agentMemorySection, agentsListText, buildHookAgent, getPiInvocation, tasksStatusText, withMemoryTools } from '../extensions/subagent/index.ts'
+import subagentExtension, { AGENT_HOOK_SYSTEM, agentMemoryDir, agentMemorySection, agentsListText, buildHookAgent, getPiInvocation, setKnownMcpAliases, tasksStatusText, withMemoryTools } from '../extensions/subagent/index.ts'
 
 // The agent-memory tests read settings and stores under the home directory; point
 // homedir at a throwaway dir so the developer's real ~/.claude cannot influence them.
@@ -212,6 +212,9 @@ const results = (result: ToolResult): ResultShape[] => {
 let execute: Execute
 
 beforeEach(() => {
+  // The alias roster is module state that a bus event fills; clearing it keeps a test
+  // that publishes MCP tools from reaching whatever runs next under shuffle.
+  setKnownMcpAliases([])
   spawnCalls = []
   spawnedChildren = []
   scripts = new Map()

--- a/tests/todo-more.test.ts
+++ b/tests/todo-more.test.ts
@@ -723,6 +723,9 @@ describe('replay with a failed todo call', () => {
     // pi persists a rejected or blocked call as details: {}, which is truthy; the
     // list must survive it rather than the replay throwing for the rest of the session.
     const entries = [resultEntry([{ id: 1, text: 'kept', done: false }], 2), { type: 'message', message: { role: 'toolResult', toolName: 'todo', details: {} } }]
-    await expect(h.fire('session_start', {}, branchCtx(entries as never, fakeUI()))).resolves.not.toThrow()
+    await h.fire('session_start', {}, branchCtx(entries as never, fakeUI()))
+
+    // The errored result must neither throw nor wipe the list it followed.
+    expect((await h.call({ action: 'list' })).content[0].text).toBe('[ ] #1: kept')
   })
 })


### PR DESCRIPTION
From the round 4 test-quality and error-handling findings. Most of this is test work; four changes alter behavior by reporting a failure that was silent.

**Tests that asserted nothing in particular.** Nine assertions checked that a call returned or did not throw, which holds however the behavior changes. Each now asserts the outcome that matters: the execution-mode injection names the remaining step and drops the finished one; a runtime too old for project trust reads as unapproved; an errored todo result leaves the replayed list intact; the Windows toast runs PowerShell by absolute System32 path; a hook child inherits the parent PATH; a broken child pipe leaves the run completing normally; a sweep of a missing root creates nothing; the two viewer commands carry their real descriptions; and the clean OAuth retry returns the client it connected after exactly one connect. Each was checked by breaking the behavior it names.

**Three hook tests now run on Windows.** The exec-form pair spawns node instead of `/bin/echo`, and the timeout test needs no skip since the shell path resolves Git Bash there. The one remaining skip in that file is genuine: process groups and negative-pid probes are POSIX semantics.

**Coverage.** The no-shell fallback for an MCP headers helper, the one branch of the Windows shell work no test reached, although it decides whether such a host connects at all.

**Module state.** The MCP alias roster and the interactive-login queue outlived the tests that filled them, so under shuffled order one test's published tools, or a login it left pending, reached whatever ran next in the same file.

**Silent failures now reported.** An unreadable settings file was treated exactly like a missing one on two guard paths, and the failure modes run the dangerous way: an MCP deny list silently dropped leaves every server allowed, and a lost `disableSkillShellExecution` leaves skill shells running. A failure to mirror `.git/info/exclude` into the checkpoint shadow silently returned to snapshotting the files that mirror exists to keep out. All three now name the file or the reason; a genuinely missing file stays silent.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change
