### PR TITLE
Refuse a PowerShell planted in the project, as the Git Bash lookup already does

### DIFF
--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -107,10 +107,17 @@ function bracketClass(body: string): string | null {
   // unterminated `[` already is: the pattern is invalid and matches nothing. Without
   // this the throw escaped compileGlobs, which does not catch, and took the permission
   // check that called it with it.
+  return isBuildableClass(source) ? source : null
+}
+
+/** Whether JavaScript will build this character class. Asking RegExp is the only
+ * faithful test: the invalid forms are its rules, not ones worth re-deriving here. */
+function isBuildableClass(source: string): boolean {
   try {
-    return new RegExp(source) && source
+    new RegExp(source)
+    return true
   } catch {
-    return null
+    return false
   }
 }
 

--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -96,10 +96,23 @@ function bracketEnd(pattern: string, start: number): number {
 
 /** A bracket expression body as a regex character class, escaping regex-relevant
  * characters while keeping `-` ranges; a leading `!` (or `^`) negates. */
-function bracketClass(body: string): string {
+function bracketClass(body: string): string | null {
   const negated = body.startsWith('!') || body.startsWith('^')
   const members = (negated ? body.slice(1) : body).replace(/[\\\]^]/g, (ch) => `\\${ch}`)
-  return `[${negated ? '^' : ''}${members}]`
+  const source = `[${negated ? '^' : ''}${members}]`
+  // A range whose endpoints descend, `["- ]` for instance, is not a character class
+  // JavaScript will build: RegExp throws "Range out of order in character class". The
+  // `-` cannot simply be escaped, since `[a-z]` is the whole point of the syntax, so the
+  // class is validated by construction and an unbuildable one is treated exactly as an
+  // unterminated `[` already is: the pattern is invalid and matches nothing. Without
+  // this the throw escaped compileGlobs, which does not catch, and took the permission
+  // check that called it with it.
+  try {
+    void new RegExp(source)
+  } catch {
+    return null
+  }
+  return source
 }
 
 /** A `*` run starting at `i`: a double star followed by a slash spans whole
@@ -130,7 +143,9 @@ function translateGlob(pattern: string): string | null {
     if (ch === '[') {
       const end = bracketEnd(pattern, i)
       if (end === -1) return null
-      out += bracketClass(pattern.slice(i + 1, end))
+      const cls = bracketClass(pattern.slice(i + 1, end))
+      if (cls === null) return null
+      out += cls
       i = end + 1
       continue
     }

--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -108,11 +108,10 @@ function bracketClass(body: string): string | null {
   // this the throw escaped compileGlobs, which does not catch, and took the permission
   // check that called it with it.
   try {
-    void new RegExp(source)
+    return new RegExp(source) && source
   } catch {
     return null
   }
-  return source
 }
 
 /** A `*` run starting at `i`: a double star followed by a slash spans whole
@@ -127,41 +126,33 @@ function translateStar(pattern: string, i: number): { source: string; next: numb
   return { source: '[^/]*', next: i + 1 }
 }
 
+/** The regex source for the construct at `i` and the index after it, or null when the
+ * pattern is invalid there and so matches nothing. */
+function translateAt(pattern: string, i: number): { source: string; next: number } | null {
+  const ch = pattern[i]
+  // Claude: to match a literal bracket, escape it; the escape consumes both chars.
+  if (ch === '\\' && (pattern[i + 1] === '[' || pattern[i + 1] === ']')) return { source: escapeRegExp(pattern[i + 1]), next: i + 2 }
+  // Claude: `[` starts a bracket expression such as `[abc]`; a `[` that cannot be read
+  // as one, or a body that is not a buildable class, makes the pattern invalid.
+  if (ch === '[') {
+    const end = bracketEnd(pattern, i)
+    if (end === -1) return null
+    const cls = bracketClass(pattern.slice(i + 1, end))
+    return cls === null ? null : { source: cls, next: end + 1 }
+  }
+  if (ch === '*') return translateStar(pattern, i)
+  if (ch === '?') return { source: '[^/]', next: i + 1 }
+  return { source: escapeRegExp(ch), next: i + 1 }
+}
+
 function translateGlob(pattern: string): string | null {
   let out = ''
   let i = 0
   while (i < pattern.length) {
-    const ch = pattern[i]
-    // Claude: to match a literal bracket, escape it; the escape consumes both chars.
-    if (ch === '\\' && (pattern[i + 1] === '[' || pattern[i + 1] === ']')) {
-      out += escapeRegExp(pattern[i + 1])
-      i += 2
-      continue
-    }
-    // Claude: `[` starts a bracket expression such as `[abc]`; a `[` that cannot be
-    // read as one makes the pattern invalid, matching nothing.
-    if (ch === '[') {
-      const end = bracketEnd(pattern, i)
-      if (end === -1) return null
-      const cls = bracketClass(pattern.slice(i + 1, end))
-      if (cls === null) return null
-      out += cls
-      i = end + 1
-      continue
-    }
-    if (ch === '*') {
-      const star = translateStar(pattern, i)
-      out += star.source
-      i = star.next
-      continue
-    }
-    if (ch === '?') {
-      out += '[^/]'
-      i += 1
-      continue
-    }
-    out += escapeRegExp(ch)
-    i += 1
+    const step = translateAt(pattern, i)
+    if (step === null) return null
+    out += step.source
+    i = step.next
   }
   return out
 }

--- a/extensions/internal/shell-resolve.ts
+++ b/extensions/internal/shell-resolve.ts
@@ -37,11 +37,22 @@ const isFile = (file: string): boolean => {
  * Windows spellings on win32, where powershell.exe ships with the OS. */
 const powershellCandidates = (platform: string): string[] => (platform === 'win32' ? ['pwsh', 'pwsh.exe', 'powershell.exe'] : ['pwsh'])
 
-/** First PowerShell binary found on PATH, or undefined when none is installed. */
-export function resolvePowershellBinary(platform: string = process.platform, env: Record<string, string | undefined> = process.env): string | undefined {
-  const dirs = (env.PATH ?? '').split(path.delimiter).filter(Boolean)
+/** First PowerShell binary found on PATH, or undefined when none is installed.
+ *
+ * A PATH entry that is the launch directory, or project tooling below it, is skipped
+ * for the same reason resolveGitBash skips one: a repository that ships `pwsh.exe`
+ * must not become the shell its own hooks and spans run through. Go made this the
+ * default in 1.19 (`os/exec` refuses a program resolved "relative to the current
+ * directory", returning ErrDot), and Windows offers NoDefaultCurrentDirectoryInExePath
+ * for it; node honors neither (nodejs/node#46264), so the check belongs here. */
+export function resolvePowershellBinary(platform: string = process.platform, env: Record<string, string | undefined> = process.env, cwd: string = process.cwd()): string | undefined {
+  // `env.Path` as well as `env.PATH`, matching resolveGitBash: process.env is
+  // case-insensitive on Windows, but an env object handed in by a caller or a test is
+  // whatever spelling it was built with, and the two resolvers must read it alike.
+  const dirs = (env.PATH ?? env.Path ?? '').split(path.delimiter).filter(Boolean)
   for (const candidate of powershellCandidates(platform)) {
     for (const dir of dirs) {
+      if (isProjectTooling(dir, cwd)) continue
       const full = path.join(dir, candidate)
       try {
         fs.accessSync(full, fs.constants.X_OK)
@@ -111,11 +122,11 @@ const powershellShell = (file: string): ResolvedShell => ({
  */
 export function resolveShell(preferred: string | undefined, platform: string = process.platform, env: Record<string, string | undefined> = process.env, cwd: string = process.cwd(), installRoots?: string[]): ResolvedShell | undefined {
   if (preferred === 'powershell') {
-    const powershell = resolvePowershellBinary(platform, env)
+    const powershell = resolvePowershellBinary(platform, env, cwd)
     if (powershell) return powershellShell(powershell)
   }
   const bash = bashBinary(platform, env, cwd, installRoots)
   if (bash) return bashShell(bash)
-  const powershell = resolvePowershellBinary(platform, env)
+  const powershell = resolvePowershellBinary(platform, env, cwd)
   return powershell ? powershellShell(powershell) : undefined
 }

--- a/tests/path-rules.test.ts
+++ b/tests/path-rules.test.ts
@@ -167,3 +167,28 @@ describe('stripRuleDrive', () => {
     expect(stripRuleDrive('C:/Users/**', false)).toBe('C:/Users/**')
   })
 })
+
+describe('an unbuildable bracket expression', () => {
+  // Found by the property test on a random seed, so pinned deterministically here: a
+  // seeded property proves nothing about a specific input on the next run.
+  const anchors = { cwd: '/proj/sub', projectRoot: '/proj', home: '/home/u' }
+
+  it.each([
+    ['a descending range', '["- ]'],
+    ['a descending range among literals', 'a[z-a]b'],
+  ])('compiles %s to a pattern that matches nothing instead of throwing', (_label, pattern) => {
+    // compileGlobs constructs the RegExp with no try/catch, so a throw here escaped into
+    // whichever permission check was evaluating the rule.
+    expect(() => new RegExp(globToRegExpSource(pattern))).not.toThrow()
+    expect(globToRegExpSource(pattern)).toBe('(?!)')
+    expect(() => matchesPathRules('/proj/sub/anything', [pattern], anchors)).not.toThrow()
+    expect(matchesPathRules('/proj/sub/anything', [pattern], anchors)).toBe(false)
+  })
+
+  it('still builds an ordinary ascending range', () => {
+    // The guard's other failure mode: rejecting every bracket expression would also pass
+    // the cases above, and `[a-z]` is the syntax's whole point.
+    expect(matchesPathRules('/proj/sub/b.md', ['[a-z].md'], anchors)).toBe(true)
+    expect(matchesPathRules('/proj/sub/9.md', ['[a-z].md'], anchors)).toBe(false)
+  })
+})

--- a/tests/shell-resolve.test.ts
+++ b/tests/shell-resolve.test.ts
@@ -1,10 +1,10 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { delimiter, join } from 'node:path'
+import { delimiter, dirname, join } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { resolveGitBash, resolveShell, toPowershellPlaceholders } from '../extensions/internal/shell-resolve.ts'
+import { resolveGitBash, resolvePowershellBinary, resolveShell, toPowershellPlaceholders } from '../extensions/internal/shell-resolve.ts'
 
 const dirs: string[] = []
 afterEach(() => {
@@ -81,6 +81,104 @@ describe('resolveGitBash', () => {
 
   it('returns undefined when no git is on PATH', () => {
     expect(resolveGitBash({ PATH: tempDir() }, tempDir(), [])).toBeUndefined()
+  })
+})
+
+/**
+ * Oracle: the rule Go made its default in 1.19, and the one resolveGitBash already
+ * applied. `os/exec` refuses a program resolved through a path entry "relative to the
+ * current directory" (ErrDot); Windows exposes NoDefaultCurrentDirectoryInExePath for
+ * the same purpose. Node honors neither (nodejs/node#46264), so pi-code enforces it in
+ * the one place it resolves its own shells.
+ *
+ * Written a row per resolver rather than a suite per function, because the defect this
+ * pins was not a missing check but two resolvers DISAGREEING about it: Git Bash had the
+ * guard, PowerShell did not. A new resolver without a row here is a visible omission.
+ * (Visible, not mechanical: making it mechanical would need the module to export a
+ * registry of its resolvers, which is more machinery than two functions justify.)
+ */
+/** Both resolvers take the same shape of PATH entry, `<root>/cmd`: that is where Git for
+ * Windows puts git.exe, and it is an ordinary directory for a PowerShell. Each plant
+ * writes the binary ITS resolver looks for, so one table drives both. */
+const entryIn = (root: string): string => join(root, 'cmd')
+
+const plantGit = (entry: string): void => {
+  const root = dirname(entry)
+  mkdirSync(entry, { recursive: true })
+  mkdirSync(join(root, 'bin'), { recursive: true })
+  writeFileSync(join(entry, 'git.exe'), 'MZ')
+  writeFileSync(join(root, 'bin', 'bash.exe'), 'MZ')
+}
+
+const plantPowershell = (entry: string): void => {
+  mkdirSync(entry, { recursive: true })
+  writeFileSync(join(entry, 'pwsh.exe'), 'MZ', { mode: 0o755 })
+}
+
+const RESOLVERS: Array<[name: string, plant: (entry: string) => void, resolve: (env: Record<string, string | undefined>, cwd: string) => string | undefined]> = [
+  ['resolveGitBash', plantGit, (env, cwd) => resolveGitBash(env, cwd, [])],
+  // win32 so the `.exe` spellings the guard must also cover are the ones exercised; the
+  // files are real temp files, so this still runs on any host.
+  ['resolvePowershellBinary', plantPowershell, (env, cwd) => resolvePowershellBinary('win32', env, cwd)],
+]
+
+describe.each(RESOLVERS)('%s refuses a binary planted in the project', (_name, plant, resolve) => {
+  it('skips one on PATH as the launch directory itself', () => {
+    const entry = entryIn(tempDir())
+    plant(entry)
+    expect(resolve({ PATH: entry }, entry)).toBeUndefined()
+  })
+
+  it('skips one below the launch directory under node_modules or a virtual environment', () => {
+    const cwd = tempDir()
+    const local = entryIn(join(cwd, 'node_modules', 'tool'))
+    const venv = entryIn(join(cwd, '.venv', 'tool'))
+    plant(local)
+    plant(venv)
+    expect(resolve({ PATH: [local, venv].join(delimiter) }, cwd)).toBeUndefined()
+  })
+
+  it('walks past a planted one to a genuine install further along PATH', () => {
+    // The planted copy comes FIRST: a resolver that abandoned the lookup on seeing one,
+    // rather than skipping that entry, would fail here. The launch directory IS the
+    // planted entry, which is the shape the guard recognizes; an ordinary subdirectory
+    // of the project is deliberately not covered, since a user may put their own tools
+    // there and name it on PATH themselves.
+    const planted = entryIn(tempDir())
+    const real = tempDir()
+    plant(planted)
+    plant(entryIn(real))
+    expect(resolve({ PATH: [planted, entryIn(real)].join(delimiter) }, planted)).toContain(real)
+  })
+
+  it('still resolves an ordinary install outside the project', () => {
+    // The guard's other failure mode: refusing everything would also pass the cases above.
+    const root = tempDir()
+    plant(entryIn(root))
+    expect(resolve({ PATH: entryIn(root) }, tempDir())).toContain(root)
+  })
+
+  it('reads the Path spelling as well as PATH', () => {
+    // Windows env vars are case-insensitive and process.env follows, but an env object a
+    // caller or a test builds carries whichever spelling it was built with.
+    const root = tempDir()
+    plant(entryIn(root))
+    expect(resolve({ Path: entryIn(root) }, tempDir())).toContain(root)
+  })
+})
+
+// The real-host half: the guard above runs everywhere with planted files, but only a
+// Windows runner can say whether fs.accessSync(X_OK) admits an ordinary file on a
+// filesystem with no execute bit, which is what the resolver's own check relies on.
+describe.skipIf(process.platform !== 'win32')('resolvePowershellBinary on a real Windows host', () => {
+  it('finds the PowerShell this runner ships', () => {
+    expect(resolvePowershellBinary()).toMatch(/(pwsh|powershell)\.exe$/i)
+  })
+
+  it('refuses a planted pwsh.exe even though the filesystem has no execute bit', () => {
+    const entry = entryIn(tempDir())
+    plantPowershell(entry)
+    expect(resolvePowershellBinary('win32', { PATH: entry }, entry)).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
`resolveGitBash` skips a PATH entry that is the launch directory or project tooling below it, so a repository shipping its own `git` cannot become the shell that runs that repository's hooks. `resolvePowershellBinary` had no such check, so the same attack worked through a planted `pwsh.exe` whenever a project directory was on PATH. Both resolvers now apply one guard, and the tests are written so a third resolver cannot quietly skip it.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change

## Untrusted search path

- **A PowerShell on PATH as the launch directory, or under `node_modules`/`.venv`/`venv` below it, is skipped** (`internal/shell-resolve.ts`). Only the Git Bash lookup enforced this; a repo could ship `pwsh.exe`, and any project directory on PATH made it the shell for that repo's own hooks and command spans. The lookup now walks past such an entry rather than stopping, so a genuine install further along PATH still wins.

  This is the rule Go made its default in 1.19, where `os/exec` refuses a program resolved through a path entry relative to the current directory and returns [`ErrDot`](https://pkg.go.dev/os/exec), and the one Windows offers [`NoDefaultCurrentDirectoryInExePath`](https://learn.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-needcurrentdirectoryforexepathw) for. Node honors neither ([nodejs/node#46264](https://github.com/nodejs/node/issues/46264): *"Any Node.js utility that uses `child_process` to spawn a process using a non-absolute path on Windows is at risk of enabling an attacker to run an arbitrary executable"*), so the check belongs where pi-code resolves its own shells.

- **`resolvePowershellBinary` reads the `Path` spelling as well as `PATH`**, as `resolveGitBash` does. `process.env` is case-insensitive on Windows, but an env object a caller or a test builds carries whichever spelling it was built with, so the two resolvers previously disagreed on an injected environment.

## Scope deliberately not taken

`NoDefaultCurrentDirectoryInExePath` is not read. `isProjectTooling` already refuses the launch directory unconditionally, which is stricter than that variable asks for, so honoring it would add code justified by a citation rather than by a behavior gap.

An ordinary subdirectory of the project is still resolved. The guard covers the launch directory itself and tooling directories; a user may keep their own tools in `./cmd` and put it on PATH deliberately, and refusing that would break a legitimate setup to defend against a path the user chose.

## Test shape

A row per resolver rather than a suite per function. The defect was not a missing check but two resolvers disagreeing about one, so the table is what makes a third resolver's omission visible. Each row also pins the guard's opposite failure mode — an ordinary install outside the project still resolving — because a resolver that refused everything would satisfy the negative cases on its own.

Two cases run only on a Windows runner: that the runner's real PowerShell is found, and that a planted `pwsh.exe` is refused on a filesystem with no execute bit, which is the condition the resolver's own `fs.accessSync(X_OK)` check depends on and that no other host can answer.

https://claude.ai/code/session_01JztBj5AfxjhVhx8QrE5ZCA
