### PR TITLE
Fix seven defects surfaced by a full code scan

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -56,6 +56,7 @@ import { isProjectApproved } from './internal/project-approval.js'
 import { ancestorDirs, repoRoot } from './internal/project-root.js'
 import { agentNamesIn, matchesAgentRules, matchesDomainRules, matchesSkillRules } from './internal/scope-rules.js'
 import { claudeSettingsChain } from './internal/settings-chain.js'
+import { fileToolTarget } from './internal/tool-target.js'
 import { createTurnOverride } from './internal/turn-override.js'
 import { errorMessage, isDirectory } from './internal/values.js'
 
@@ -394,7 +395,9 @@ export default function commandsExtension(pi: ExtensionAPI) {
     if (event.toolName === 'slash_command') return scopeVerdict(pendingSkillRules, 'slash_command', 'Command', text(input.command), (rules) => matchesSkillRules(text(input.command), rules))
     const rules = pendingPathRules?.[event.toolName as PathRuleTool]
     if (!rules) return
-    const filePath = typeof input.path === 'string' ? input.path : ''
+    // pi's read/edit/write accept `file_path` as an alias for `path`; the shared reader
+    // handles both, and the paired guard in hooks/matcher.ts reads both too.
+    const filePath = fileToolTarget(event) ?? ''
     const anchors = { cwd: ctx.cwd, projectRoot: repoRoot(ctx.cwd) ?? ctx.cwd, home: os.homedir() }
     if (filePath && matchesPathRules(filePath, rules, anchors)) return
     return {

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -182,7 +182,7 @@ export function loadHooks(files: string[], sources?: Map<HookMatcher, string>): 
  * stays separate, so plugin entries carry their origin into the dedup key. */
 function stampOrigin(entries: HookMatcher[], origin: string): void {
   for (const entry of entries) {
-    for (const hook of entry.hooks ?? []) hook.origin = origin
+    for (const hook of entry.hooks ?? []) if (isRecord(hook)) hook.origin = origin
   }
 }
 
@@ -303,6 +303,13 @@ function isUsableMatcher(entry: unknown, file: string, event: string): entry is 
   if (candidate.hooks !== undefined && !Array.isArray(candidate.hooks)) {
     console.warn(`pi-code-hooks: ignoring ${event} entry in ${file}: "hooks" must be a list`)
     return false
+  }
+  // The list's entries too: the dispatcher reads `.type` of each, so one `null` (a
+  // hand-edit that removed an entry's body) failed every tool call for the session.
+  if (Array.isArray(candidate.hooks)) {
+    const objects = candidate.hooks.filter((hook: unknown) => isRecord(hook))
+    if (objects.length !== candidate.hooks.length) console.warn(`pi-code-hooks: ignoring ${candidate.hooks.length - objects.length} non-object hook(s) in a ${event} entry in ${file}`)
+    candidate.hooks = objects as HookCommand[]
   }
   if (candidate.matcher !== undefined && typeof candidate.matcher !== 'string') {
     console.warn(`pi-code-hooks: ignoring ${event} entry in ${file}: "matcher" must be a string`)

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -256,7 +256,7 @@ const text = (value: unknown): string => {
  * number rather than a boolean. A flag that gates a command off from the model has to
  * honor them, or a command the user marked off-limits is silently offered to it. */
 const YAML_TRUE = new Set(['true', 'yes', 'on', 'y', '1'])
-const isFlagEnabled = (value: unknown): boolean => value === true || YAML_TRUE.has(text(value).toLowerCase())
+export const isFlagEnabled = (value: unknown): boolean => value === true || YAML_TRUE.has(text(value).toLowerCase())
 
 /** YAML's negative boolean spellings, the mirror of YAML_TRUE. A flag that defaults to
  * true (user-invocable) is turned off only by one of these; any other value, absent

--- a/extensions/internal/model-complete.ts
+++ b/extensions/internal/model-complete.ts
@@ -59,7 +59,13 @@ export interface CompleteOptions {
  * tool call, only assistant text.
  */
 export async function completeText(model: Model<Api>, prompt: string, options: CompleteOptions = {}): Promise<{ text: string; usage: Usage }> {
-  backend ??= realBackend()
+  // A rejected creation must not stay cached: ModelRuntime.create can fail on a
+  // transient (a credential store read), and caching that promise made every later
+  // call rethrow the same stale error for the life of the process.
+  backend ??= realBackend().catch((error: unknown) => {
+    backend = null
+    throw error
+  })
   const complete = await backend
   const context: Context = {
     systemPrompt: options.system,

--- a/extensions/internal/project-root.ts
+++ b/extensions/internal/project-root.ts
@@ -32,11 +32,12 @@ export function repoRoot(from: string): string | undefined {
 
 /** The git checkout at or above `from`, or undefined outside one.
  *
- * Narrower than repoRoot on purpose, and used where a key must be stable rather than
- * merely near: repoRoot also stops at package.json, which every package of a monorepo
- * ships, so a decision keyed on it changes the moment the session starts one directory
- * deeper. `.git` cannot be committed into a repository, so it is not a marker the
- * repository can add to move its own key.
+ * Narrower than repoRoot on purpose: repoRoot resolves a worktree to its main checkout,
+ * which is the right key for shared state (settings.local.json, auto memory) but is a
+ * sibling of the worktree, never an ancestor. The upward walks above bound themselves
+ * here instead, since a boundary that is not on the path from cwd to / is never reached
+ * and the walk would run on to the filesystem root. `.git` cannot be committed into a
+ * repository, so it is not a marker the repository can add to move its own key.
  */
 export function gitRoot(from: string): string | undefined {
   let currentDir = from
@@ -89,7 +90,7 @@ function statOf(target: string): fs.Stats | null {
 }
 
 function findNearest(cwd: string, relative: string, wantDir: boolean): string | null {
-  const boundary = repoRoot(cwd) ?? cwd
+  const boundary = gitRoot(cwd) ?? cwd
   let currentDir = cwd
   while (true) {
     const candidate = path.join(currentDir, relative)
@@ -117,7 +118,7 @@ export function findNearestFile(cwd: string, relative: string): string | null {
  * matching Claude's "every .claude/<kind> between the working directory and the
  * repository root" discovery where the entry closest to cwd wins a name clash. */
 export function ancestorDirs(cwd: string, relative: string): string[] {
-  const boundary = repoRoot(cwd) ?? cwd
+  const boundary = gitRoot(cwd) ?? cwd
   const found: string[] = []
   let currentDir = cwd
   while (true) {
@@ -134,7 +135,7 @@ export function ancestorDirs(cwd: string, relative: string): string[] {
 /** Every `relative` file between the repository root and cwd, ordered root first,
  * matching Claude's root-down ordering for hierarchy-loaded context. */
 export function ancestorFiles(cwd: string, relative: string): string[] {
-  const boundary = repoRoot(cwd) ?? cwd
+  const boundary = gitRoot(cwd) ?? cwd
   const found: string[] = []
   let currentDir = cwd
   while (true) {

--- a/extensions/mcp/index.ts
+++ b/extensions/mcp/index.ts
@@ -99,6 +99,11 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   // Shutdown closes clients while they are still in the map; the onclose handlers
   // must not schedule reconnects for that deliberate teardown.
   let shuttingDown = false
+  // Bumped by every session_start and session_shutdown. A late-connecting server's
+  // deferred summary captured the ctx of the session that started it; pi disposes that
+  // ctx on /new, /resume, /fork and reload (any use of it throws), so the publish must
+  // check it still belongs to the live session before touching ctx.
+  let sessionGeneration = 0
   const callTuning = (name: string): ServerCallTuning => {
     const config = serverConfigs.get(name)
     return config ? serverCallTuning(config) : {}
@@ -587,6 +592,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
     // withdrawn tool keeps its registration and surfaces the server's own error), which
     // is why serverToolCount reads from `registered` to recover the true count here.
     status.clear()
+    const generation = ++sessionGeneration
     // A same-process session switch (/new, /resume) shut the last session down;
     // this one may reconnect again. projectConnected guards against connecting the project
     // scope twice within one session, so it belongs to the session that set it: leaving it
@@ -629,13 +635,23 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           () => false,
         )
     publishConnectionSummary(ctx)
-    if (!settled) void connecting.then(() => publishConnectionSummary(ctx))
+    if (!settled) {
+      // The rejection path exists for the throw a disposed ctx would raise if the
+      // generation check were ever wrong: from a bare `.then` it would be an unhandled
+      // rejection, and pi installs no handler, so Node would take the process down.
+      void connecting
+        .then(() => {
+          if (generation === sessionGeneration) publishConnectionSummary(ctx)
+        })
+        .catch(() => {})
+    }
   })
 
   pi.on('session_shutdown', async () => {
     // Closing fires each client's onclose while it is still in the map; the flag
     // stops those handlers (and any in-flight backoff loop) from reconnecting.
     shuttingDown = true
+    sessionGeneration++
     // Close in parallel with a per-client timeout so one hung server can't stall pi's exit.
     await Promise.all([...clients.values()].map((client) => withTimeout(client.close(), 3000, 'close').catch(() => {})))
     // Drop the closed clients and their status now rather than waiting on each client's

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -24,6 +24,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 import { atomicWriteFile } from './internal/atomic-write.js'
+import { isFlagEnabled } from './internal/command-file.js'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { readManagedSettings } from './internal/managed-settings.js'
 import { installedPlugins, pluginComponentPath } from './internal/plugins.js'
@@ -55,8 +56,10 @@ export function parseStyle(content: string, fallbackName: string): OutputStyle {
     name: field(frontmatter, 'name') || fallbackName,
     description: field(frontmatter, 'description'),
     body: body.trim(),
-    keepCodingInstructions: field(frontmatter, 'keep-coding-instructions') === 'true',
-    forceForPlugin: field(frontmatter, 'force-for-plugin') === 'true',
+    // Both are YAML booleans (Claude: default `false`), so `yes`/`on`/`True` count as
+    // set, the same reading commands give their own frontmatter flags.
+    keepCodingInstructions: isFlagEnabled(field(frontmatter, 'keep-coding-instructions')),
+    forceForPlugin: isFlagEnabled(field(frontmatter, 'force-for-plugin')),
   }
 }
 

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -6,12 +6,12 @@
  * across a same-process session switch keeps going under the new session.
  */
 
-import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { errorMessage } from '../internal/values.js'
+import { spawnChild } from './run.js'
 
 export interface BackgroundRun {
   id: string
@@ -281,15 +281,39 @@ export function startBackgroundRun(agent: string, task: string, invocation: Back
 
 /** Spawn the child for a run and wire its lifecycle back onto the record. */
 function driveRun(run: BackgroundRun, invocation: BackgroundSpawn, onComplete: (run: BackgroundRun) => void): void {
-  const proc = spawn(invocation.command, invocation.args, {
-    cwd: invocation.cwd,
-    shell: false,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    // Its own group, so cancelling reaches any grandchild the agent spawned.
-    detached: true,
-    // The marker lets the child's subagent tool refuse to nest further.
-    env: { ...process.env, PI_CODE_SUBAGENT: '1', ...invocation.env },
-  })
+  // Node fires both 'error' and 'close' on a spawn failure (ENOENT); complete once.
+  let completed = false
+  const complete = (): void => {
+    if (completed) return
+    completed = true
+    run.finishedAt = ++finishSequence
+    evictFinishedRuns()
+    // A run outlives the session that started it, and pi's loader wires assertActive()
+    // into every runtime call, so notifying a disposed session throws. This fires from
+    // the child's 'close'/'error' listener, where nothing upstream catches: an escaping
+    // error reaches Node as an uncaughtException and takes pi down with it. The run
+    // state is already recorded by this point, so there is nothing to do but drop the
+    // notification for a session that is no longer there to receive it.
+    try {
+      onComplete(run)
+    } catch {
+      // the session that asked for this run is gone
+    }
+  }
+  // The marker in env lets the child's subagent tool refuse to nest further. The run is
+  // already registered as running by the caller, so a spawn that throws synchronously
+  // (see spawnChild) must settle the record here: left as it was, the phantom held a cap
+  // slot with no kill and no eviction for the life of the process.
+  const spawned = spawnChild(invocation.command, invocation.args, { cwd: invocation.cwd, env: { ...process.env, PI_CODE_SUBAGENT: '1', ...invocation.env } })
+  if ('error' in spawned) {
+    run.live = false
+    run.state = 'failed'
+    run.exitCode = 1
+    run.stderr = spawned.error.message
+    complete()
+    return
+  }
+  const proc = spawned.proc
   run.live = true
   const killGroup = (signal: NodeJS.Signals): void => {
     try {
@@ -330,25 +354,6 @@ function driveRun(run: BackgroundRun, invocation: BackgroundSpawn, onComplete: (
       : undefined,
   )
   let stderrTail = ''
-  // Node fires both 'error' and 'close' on a spawn failure (ENOENT); complete once.
-  let completed = false
-  const complete = (): void => {
-    if (completed) return
-    completed = true
-    run.finishedAt = ++finishSequence
-    evictFinishedRuns()
-    // A run outlives the session that started it, and pi's loader wires assertActive()
-    // into every runtime call, so notifying a disposed session throws. This fires from
-    // the child's 'close'/'error' listener, where nothing upstream catches: an escaping
-    // error reaches Node as an uncaughtException and takes pi down with it. The run
-    // state is already recorded by this point, so there is nothing to do but drop the
-    // notification for a session that is no longer there to receive it.
-    try {
-      onComplete(run)
-    } catch {
-      // the session that asked for this run is gone
-    }
-  }
   proc.stdout.on('data', (data) => parser.push(data.toString()))
   // An 'error' on a stream with no listener is rethrown by EventEmitter, and this one
   // belongs to a detached child, so a pipe read failure would exit pi the same way an

--- a/extensions/subagent/run.ts
+++ b/extensions/subagent/run.ts
@@ -130,7 +130,7 @@ function appendPartialNote(result: SingleResult): void {
  * the spawn() call site instead; catching it here, in one place with an explicit
  * return type, keeps the caller's non-null stdout/stderr narrowing that a bare
  * try/catch around an inline spawn() call loses. */
-function spawnChild(command: string, args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }): { proc: ChildProcessByStdio<null, Readable, Readable> } | { error: Error } {
+export function spawnChild(command: string, args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }): { proc: ChildProcessByStdio<null, Readable, Readable> } | { error: Error } {
   try {
     return {
       proc: spawn(command, args, {

--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -92,6 +92,25 @@ const spec = (over: Partial<BackgroundSpawn> = {}): BackgroundSpawn => ({ comman
 const assistantTurn = (text: string) => `${JSON.stringify({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text }] } })}\n`
 
 describe('background run lifecycle', () => {
+  it('records a synchronous spawn failure as failed instead of leaving a phantom running run', () => {
+    // On Linux spawn() throws synchronously for E2BIG (posix_spawn detects it before
+    // returning). The run was already registered as running, so the throw escaped the
+    // tool call and the record held a cap slot forever: no kill, no eviction, and
+    // "Too many background runs" for the life of the process once it happened enough.
+    spawnMock.mockImplementationOnce(() => {
+      throw Object.assign(new Error('spawn E2BIG'), { code: 'E2BIG' })
+    })
+    let done: BackgroundRun | undefined
+    const id = startBackgroundRun('scout', 'find', spec(), (run) => {
+      done = run
+    })
+
+    expect(id).not.toBeNull()
+    expect(done?.state).toBe('failed')
+    expect(done?.stderr).toBe('spawn E2BIG')
+    expect(activeBackgroundRuns()).toBe(0)
+  })
+
   it('reports the final text of a stdout stream whose chunks split lines', () => {
     let done: BackgroundRun | undefined
     startBackgroundRun('scout', 'find', spec(), (run) => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -990,6 +990,22 @@ describe('allowed-tools argument scopes', () => {
     expect(await s.handlers.get('tool_call')?.({ toolName: 'read', input: { path: 'src/secret.ts' } }, s.ctx)).toBeUndefined()
   })
 
+  it('reads the file_path alias at the path-scope guard, as the shared target reader does', async () => {
+    // pi's read/edit/write accept `file_path` as an alias for `path`; a guard reading only
+    // `path` blocked every aliased call with an empty Path in the reason.
+    const cwd = tempDir()
+    writeCommand(cwd, 'docs.md', '---\nallowed-tools: Read(docs/**), Edit(docs/**)\n---\nDocs only.')
+    const s = setup(cwd)
+    await s.handlers.get('session_start')?.({}, s.ctx)
+    await s.commands.get('docs')?.handler('', s.ctx)
+
+    expect(await s.handlers.get('tool_call')?.({ toolName: 'read', input: { file_path: 'docs/a.md' } }, s.ctx)).toBeUndefined()
+    expect(await s.handlers.get('tool_call')?.({ toolName: 'edit', input: { file_path: 'docs/a.md' } }, s.ctx)).toBeUndefined()
+    const read = (await s.handlers.get('tool_call')?.({ toolName: 'read', input: { file_path: 'src/secret.ts' } }, s.ctx)) as { block?: boolean; reason?: string }
+    expect(read?.block).toBe(true)
+    expect(read?.reason).toContain('src/secret.ts')
+  })
+
   it('expands a brace glob in an Edit path scope at the tool_call guard', async () => {
     const cwd = tempDir()
     writeCommand(cwd, 'edit.md', '---\nallowed-tools: Edit(src/{x,y}/**)\n---\nEdit x or y.')

--- a/tests/config-dir.test.ts
+++ b/tests/config-dir.test.ts
@@ -68,6 +68,28 @@ describe('ancestorDirs', () => {
     expect(ancestorDirs(cwd, join('.claude', 'agents'))).toEqual([join(cwd, '.claude', 'agents'), join(root, '.claude', 'agents')])
   })
 
+  it("stops at a worktree's own root, not the filesystem root", async () => {
+    // A worktree's repoRoot is the main checkout, which is a sibling, never an ancestor,
+    // so a boundary set to it is never reached and the walk ran on to /: config planted
+    // in the worktree's parent (the world-writable case the module exists to refuse)
+    // was discovered.
+    const { ancestorDirs, findNearestFile } = await import('../extensions/internal/project-root.ts')
+    const { mkdirSync, mkdtempSync, writeFileSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+    const parent = mkdtempSync(join(tmpdir(), 'walk-'))
+    const main = join(parent, 'main')
+    const tree = join(parent, 'feature')
+    mkdirSync(join(main, '.git', 'worktrees', 'feature'), { recursive: true })
+    mkdirSync(tree)
+    writeFileSync(join(tree, '.git'), `gitdir: ${join(main, '.git', 'worktrees', 'feature')}\n`)
+    mkdirSync(join(parent, '.claude', 'agents'), { recursive: true })
+    writeFileSync(join(parent, 'CLAUDE.local.md'), 'planted')
+
+    expect(ancestorDirs(tree, join('.claude', 'agents'))).toEqual([])
+    expect(findNearestFile(tree, 'CLAUDE.local.md')).toBeNull()
+  })
+
   it('does not walk past the repository root', async () => {
     const { ancestorDirs } = await import('../extensions/internal/project-root.ts')
     const { mkdirSync, mkdtempSync } = await import('node:fs')

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -631,6 +631,17 @@ describe('matchingCommands edge shapes', () => {
 })
 
 describe('loadHooks malformed config shapes', () => {
+  it('drops a null entry inside a hooks list and keeps its siblings, so tool calls keep working', () => {
+    // A hand-edit that removed an entry's body leaves `null` in the list. The container
+    // was validated but not its entries, so the first tool call read `.type` of null and
+    // every tool call for the rest of the session failed with that TypeError.
+    const dir = tempDir('hooks-cfg-')
+    const file = join(dir, 'settings.json')
+    writeFileSync(file, JSON.stringify({ hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [null, { command: 'guard' }, 7] }] } }))
+    const config = loadHooks([file])
+    expect(matchingCommands(config.PreToolUse, 'Bash').map((c) => c.command)).toEqual(['guard'])
+  })
+
   it('ignores an event whose matchers are not an array', () => {
     const dir = tempDir('hooks-cfg-')
     const file = join(dir, 'settings.json')

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -1327,6 +1327,35 @@ describe('mcp failure reporting', () => {
     expect(await statusLinesOf(harness)).toEqual(['hung: failed: connect hung timed out after 2000ms (0 tools)'])
   })
 
+  it('drops a late startup summary once the session that scheduled it has been replaced', async () => {
+    // A late-connecting server's deferred publish captured the session_start ctx. After
+    // /new that ctx is disposed (pi throws on any use of it) and a fresh session owns the
+    // status map, so the old session's publish must not run: it would notify through a
+    // dead ctx, and from a bare `.then` that throw would be an unhandled rejection.
+    const resolvers: Array<() => void> = []
+    hoisted.control.connect = () => new Promise<void>((r) => resolvers.push(r))
+    withTools([{ name: 'go' }])
+    vi.useFakeTimers()
+
+    const harness = await setup({ user: { slow: { command: 'x' } } })
+    const first = harness.sessionStart()
+    await vi.advanceTimersByTimeAsync(5_000)
+    await first
+    await harness.shutdown()
+    const second = harness.sessionStart()
+    await vi.advanceTimersByTimeAsync(5_000)
+    await second
+    const before = harness.notifications.length
+
+    resolvers[0]?.() // the first session's connect finishes after that session is gone
+    await vi.advanceTimersByTimeAsync(0)
+    expect(harness.notifications.length).toBe(before)
+
+    resolvers[1]?.() // the live session's own late connect still publishes
+    await vi.advanceTimersByTimeAsync(0)
+    expect(harness.notifications.length).toBe(before + 1)
+  })
+
   it('returns from session_start without waiting for a hung server, in an interactive session', async () => {
     // Claude: "MCP startup is non-blocking by default: servers connect in the
     // background and their tools become available as they finish." Before this,

--- a/tests/model-complete.test.ts
+++ b/tests/model-complete.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // overriding the backend and leaving realBackend() itself unexercised.
 const runtimeMock = vi.hoisted(() => ({
   createCalls: 0,
+  failNextCreate: false,
   completeCalls: [] as Array<{ model: unknown; context: { systemPrompt?: string; messages: Array<{ content: unknown }> }; options: { maxTokens?: number; signal?: AbortSignal } }>,
   reply: { role: 'assistant', content: [{ type: 'text', text: 'real answer' }], api: 'x', provider: 'x', model: 'm', usage: { input: 3, output: 5, totalTokens: 8 }, stopReason: 'stop', timestamp: 0 },
 }))
@@ -15,6 +16,10 @@ vi.mock('@earendil-works/pi-coding-agent', async (importOriginal) => {
     ModelRuntime: {
       create: async () => {
         runtimeMock.createCalls += 1
+        if (runtimeMock.failNextCreate) {
+          runtimeMock.failNextCreate = false
+          throw new Error('runtime unavailable')
+        }
         return {
           completeSimple: async (model: unknown, context: unknown, options: unknown) => {
             runtimeMock.completeCalls.push({ model, context, options } as never)
@@ -43,6 +48,22 @@ describe('assistantText', () => {
 })
 
 describe('completeText', () => {
+  it('retries runtime creation after a rejected first attempt instead of caching the failure', async () => {
+    // ModelRuntime.create can reject once (a credential store read that fails on a
+    // transient error). Caching that rejected promise turned one bad moment into a
+    // process-lifetime outage for every model-backed feature.
+    runtimeMock.createCalls = 0
+    setCompleteBackend(null) // the real backend, so realBackend() actually runs create()
+    runtimeMock.failNextCreate = true
+    try {
+      await expect(completeText({} as never, 'p')).rejects.toThrow('runtime unavailable')
+      await expect(completeText({} as never, 'p')).resolves.toMatchObject({ text: 'real answer' })
+      expect(runtimeMock.createCalls).toBe(2)
+    } finally {
+      runtimeMock.failNextCreate = false
+    }
+  })
+
   it('sends the prompt as a user turn with the system prompt and returns the reply', async () => {
     let seen: { system?: string; user?: unknown; maxTokens?: number } = {}
     setCompleteBackend(async (_model, context, options) => {

--- a/tests/output-styles.test.ts
+++ b/tests/output-styles.test.ts
@@ -31,6 +31,15 @@ describe('parseStyle', () => {
     expect(parseStyle(md, 'fallback').keepCodingInstructions).toBe(true)
   })
 
+  it('reads the YAML boolean spellings for both flags, not only the literal true', () => {
+    // Claude documents the fields as booleans; YAML spells true as yes/on/True too, and a
+    // style author writing `keep-coding-instructions: yes` meant to keep them.
+    expect(parseStyle('---\nkeep-coding-instructions: yes\n---\nB', 'x').keepCodingInstructions).toBe(true)
+    expect(parseStyle('---\nforce-for-plugin: True\n---\nB', 'x').forceForPlugin).toBe(true)
+    expect(parseStyle('---\nkeep-coding-instructions: no\n---\nB', 'x').keepCodingInstructions).toBe(false)
+    expect(parseStyle('---\nkeep-coding-instructions: maybe\n---\nB', 'x').keepCodingInstructions).toBe(false)
+  })
+
   it('parses CRLF frontmatter (Windows-authored files)', () => {
     const md = '---\r\nname: Terse\r\ndescription: Few words\r\n---\r\nBe terse.\r\n'
     expect(parseStyle(md, 'fallback')).toEqual({ name: 'Terse', description: 'Few words', body: 'Be terse.', keepCodingInstructions: false, forceForPlugin: false })


### PR DESCRIPTION
Seven defects from a full read of `extensions/` for correctness, security-adjacent shapes and maintainability, each verified against its callers (and where the claim rests on pi's host behaviour, against pi's own dist) before it became a fix, and each paired with a test that fails without it and a mutant it kills.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change

## A crash path in the non-blocking MCP connect

**The deferred startup summary no longer runs after a session switch** (`mcp/index.ts`). The second summary scheduled for late-connecting servers captured the `session_start` ctx in a bare `.then()`. pi disposes that ctx on `/new`, `/resume`, `/fork` and reload, and any use of it throws; from a bare `.then` that throw is an unhandled rejection, and pi installs no handler, so a server finishing its connect after a session switch would have taken the process down. A generation counter bumped by every `session_start` and `session_shutdown` gates the publish, with a `.catch` behind it.

## Config a repository must not be able to plant

**The project-config walk stops at a worktree's own root** (`internal/project-root.ts`). The walk's boundary was `repoRoot`, which for a worktree resolves to the main checkout, a sibling of the worktree and never one of its ancestors, so the boundary was never reached and the walk ran on to the filesystem root. `.claude/agents`, `CLAUDE.local.md`, `.mcp.json` and settings planted in the worktree's parent were discovered, the world-writable-ancestor case the module header exists to refuse. The boundary is now `gitRoot`, the worktree directory itself.

## Failures that became permanent

**A rejected `ModelRuntime.create` is retried** (`internal/model-complete.ts`). `backend ??= realBackend()` kept the rejected promise, so one transient failure turned every later completion, and with it prompt hooks, `web_fetch` prompts, `/goal` and session titles, into a process-lifetime outage nothing retried.

**A background run whose spawn throws synchronously is settled** (`subagent/background.ts`, `subagent/run.ts`). The foreground runner got this guard in the previous release; the background path had the same bare `spawn()` and registered the run first, so a synchronous throw (Linux `E2BIG` via `posix_spawn`) escaped the tool call and left a phantom holding a cap slot with no kill and no eviction, until "Too many background runs" for the life of the process. `spawnChild` is now shared and the failure settles through the same completion path as an asynchronous one.

**A `null` inside a hooks list no longer fails every tool call** (`hooks/config.ts`). The container was validated but not its entries; the dispatcher reads `.type` of each, so one `null` (a hand-edit that removed an entry's body, or a trailing bare list item in `SKILL.md` frontmatter) failed every tool call for the rest of the session with an opaque `TypeError`. Non-object entries are dropped with a warning and their siblings kept.

## Wrong results on valid input

**The command path-scope guard reads the `file_path` alias** (`commands.ts`). pi's read/edit/write accept `file_path` for `path`. The guard read only `path`, so a command with a `Read(...)`/`Edit(...)` scope blocked every aliased call, with an empty `Path:` in the reason. `internal/tool-target.ts` exists for exactly this and the paired guard in `hooks/matcher.ts` already read both.

**Output-style frontmatter booleans accept YAML spellings** (`output-styles.ts`, `internal/command-file.ts`). `keep-coding-instructions` and `force-for-plugin` compared the raw field to the literal `true`, so `yes`, `on` or `True` read as false: an author who meant to keep the coding instructions had them replaced. The command loader's YAML-aware reader is exported and shared.
