### PR TITLE
Report nine failures that silently disabled something

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -325,7 +325,11 @@ export default function commandsExtension(pi: ExtensionAPI) {
     // escape as unhandled; surface it as a no-op instead of leaving the session silently
     // on the command's override model.
     set: (model) => {
-      void pi.setModel(model as Parameters<typeof pi.setModel>[0]).catch(() => {})
+      // A refused switch leaves the turn on the session model rather than the one the
+      // command named, and the reply gives no sign of it, so the refusal is reported.
+      void pi.setModel(model as Parameters<typeof pi.setModel>[0]).catch((error: unknown) => {
+        console.warn(`pi-code-commands: could not switch to ${typeof model === 'object' && model !== null && 'id' in model ? String((model as { id: unknown }).id) : String(model)}: ${error instanceof Error ? error.message : String(error)}`)
+      })
     },
   })
   /** The thinking level to restore after a command's `effort:` override drove its run,
@@ -505,8 +509,12 @@ export default function commandsExtension(pi: ExtensionAPI) {
       let parsed: ParsedCommand
       try {
         parsed = parseCommandFile(fs.readFileSync(command.filePath, 'utf-8'))
-      } catch {
-        continue // an unreadable command file must not take down session start
+      } catch (error) {
+        // An unreadable file must not take down session start, but the command is then
+        // absent from /help and unresolvable by the model, which looks like one that was
+        // never written.
+        console.warn(`pi-code-commands: ignoring ${command.filePath}: ${error instanceof Error ? error.message : String(error)}`)
+        continue
       }
       discovered.set(command.name, command)
       // A user-only command stays off the tool description; it is still in the

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -200,7 +200,10 @@ function mergeHooksJson(config: HooksConfig, raw: string, source: string, source
   let parsed: { hooks?: HooksConfig }
   try {
     parsed = JSON.parse(raw)
-  } catch {
+  } catch (error) {
+    // Every hook this source declares is now absent, a policy hook among them, so the
+    // failure is named rather than left to look like a file with no hooks in it.
+    console.warn(`pi-code-hooks: ignoring the hooks in ${source}: ${error instanceof Error ? error.message : String(error)}`)
     return
   }
   for (const [event, matchers] of Object.entries(parsed?.hooks ?? {})) {

--- a/extensions/hooks/matcher.ts
+++ b/extensions/hooks/matcher.ts
@@ -59,8 +59,10 @@ function compileMatcher(matcher: string): CompiledMatcher {
   } else {
     try {
       compiled = { regex: new RegExp(matcher, 'i') }
-    } catch {
-      // An invalid regex matcher falls back to exact-name matching, as before.
+    } catch (error) {
+      // The fallback matches the literal text, which almost never matches a tool name, so
+      // the hook simply never fires. Say so: the matcher reads as merely wrong otherwise.
+      console.warn(`pi-code-hooks: matcher ${matcher} is not a valid regular expression (${error instanceof Error ? error.message : String(error)}); it will only match a tool of that exact name`)
       compiled = { tokens: exactTokens(matcher) }
     }
   }

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -31,10 +31,19 @@ export interface InstalledPlugin {
 }
 
 function readJson(file: string): Record<string, unknown> {
+  let raw: string
   try {
-    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'))
-    return parsed !== null && typeof parsed === 'object' ? parsed : {}
+    raw = fs.readFileSync(file, 'utf-8')
   } catch {
+    return {} // no such file: nothing to read, and most callers expect that
+  }
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed !== null && typeof parsed === 'object' ? parsed : {}
+  } catch (error) {
+    // A manifest that does not parse leaves the plugin with no components at all, and
+    // settings that do not parse drop the enablement or configuration they carried.
+    console.warn(`pi-code-plugins: ignoring ${file}: ${error instanceof Error ? error.message : String(error)}`)
     return {}
   }
 }

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -345,8 +345,20 @@ export function runHeadersHelper(command: string, env: NodeJS.ProcessEnv, resolv
       resolve({})
       return
     }
+    const server = env.CLAUDE_CODE_MCP_SERVER_NAME ?? 'the server'
     execFile(shell.file, shell.argsFor(command), { timeout: 10_000, env }, (error, stdout) => {
-      resolve(error ? {} : parseHelperHeaders(stdout))
+      if (error) {
+        // The connect proceeds unauthenticated and the server answers 401, which reads as
+        // a login problem rather than a helper that never produced a header.
+        console.warn(`pi-code-mcp: the headersHelper for ${server} failed: ${error.message}; connecting without the headers it would have supplied`)
+        resolve({})
+        return
+      }
+      const headers = parseHelperHeaders(stdout)
+      if (Object.keys(headers).length === 0 && stdout.trim().length > 0) {
+        console.warn(`pi-code-mcp: the headersHelper for ${server} produced no usable headers; it must print a JSON object of header names to string values`)
+      }
+      resolve(headers)
     })
   })
 }

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -149,8 +149,10 @@ export function migrateLegacyStore(cwd: string): void {
     if (legacy === current || !fs.existsSync(legacy)) continue
     try {
       fs.renameSync(legacy, current)
-    } catch {
-      // A failed migration must not take down session start; the store stays put.
+    } catch (error) {
+      // A failed migration must not take down session start, but the session then has no
+      // memories while they sit under the old slug, which reads as having lost them.
+      console.warn(`pi-code-memory: could not move ${legacy} to ${current}: ${error instanceof Error ? error.message : String(error)}; this session starts without those memories`)
     }
     return
   }
@@ -230,7 +232,12 @@ function readMemory(dir: string, name: string): MemoryToolResult {
   try {
     const body = fs.readFileSync(path.join(dir, `${name}.md`), 'utf-8')
     return { content: [{ type: 'text', text: capForContext(body) }], details: {} }
-  } catch {
+  } catch (error) {
+    // Only a missing file is "no such memory"; anything else (a directory in its place, a
+    // permission problem) sends the model hunting for a name that is actually there.
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      return { content: [{ type: 'text', text: `Memory ${name} could not be read: ${error instanceof Error ? error.message : String(error)}` }], details: {} }
+    }
     return { content: [{ type: 'text', text: `No memory named ${name}.` }], details: {} }
   }
 }

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -177,8 +177,11 @@ function parseAgentFile(content: string, source: AgentSource, filePath: string, 
   let parsed: { frontmatter: Record<string, unknown>; body: string }
   try {
     parsed = parseFrontmatter<Record<string, unknown>>(content)
-  } catch {
-    return null // malformed YAML must not abort discovery for the whole directory
+  } catch (error) {
+    // Malformed YAML must not abort discovery for the whole directory, but a silent drop
+    // reads as "that agent does not exist", so it is named like the other rejections here.
+    console.warn(`pi-code-subagent: ignoring agent ${filePath}: its frontmatter could not be parsed (${error instanceof Error ? error.message : String(error)})`)
+    return null
   }
   const { frontmatter, body } = parsed
   const name = agentName(frontmatter, filePath, pluginName)

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -204,7 +204,7 @@ export function resumeBackgroundRun(id: string, task: string, onComplete: (run: 
   if (!fs.existsSync(run.spawn.cwd)) return 'cwd-gone'
   // Persisted so the rebuild happens once: rebuilding per resume leaked one temp
   // prompt dir every follow-up.
-  const rebuilt = withRebuiltPrompt(run.spawn)
+  const rebuilt = withRebuiltPrompt(run.spawn, run.agent)
   run.spawn = { ...run.spawn, args: rebuilt.args }
   if (rebuilt.dir) run.rebuiltPromptDir = rebuilt.dir
   // The task prompt is always the final argument: both spawn paths push it last and the
@@ -228,7 +228,7 @@ export function resumeBackgroundRun(id: string, task: string, onComplete: (run: 
 
 /** Re-point --system-prompt at a fresh file when the original is gone; `dir` is the
  * temp dir created for it, which the run then owns. */
-function withRebuiltPrompt(spawnSpec: BackgroundSpawn): { args: string[]; dir?: string } {
+function withRebuiltPrompt(spawnSpec: BackgroundSpawn, agent: string): { args: string[]; dir?: string } {
   const flag = spawnSpec.args.indexOf('--system-prompt')
   if (flag === -1 || !spawnSpec.promptBody) return { args: spawnSpec.args }
   const current = spawnSpec.args[flag + 1]
@@ -240,9 +240,12 @@ function withRebuiltPrompt(spawnSpec: BackgroundSpawn): { args: string[]; dir?: 
     const rebuilt = [...spawnSpec.args]
     rebuilt[flag + 1] = file
     return { args: rebuilt, dir }
-  } catch {
+  } catch (error) {
     // Cannot rewrite it: drop the pair rather than hand pi a path it will treat as
-    // prompt text, which would replace the agent persona with a temp path.
+    // prompt text, which would replace the agent persona with a temp path. The child then
+    // runs as a plain assistant instead of the agent asked for, and nothing in its output
+    // says so, hence the notice.
+    console.warn(`pi-code-subagent: resuming ${agent} without its agent prompt: ${error instanceof Error ? error.message : String(error)}`)
     return { args: spawnSpec.args.filter((_arg, i) => i !== flag && i !== flag + 1) }
   }
 }

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -274,6 +274,36 @@ describe('background run lifecycle', () => {
     cancelAllBackgroundRuns()
 
     expect(existsSync(promptDir)).toBe(false)
+  })
+
+  it('reports a resume that cannot rebuild the agent prompt', () => {
+    // Dropping --system-prompt is the safe fallback, but it means the resumed child runs
+    // as a plain assistant instead of the agent the user asked for. That difference is
+    // invisible in the output, so it is stated.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const id = startBackgroundRun('scout', 'one', spec({ args: ['--system-prompt', '/gone/prompt.md', 'Task: one'], promptBody: 'PERSONA' }), () => {})
+      children.at(-1)?.emit('close', 0)
+
+      // Only the rebuild is blocked: a temp dir cannot be created under a file. The run's
+      // own working directory stays valid, or the resume would refuse for that instead.
+      const blocked = join(tmpdir(), `pi-blocked-${process.pid}`)
+      writeFileSync(blocked, 'not a directory')
+      const saved = process.env.TMPDIR
+      process.env.TMPDIR = join(blocked, 'nested')
+      try {
+        expect(resumeBackgroundRun(id ?? '', 'two', () => {})).toBe('resumed')
+      } finally {
+        if (saved === undefined) delete process.env.TMPDIR
+        else process.env.TMPDIR = saved
+      }
+
+      const args = spawnMock.mock.calls.at(-1)?.[1] as string[]
+      expect(args).not.toContain('--system-prompt')
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('scout'))
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   it('rebuilds the prompt file once and reuses it across resumes', () => {

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -289,13 +289,17 @@ describe('background run lifecycle', () => {
       // own working directory stays valid, or the resume would refuse for that instead.
       const blocked = join(tmpdir(), `pi-blocked-${process.pid}`)
       writeFileSync(blocked, 'not a directory')
-      const saved = process.env.TMPDIR
-      process.env.TMPDIR = join(blocked, 'nested')
+      // os.tmpdir() reads TMPDIR on POSIX and TEMP or TMP on Windows, so all three move.
+      const tempVars = ['TMPDIR', 'TEMP', 'TMP'] as const
+      const saved = tempVars.map((name) => [name, process.env[name]] as const)
+      for (const name of tempVars) process.env[name] = join(blocked, 'nested')
       try {
         expect(resumeBackgroundRun(id ?? '', 'two', () => {})).toBe('resumed')
       } finally {
-        if (saved === undefined) delete process.env.TMPDIR
-        else process.env.TMPDIR = saved
+        for (const [name, value] of saved) {
+          if (value === undefined) delete process.env[name]
+          else process.env[name] = value
+        }
       }
 
       const args = spawnMock.mock.calls.at(-1)?.[1] as string[]

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -112,6 +112,7 @@ const setup = (cwd: string, trusted = true) => {
   const notices: string[] = []
   const execCalls: Array<{ file: string; args: string[]; shell: string; timeout?: number; env?: Record<string, string> }> = []
   const execResult = { stderr: '', code: 0, killed: false }
+  let setModelRejection: string | undefined
   let active = ['bash', 'read', 'edit', 'write']
   const pi = {
     on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn),
@@ -132,6 +133,7 @@ const setup = (cwd: string, trusted = true) => {
     },
     setModel: async (model: { id: string }) => {
       modelSets.push(model.id)
+      if (setModelRejection) throw new Error(setModelRejection)
       return true
     },
     setThinkingLevel: (level: string) => {
@@ -180,6 +182,9 @@ const setup = (cwd: string, trusted = true) => {
       idle = value
     },
     failExec: (result: { stderr: string; code: number; killed?: boolean }) => Object.assign(execResult, result),
+    rejectSetModel: (message: string) => {
+      setModelRejection = message
+    },
   }
 }
 
@@ -702,6 +707,44 @@ it('substitutes CLAUDE_EFFORT in Claude vocabulary, and leaves it unset when thi
 
   await s.commands.get('e')?.handler('', { ...s.ctx, thinkingLevel: 'off' })
   expect(s.sent.at(-1)).toBe('effort: ${CLAUDE_EFFORT}')
+})
+
+it('reports a command file it cannot read instead of leaving the command missing', async () => {
+  // The command simply is not there afterwards: not in /help, not resolvable by the
+  // model, with nothing to distinguish it from a file that was never written.
+  const cwd = tempDir()
+  // Frontmatter the YAML parser rejects: the file is found, then fails to parse.
+  writeCommand(cwd, 'broken.md', '---\nallowed-tools: [unclosed\n---\nbody')
+  const s = setup(cwd)
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  try {
+    await s.handlers.get('session_start')?.({}, s.ctx)
+
+    expect(s.commands.has('broken')).toBe(false)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('broken.md'))
+  } finally {
+    warn.mockRestore()
+  }
+})
+
+it('reports a model restore the runtime refused, which would strand the session', async () => {
+  // A command's model: override lasts one run and is put back when the run settles. A
+  // refused restore leaves the session on the command's model with nothing said.
+  const cwd = tempDir()
+  writeCommand(cwd, 'm.md', '---\nmodel: opus\n---\nDo it.')
+  const s = setup(cwd)
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  try {
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('m')?.handler('', s.ctx)
+    s.rejectSetModel('model is gone')
+    await s.handlers.get('agent_settled')?.({}, s.ctx)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('model is gone'))
+  } finally {
+    warn.mockRestore()
+  }
 })
 
 describe('shell frontmatter', () => {

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -1151,6 +1151,24 @@ describe('hooks extension notify-style events', () => {
     return ext
   }
 
+  it('reports a settings file whose hooks cannot be parsed instead of dropping them silently', async () => {
+    // Every hook the file declares vanishes on a parse failure, including a policy hook
+    // the user believes is gating their tools, so the failure has to be visible.
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), '{"hooks": {"PreToolUse": [{"hooks": [{"command": "guard"}]}]},}')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const ext = setupExtension()
+      await ext.sessionStart('startup', { cwd: tempDir('hooks-proj-') })
+      await ext.toolCall('bash', {})
+
+      expect(commandsRun()).toEqual([])
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('settings.json'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it('runs an enabled plugin hook with its plugin root substituted', async () => {
     const root = join(hoisted.home, '.claude', 'plugins', 'cache', 'market', 'fmt', '1.0.0')
     mkdirSync(join(root, 'hooks'), { recursive: true })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -417,6 +417,20 @@ describe('formatHooksSummary', () => {
 })
 
 describe('matchingCommands', () => {
+  it('reports a matcher whose regex does not compile instead of quietly matching by name', () => {
+    // The fallback matches the literal text, which almost never matches a tool name, so
+    // the hook silently never fires and its matcher reads as merely wrong, not broken.
+    resetMatcherCache()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const broken = { matcher: 'Bash(', hooks: [{ command: 'guard.sh' }] } as never
+      expect(matchingCommands([broken], 'bash')).toEqual([])
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Bash('))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   const bashHook = { matcher: 'Bash', hooks: [{ command: 'guard.sh' }] }
 
   it('matches a Claude PascalCase matcher against a lowercase pi tool name', () => {

--- a/tests/mcp-transient.test.ts
+++ b/tests/mcp-transient.test.ts
@@ -1,6 +1,6 @@
 import { createServer } from 'node:net'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { isTransientConnectError } from '../extensions/mcp/transport.ts'
 
@@ -53,5 +53,38 @@ describe('runHeadersHelper', () => {
 
     // The server still connects, with whatever static headers it was configured with.
     expect(headers).toEqual({})
+  })
+})
+
+describe('runHeadersHelper failure reporting', () => {
+  // A helper is how a server gets its Authorization when there is no OAuth. Silence here
+  // means the connect proceeds unauthenticated and the server answers 401, which the user
+  // then sees as a login problem rather than a broken helper.
+  const nodeShell = () => ({ kind: 'bash' as const, file: process.execPath, argsFor: (command: string) => ['-e', command] })
+
+  it('reports a helper that exits non-zero', async () => {
+    const { runHeadersHelper } = await import('../extensions/mcp/transport.ts')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const headers = await runHeadersHelper('process.exit(3)', { CLAUDE_CODE_MCP_SERVER_NAME: 'vault' }, nodeShell)
+
+      expect(headers).toEqual({})
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('vault'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('reports a helper whose output is not usable as headers', async () => {
+    const { runHeadersHelper } = await import('../extensions/mcp/transport.ts')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const headers = await runHeadersHelper('process.stdout.write("not json")', { CLAUDE_CODE_MCP_SERVER_NAME: 'vault' }, nodeShell)
+
+      expect(headers).toEqual({})
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('vault'))
+    } finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/tests/memory-actions.test.ts
+++ b/tests/memory-actions.test.ts
@@ -119,6 +119,21 @@ describe('memory index robustness', () => {
 
   const start = async (handlers: Map<string, Handler>, cwd: string) => handlers.get('session_start')?.({}, { cwd, ui: { notify: () => {} } })
 
+  it('distinguishes a memory that cannot be read from one that does not exist', async () => {
+    // "No memory named x" sends the model hunting for a different name. A read that failed
+    // for another reason, a directory in its place or a permission problem, is a different
+    // situation, and the reply now says which one happened.
+    const { handlers, tool, cwd, dir } = setup()
+    await start(handlers, cwd)
+    mkdirSync(join(dir, 'blocked.md'), { recursive: true })
+
+    const absent = (await tool.execute('1', { action: 'read', name: 'absent' })).content[0].text
+    const blocked = (await tool.execute('2', { action: 'read', name: 'blocked' })).content[0].text
+
+    expect(absent).toBe('No memory named absent.')
+    expect(blocked).toContain('could not be read')
+  })
+
   it('refuses to save while the index is unreadable instead of clobbering it', async () => {
     const { handlers, tool, cwd, dir } = setup()
     await start(handlers, cwd)

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -14,7 +14,7 @@ vi.mock('node:os', async (importOriginal) => {
 // Records every readFileSync path (so the index-cache test can count index reads) and
 // every renameSync (so the atomic-write tests can assert a temp file was renamed onto
 // the target). The builtin namespace is not spyable either, so the module is wrapped like os.
-const fsHoisted = vi.hoisted(() => ({ reads: [] as string[], renames: [] as Array<[string, string]> }))
+const fsHoisted = vi.hoisted(() => ({ reads: [] as string[], renames: [] as Array<[string, string]>, renameError: undefined as string | undefined }))
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>()
   const readFileSync = ((...args: Parameters<typeof actual.readFileSync>) => {
@@ -23,6 +23,9 @@ vi.mock('node:fs', async (importOriginal) => {
   }) as typeof actual.readFileSync
   const renameSync = ((...args: Parameters<typeof actual.renameSync>) => {
     fsHoisted.renames.push([String(args[0]), String(args[1])])
+    // A store move can fail for reasons no fixture reproduces portably (a cross-device
+    // rename, a permission problem), so the failure is injected here.
+    if (fsHoisted.renameError) throw new Error(fsHoisted.renameError)
     return actual.renameSync(...args)
   }) as typeof actual.renameSync
   return { ...actual, readFileSync, renameSync }
@@ -446,6 +449,29 @@ describe('memory extension', () => {
 })
 
 describe('migrateLegacyStore', () => {
+  it('reports a store it could not migrate rather than starting empty in silence', () => {
+    // The session then has no memories while they sit under the old slug, which reads as
+    // having lost them.
+    const home = mkdtempSync(join(tmpdir(), 'mem-home-'))
+    hoisted.home = home
+    const cwd = '/proj/blocked'
+    const legacy = join(home, '.pi', 'agent', 'memory', '-proj-blocked')
+    mkdirSync(legacy, { recursive: true })
+    writeFileSync(join(legacy, 'MEMORY.md'), '- [a](a.md): kept\n')
+    fsHoisted.renameError = 'EXDEV: cross-device link not permitted'
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      migrateLegacyStore(cwd)
+
+      expect(existsSync(legacy)).toBe(true)
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(legacy))
+    } finally {
+      fsHoisted.renameError = undefined
+      warn.mockRestore()
+    }
+  })
+
   it('renames a pre-digest store to the current slug, once, without clobbering', () => {
     const home = mkdtempSync(join(tmpdir(), 'mem-home-'))
     hoisted.home = home

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -200,6 +200,29 @@ describe('installedPlugins', () => {
   })
 })
 
+describe('installedPlugins manifest failures', () => {
+  it('reports a plugin manifest it cannot parse instead of dropping the plugin', () => {
+    // Without the manifest the plugin has no components at all: no commands, agents,
+    // skills, hooks or MCP servers, and nothing says why it stopped working.
+    const home = mkdtempSync(join(tmpdir(), 'plug-home-'))
+    const root = join(home, '.claude', 'plugins', 'cache', 'market', 'broken', '1.0.0')
+    mkdirSync(join(root, '.claude-plugin'), { recursive: true })
+    writeFileSync(join(root, '.claude-plugin', 'plugin.json'), '{"name": "broken",}')
+    mkdirSync(join(home, '.claude'), { recursive: true })
+    writeFileSync(join(home, '.claude', 'settings.json'), JSON.stringify({ enabledPlugins: { broken: true } }))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      resetInstalledPluginsCache()
+      installedPlugins(home)
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('plugin.json'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})
+
 describe('installedPlugins cache', () => {
   it('serves a repeat call without re-reading settings or manifests', () => {
     const h = home()

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -303,12 +303,19 @@ describe('discoverAgents', () => {
     expect(nonBuiltin(discoverAgents(cwd, 'user').agents)[0].tools).toEqual(['read', 'find'])
   })
 
-  it('skips a file with malformed YAML frontmatter instead of aborting discovery', () => {
+  it('skips a file with malformed YAML frontmatter instead of aborting discovery, and says which', () => {
     mkdirSync(piUserDir, { recursive: true })
     writeFileSync(join(piUserDir, 'broken-yaml.md'), '---\nname: [unclosed\ndescription: d\n---\nprompt')
     writeAgent(piUserDir, 'fine2.md', { name: 'fine2', description: 'ok' })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['fine2'])
+    try {
+      expect(names(discoverAgents(cwd, 'user').agents)).toEqual(['fine2'])
+      // Silence here reads as "I never wrote that agent" rather than "it is broken".
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('broken-yaml.md'))
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   it('skips an agent whose tools field is unusable instead of aborting discovery', () => {


### PR DESCRIPTION
Each of these caught an error and carried on, leaving the session looking normal while something the user configured had stopped working. None changes what happens; each says what happened.

- **Hook settings that fail to parse.** Every hook that file declared was absent for the session, and the file read like one that simply declares none.
- **A hook matcher whose regex does not compile.** The fallback matches the literal matcher text, which almost never equals a tool name, so the hook silently never fired.
- **A resume that cannot rebuild the agent's prompt.** Dropping the prompt is the safe choice, but the child then runs as a plain assistant rather than the agent asked for, and its output gives no sign.
- **An agent file with unparseable frontmatter.** Every sibling rejection in that parser already explained itself; this one left the agent simply missing from `/agents`.
- **An unreadable command file**, absent from `/help` and unresolvable by the model, indistinguishable from one never written.
- **A refused model restore.** A command's `model:` override lasts one run; a refused restore silently left the session on the command's model.
- **A memory that cannot be read.** Any failure answered "No memory named x", sending the model hunting for a name that is actually there. Only a missing file says that now.
- **A memory store that cannot be migrated.** The session had no memories while they sat under the old slug, with nothing to distinguish it from having none.
- **An MCP headers helper that fails or produces nothing usable.** The connect proceeded unauthenticated and the server answered 401, which reads as a login problem rather than a broken helper.
- **A plugin manifest that cannot be parsed.** The plugin loses every component at once: no commands, agents, skills, hooks or MCP servers.

In each case a genuinely missing file stays silent, since that is not a failure. Two tests needed injected failures rather than fixtures: a cross-device rename and a helper exit code have no portable filesystem equivalent.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change
