### PR TITLE
Fix S5: cap the subagent task argv and catch a synchronous spawn throw

### DIFF
--- a/extensions/subagent/child.ts
+++ b/extensions/subagent/child.ts
@@ -12,6 +12,7 @@ import * as path from 'node:path'
 
 import type { AgentRunRequest } from '../internal/agent-run.js'
 import { claudeConfigDir } from '../internal/config-dir.js'
+import { sliceBytes } from '../internal/output-guard.js'
 import { repoRoot } from '../internal/project-root.js'
 import { autoMemoryEnabled, capIndexForPrompt, INDEX_MAX_BYTES, INDEX_MAX_LINES, memorySettingsFiles, readMemorySettings } from '../memory.js'
 import { type AgentConfig, type AgentMemoryScope, expandMcpToolPatterns, withPreloadedSkills } from './agents.js'
@@ -188,10 +189,24 @@ export function agentHooksEnv(agent: AgentConfig, agentId: string): Record<strin
   return { PI_CODE_AGENT_HOOKS: JSON.stringify({ agent: agent.name, id: agentId, hooks }) }
 }
 
+/** This string becomes the whole of one argv element to the spawned child
+ * (run.ts, `spawn(..., { shell: false })`). Linux's MAX_ARG_STRLEN, a per-argument
+ * limit distinct from the much larger total ARG_MAX, is 128KiB; confirmed on a real
+ * Linux host that a single argv string over it fails execve with E2BIG. Neither the
+ * model's task text nor a SubagentStart hook's additionalContext is capped
+ * upstream, so this is where the assembled string caps itself. The budget leaves
+ * headroom under the hard limit for the "Task: " prefix, the notice below, and
+ * platforms whose limit differs from Linux's. */
+const TASK_ARGV_MAX_BYTES = 96 * 1024
+
 /** The task argument with any SubagentStart hook context ahead of it, per Claude:
  * "added to the subagent's context at the start of its conversation, before its
- * first prompt". */
+ * first prompt". Capped as one combined string, since either the context or the
+ * task alone can already be oversized. */
 export function taskWithStartContext(task: string, contexts: string[]): string {
   const context = contexts.filter(Boolean).join('\n')
-  return context ? `${context}\n\nTask: ${task}` : `Task: ${task}`
+  const assembled = context ? `${context}\n\nTask: ${task}` : `Task: ${task}`
+  if (Buffer.byteLength(assembled, 'utf-8') <= TASK_ARGV_MAX_BYTES) return assembled
+  const kept = sliceBytes(assembled, TASK_ARGV_MAX_BYTES)
+  return `${kept}\n\n[truncated: too long for the child process to receive]`
 }

--- a/extensions/subagent/run.ts
+++ b/extensions/subagent/run.ts
@@ -6,11 +6,12 @@
  * worktree; everything about how the child was configured lives in child.ts.
  */
 
-import { spawn } from 'node:child_process'
+import { type ChildProcessByStdio, spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import type { Readable } from 'node:stream'
 
 import type { AgentToolResult } from '@earendil-works/pi-agent-core'
 import type { Message } from '@earendil-works/pi-ai'
@@ -121,6 +122,29 @@ function appendWorktreeNote(result: SingleResult, worktree: AgentWorktree): void
  * with the output. A no-op for uncapped runs. */
 function appendPartialNote(result: SingleResult): void {
   if (result.partial) appendResultNote(result, '[Output is partial: the subagent stopped at its maxTurns limit.]')
+}
+
+/** The pi child, or the error spawning it threw synchronously. Node normally
+ * reports a spawn failure through the child's async 'error' event, but some
+ * failures (confirmed on Linux: posix_spawn detects E2BIG immediately) throw at
+ * the spawn() call site instead; catching it here, in one place with an explicit
+ * return type, keeps the caller's non-null stdout/stderr narrowing that a bare
+ * try/catch around an inline spawn() call loses. */
+function spawnChild(command: string, args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }): { proc: ChildProcessByStdio<null, Readable, Readable> } | { error: Error } {
+  try {
+    return {
+      proc: spawn(command, args, {
+        ...options,
+        shell: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // Its own group, so an abort reaches grandchildren too: killing only the
+        // direct child orphans a build or dev server the agent started.
+        detached: true,
+      }),
+    }
+  } catch (error) {
+    return { error: error as Error }
+  }
 }
 
 export async function runSingleAgent(options: RunAgentOptions): Promise<SingleResult> {
@@ -244,16 +268,17 @@ async function runSingleAgentInner(options: RunAgentOptions): Promise<SingleResu
 
     const exitCode = await new Promise<number>((resolve) => {
       const invocation = getPiInvocation(args)
-      const proc = spawn(invocation.command, invocation.args, {
+      const spawned = spawnChild(invocation.command, invocation.args, {
         cwd: worktree?.dir ?? runCwd,
-        shell: false,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        // Its own group, so an abort reaches grandchildren too: killing only the
-        // direct child orphans a build or dev server the agent started.
-        detached: true,
         // The marker lets the child's subagent tool refuse to nest further.
         env: { ...process.env, PI_CODE_SUBAGENT: '1', ...agentHooksEnv(agent, options.agentId ?? '') },
       })
+      if ('error' in spawned) {
+        if (!currentResult.stderr) currentResult.stderr = spawned.error.message
+        resolve(1)
+        return
+      }
+      const proc = spawned.proc
       let buffer = ''
       let assistantTurns = 0
 

--- a/tests/argv-limit-probe.test.ts
+++ b/tests/argv-limit-probe.test.ts
@@ -2,28 +2,39 @@ import { spawn } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 
 /**
- * S5 (register): the subagent task travels to the child pi process as one argv
- * element (run.ts's `args.push(taskWithStartContext(task, ...))`). A chain step's
- * `{previous}` substitution is capped at 50KB (capForContext / DEFAULT_MAX_BYTES),
- * but the model's own task text for that step is not, and Linux enforces
- * MAX_ARG_STRLEN, a PER-ARGUMENT limit of 128KiB distinct from the much larger
- * total ARG_MAX — a single argv string over that limit fails execve with E2BIG,
- * whatever the combined length of every other argument.
+ * S5 (register, now fixed): confirms, on a real Linux host rather than trusting
+ * the textbook constant, that a single argv element over MAX_ARG_STRLEN (128KiB, a
+ * PER-ARGUMENT limit distinct from the much larger total ARG_MAX) fails execve
+ * with E2BIG. This is what justifies capping the assembled task string in
+ * subagent/child.ts's `taskWithStartContext`, and what surfaced that spawn()
+ * itself needed a try/catch in subagent/run.ts (`spawnChild`): on this Linux/Node
+ * combination it throws synchronously for E2BIG rather than only emitting the
+ * async 'error' event.
  *
- * This is a probe, not a fix: it spawns a real child (no shell, exactly like
- * run.ts's `spawn(invocation.command, invocation.args, { shell: false, ... })`)
- * with one oversized argument and observes what actually happens on the host
- * running it, rather than trusting the textbook constant. Linux-gated because the
- * limit, and its value, is a Linux kernel property; macOS and Windows have
- * different (and in macOS's case, much larger) argument-length rules.
+ * Spawns a real child (no shell, exactly like run.ts's
+ * `spawn(invocation.command, invocation.args, { shell: false, ... })`) with one
+ * oversized argument. Linux-gated because the limit, and its value, is a Linux
+ * kernel property; macOS and Windows have different (and in macOS's case, much
+ * larger) argument-length rules.
  */
 describe.skipIf(process.platform !== 'linux')('a single argv element near the Linux MAX_ARG_STRLEN boundary', () => {
   // node -e 'process.exit(0)' is the same shape run.ts spawns: no shell, a fixed
-  // command, extra positional args the child ignores.
+  // command, extra positional args the child ignores. spawn() itself needs a
+  // try/catch here too: this run confirmed spawn() throws SYNCHRONOUSLY for
+  // E2BIG on this Linux/Node combination (posix_spawn detects it before
+  // returning), rather than only emitting the async 'error' event below, which
+  // production code had the same gap and is now fixed to catch (subagent/run.ts,
+  // spawnChild).
   const run = (argLength: number): Promise<{ code: number | null; error: NodeJS.ErrnoException | null }> =>
     new Promise((resolve) => {
       const oversized = 'x'.repeat(argLength)
-      const proc = spawn(process.execPath, ['-e', 'process.exit(0)', oversized], { shell: false, stdio: 'ignore' })
+      let proc: ReturnType<typeof spawn>
+      try {
+        proc = spawn(process.execPath, ['-e', 'process.exit(0)', oversized], { shell: false, stdio: 'ignore' })
+      } catch (error) {
+        resolve({ code: null, error: error as NodeJS.ErrnoException })
+        return
+      }
       let settled = false
       proc.on('error', (error: NodeJS.ErrnoException) => {
         if (settled) return

--- a/tests/argv-limit-probe.test.ts
+++ b/tests/argv-limit-probe.test.ts
@@ -1,0 +1,50 @@
+import { spawn } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * S5 (register): the subagent task travels to the child pi process as one argv
+ * element (run.ts's `args.push(taskWithStartContext(task, ...))`). A chain step's
+ * `{previous}` substitution is capped at 50KB (capForContext / DEFAULT_MAX_BYTES),
+ * but the model's own task text for that step is not, and Linux enforces
+ * MAX_ARG_STRLEN, a PER-ARGUMENT limit of 128KiB distinct from the much larger
+ * total ARG_MAX — a single argv string over that limit fails execve with E2BIG,
+ * whatever the combined length of every other argument.
+ *
+ * This is a probe, not a fix: it spawns a real child (no shell, exactly like
+ * run.ts's `spawn(invocation.command, invocation.args, { shell: false, ... })`)
+ * with one oversized argument and observes what actually happens on the host
+ * running it, rather than trusting the textbook constant. Linux-gated because the
+ * limit, and its value, is a Linux kernel property; macOS and Windows have
+ * different (and in macOS's case, much larger) argument-length rules.
+ */
+describe.skipIf(process.platform !== 'linux')('a single argv element near the Linux MAX_ARG_STRLEN boundary', () => {
+  // node -e 'process.exit(0)' is the same shape run.ts spawns: no shell, a fixed
+  // command, extra positional args the child ignores.
+  const run = (argLength: number): Promise<{ code: number | null; error: NodeJS.ErrnoException | null }> =>
+    new Promise((resolve) => {
+      const oversized = 'x'.repeat(argLength)
+      const proc = spawn(process.execPath, ['-e', 'process.exit(0)', oversized], { shell: false, stdio: 'ignore' })
+      let settled = false
+      proc.on('error', (error: NodeJS.ErrnoException) => {
+        if (settled) return
+        settled = true
+        resolve({ code: null, error })
+      })
+      proc.on('close', (code) => {
+        if (settled) return
+        settled = true
+        resolve({ code, error: null })
+      })
+    })
+
+  it('fails with E2BIG at 200KiB, comfortably over the 128KiB limit', async () => {
+    const result = await run(200 * 1024)
+    expect(result.error?.code).toBe('E2BIG')
+  })
+
+  it('succeeds at 64KiB, comfortably under the limit', async () => {
+    const result = await run(64 * 1024)
+    expect(result.error).toBeNull()
+    expect(result.code).toBe(0)
+  })
+})

--- a/tests/subagent-child-task.test.ts
+++ b/tests/subagent-child-task.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { taskWithStartContext } from '../extensions/subagent/child.ts'
+
+/**
+ * S5: the assembled string is the whole of one argv element handed to a spawned
+ * child (run.ts's `args.push(taskWithStartContext(...))`, `shell: false`). Linux
+ * enforces MAX_ARG_STRLEN, a per-argument limit of 128KiB distinct from the much
+ * larger total ARG_MAX; confirmed on real ubuntu CI runners (tests/argv-limit-probe
+ * .test.ts) that a single argv string over it fails execve with E2BIG. Neither the
+ * model's task text nor a SubagentStart hook's additionalContext is capped
+ * upstream, so the assembled string must cap itself.
+ */
+describe('taskWithStartContext stays under the Linux argv limit', () => {
+  it('caps a task far larger than the 128KiB argv limit', () => {
+    const huge = 'x'.repeat(500 * 1024)
+    const result = taskWithStartContext(huge, [])
+    expect(Buffer.byteLength(result, 'utf-8')).toBeLessThan(128 * 1024)
+  })
+
+  it('caps hook context that alone would already exceed the limit', () => {
+    const hugeContext = 'y'.repeat(500 * 1024)
+    const result = taskWithStartContext('short task', [hugeContext])
+    expect(Buffer.byteLength(result, 'utf-8')).toBeLessThan(128 * 1024)
+  })
+
+  it('leaves an ordinary task and context untouched', () => {
+    const result = taskWithStartContext('do the thing', ['some context'])
+    expect(result).toBe('some context\n\nTask: do the thing')
+  })
+
+  it('notes what was cut, so the model knows its own instructions were trimmed', () => {
+    const huge = 'x'.repeat(500 * 1024)
+    const result = taskWithStartContext(huge, [])
+    expect(result).toContain('truncated')
+  })
+})

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -629,6 +629,22 @@ describe('background mode', () => {
 })
 
 describe('runSingleAgent process handling', () => {
+  it('reports a synchronous spawn failure gracefully instead of throwing', async () => {
+    // Some spawn failures (confirmed on Linux for E2BIG: posix_spawn detects it
+    // immediately) throw at the spawn() call site rather than emitting the async
+    // 'error' event the rest of run.ts already handles gracefully. Without a catch
+    // around the call, this escaped the run as an unhandled rejection.
+    discoverAgentsMock.mockReturnValue({ agents: [agentConfig({})], projectAgentsDir: null })
+    spawnMock.mockImplementationOnce(() => {
+      throw Object.assign(new Error('spawn E2BIG'), { code: 'E2BIG' })
+    })
+
+    const result = await execute('c1', { agent: 'scout', task: 'inspect' }, undefined, undefined, trustedCtx)
+
+    expect(text(result)).not.toBe('')
+    expect(results(result)[0]).toMatchObject({ exitCode: 1, stderr: 'spawn E2BIG' })
+  })
+
   it('reports an unknown agent without spawning anything', async () => {
     const result = await execute('c1', { agent: 'ghost', task: 'find it' }, undefined, undefined, trustedCtx)
 


### PR DESCRIPTION
S5 in the register was SUSPECTED, gated on probing the real limit on Linux CI before filing. Confirmed for real (`tests/argv-limit-probe.test.ts`, Linux-gated, no shell, matching the actual production spawn call): a single argv element over 200KiB fails `execve` with `E2BIG` on the ubuntu runners, and 64KiB succeeds. Two fixes follow from what the probe surfaced.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change

## The task argv element is now bounded

**`taskWithStartContext` caps the assembled string at 96KiB** (`subagent/child.ts`), with a truncation notice so the model knows its own instructions were trimmed. Neither the model's task text nor a `SubagentStart` hook's `additionalContext` was capped before becoming that one argv element (Linux's `MAX_ARG_STRLEN`, 128KiB, is a per-argument limit distinct from the much larger total `ARG_MAX`); a long chain step or a verbose hook could exceed it and fail the spawn outright, surfacing as an opaque `spawn E2BIG` with no indication of the cause.

## A synchronous spawn throw escaped as an unhandled rejection

The probe surfaced something more general than the argv question it was written to answer: on this Linux/Node combination, `spawn()` throws **synchronously** for `E2BIG` (`posix_spawn` detects it before returning) rather than emitting the async `'error'` event `run.ts` already handles gracefully. A throw inside the bare `new Promise((resolve) => { const proc = spawn(...) ... })` executor rejected that promise, and since nothing downstream caught it, escaped as an unhandled rejection instead of the same graceful failure the async case already has.

**`spawnChild` wraps the call in its own try/catch** with an explicit return type (`subagent/run.ts`), so a synchronous failure now resolves through the identical path a failure reported asynchronously already takes: `currentResult.stderr` gets the error message, the run resolves with exit code 1. The explicit return type also matters mechanically — a bare inline try/catch around `spawn()` widens the assigned variable's type from Node's stdio-narrowed overload to the general `ChildProcess`, which loses the non-null `stdout`/`stderr` narrowing every listener below depends on; the extracted helper keeps it.

*Behavior change: a synchronous spawn failure, which previously crashed the extension via an unhandled rejection, now fails the one subagent run and reports why.*

