### PR TITLE
Point the release section at the script that gates a release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,16 @@ Commit subjects are imperative and specific, one topic per commit, for example `
 
 Maintainers cut a release with a dedicated `release/x.y.z` pull request that bumps only `package.json` and the lockfile, titled `Release x.y.z`. Creating the GitHub release for the tag triggers the publish workflow, which packs, attests, and publishes to npm.
 
+[`scripts/release.sh`](scripts/release.sh) runs that whole sequence, from an open pull request to a verified package:
+
+```bash
+scripts/release.sh <pr-number> <version> "<release notes>"
+```
+
+Prefer it over doing the steps by hand, because the checks it runs are easy to skip and have each let a bad release through before. Every stage is `&&`-chained, so a red one stops what follows. Before either merge it consults three independent sources: `gh pr checks` unpiped, since piping it through `tail` swallows the exit code; the SonarCloud findings API, because a green quality gate can still carry findings; and the quality-gate API itself, because findings can be zero while a condition such as new-code coverage fails. It waits on the CI runs for the exact HEAD commit rather than the newest run, and it confirms the release by asking the npm registry for the version, not by trusting the publish workflow's exit code.
+
+It starts from an unmerged pull request and merges it. A release for work already on `main` has to follow the same steps from the version bump onward.
+
 ## Reporting bugs and security issues
 
 Open an issue for a bug or a feature idea. For anything security-sensitive, do not open a public issue: report it privately through [GitHub Security Advisories](https://github.com/ilovepixelart/pi-code/security/advisories/new), as described in [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
`scripts/release.sh` is referenced by nothing in the repository: not CI, not `package.json`, not the docs. The Releases section described the flow by hand, so a maintainer following it would reproduce the sequence without the checks the script exists to run.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change (documentation only, no code paths)

## What the section now says

- **Names the script and its usage**, so the sanctioned path is findable from the place someone looks when cutting a release.
- **Records why to prefer it over the manual steps**, one line per guard, each of which covers a failure that has actually happened: `gh pr checks` run unpiped, since piping through `tail` swallows the exit code; the SonarCloud findings API consulted separately from the quality-gate API, since a green gate can still carry findings and findings can be zero while a condition such as new-code coverage fails; the CI wait bound to the exact HEAD commit rather than the newest run; and the release confirmed by asking the npm registry for the version rather than trusting the publish workflow's exit code.
- **States its one precondition**: it starts from an unmerged pull request and merges it, so a release for work already on `main` picks the sequence up from the version bump.

Deliberately not a line-by-line restatement of the script. The failure modes are the part the code cannot express; the steps themselves are in the file and would drift.

https://claude.ai/code/session_01JztBj5AfxjhVhx8QrE5ZCA