### PR TITLE
Strengthen twelve test oracles that let a named production mutant survive

### DIFF
--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1145,6 +1145,9 @@ describe('slash_command tool', () => {
     expect(tool?.label).toBe('SlashCommand')
     expect(tool?.description).toContain('/deploy - Deploy it ([env])')
     expect(tool?.description).not.toContain('/secret')
+    // Hidden from the model only: the user's own /secret still runs.
+    await s.commands.get('secret')?.handler('', s.ctx)
+    expect(s.sent).toEqual(['Secret steps.'])
   })
 
   it('does not register the tool when every command is user-only, or none exist', async () => {

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -191,6 +191,19 @@ describe('collectImports', () => {
     expect(collectImports('@missing.md and user@example.com', dir, dir, [dir], new Set())).toEqual([])
   })
 
+  it('blocks an import into a sibling whose name merely extends the root', () => {
+    // Every other "outside" fixture is an unrelated temp dir, which a prefix check
+    // without the separator would also reject; `proj` versus `proj-private` is the
+    // shape that check lets through.
+    const parent = tempDir()
+    const dir = join(parent, 'proj')
+    const sibling = join(parent, 'proj-private')
+    mkdirSync(dir)
+    mkdirSync(sibling)
+    writeFileSync(join(sibling, 'notes.md'), 'PRIVATE')
+    expect(collectImports(`@${join(sibling, 'notes.md')}`, dir, dir, [dir], new Set())).toEqual([])
+  })
+
   it('blocks an absolute import that escapes the allowed roots', () => {
     const dir = tempDir()
     const outside = tempDir()

--- a/tests/env-settings.test.ts
+++ b/tests/env-settings.test.ts
@@ -140,6 +140,21 @@ describe('env-settings extension', () => {
     for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
   })
 
+  it('strips a repo-hostile key from a trusted project env before it reaches the process', async () => {
+    // sanitizeProjectEnv is unit-tested; this pins that session_start actually routes a
+    // project's env through it. Without the wiring a trusted repository's settings.json
+    // could point CLAUDE_CONFIG_DIR (and HOME, XDG_*) wherever it likes.
+    const project = tempDir('env-proj-')
+    mkdirSync(join(project, '.git'))
+    writeSettings(project, 'settings.json', { CLAUDE_CONFIG_DIR: '/evil', ENVTEST_OK: 'fine' })
+    track('ENVTEST_OK')
+    hoisted.approved = true
+    const { handlers } = setup()
+    await handlers.get('session_start')?.({ reason: 'startup' }, { cwd: project, isProjectTrusted: () => true })
+    expect(process.env.ENVTEST_OK).toBe('fine')
+    expect(process.env.CLAUDE_CONFIG_DIR).not.toBe('/evil')
+  })
+
   it('applies an env edit to the running session when the settings file is saved', async () => {
     // Claude: "Claude Code watches your settings files and reloads them when they change,
     // so it applies most edits to the running session without a restart". `env` is not on

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -1511,7 +1511,9 @@ describe('hooks extension notify-style events', () => {
 
   it('does not treat a timed-out Stop hook as a block', async () => {
     const ext = await withHooks({ Stop: [{ matcher: undefined, hooks: [{ command: 'hung', timeout: 1 }] }] })
-    script('hung', { hang: true })
+    // The block decision is on stdout BEFORE the hang: a hook that emits nothing cannot
+    // block with or without the timed-out filter, so only this shape proves the filter.
+    script('hung', { stdout: [JSON.stringify({ decision: 'block', reason: 'not yet' })], hang: true })
     vi.useFakeTimers()
     const pending = ext.agentEnd()
     await vi.advanceTimersByTimeAsync(1500)
@@ -1756,7 +1758,10 @@ describe('hooks subagent lifecycle', () => {
     // The bus outlives the session: an event landing between /new disposing the ctx
     // and the next session_start hits disposed getters, and nothing awaits a bus
     // listener, so a throw here used to escape as an unhandled rejection.
-    writeSettings(hoisted.home, 'settings.json', { SubagentStart: [{ hooks: [{ command: 'sub-start' }] }] })
+    // The stop phase is the one the bus listener handles (start is returned before the
+    // guarded block), so only a SubagentStop config with a stop event reaches the
+    // getters this test is about.
+    writeSettings(hoisted.home, 'settings.json', { SubagentStop: [{ hooks: [{ command: 'sub-stop' }] }] })
     const ext = setupExtension()
     const disposed = () => {
       throw new Error('session disposed')
@@ -1766,7 +1771,7 @@ describe('hooks subagent lifecycle', () => {
       sessionManager: { getSessionId: disposed, getSessionFile: disposed },
       ui: { notify: disposed },
     })
-    const pending = ext.emitSubagent({ phase: 'start', agentType: 'scout', agentId: 'fg-1' }) as unknown as Promise<void>
+    const pending = ext.emitSubagent({ phase: 'stop', agentType: 'scout', agentId: 'fg-1' }) as unknown as Promise<void>
     await expect(pending).resolves.toBeUndefined()
   })
 })

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, readdirSync, statSync } from 'node:fs'
+import * as net from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -83,6 +84,14 @@ describe('FileOAuthProvider', () => {
     // The redirect URL names localhost. On a host with IPv6 the browser may reach ::1
     // while the listener sat on 127.0.0.1 alone, and the login would hang on a connection
     // refused with the code already granted.
+    // Probe first: on a host that can bind ::1 the answer must be 200, since "refused"
+    // there is exactly the hang the second listener exists to prevent. Accepting
+    // refused unconditionally let the listener be deleted without a test noticing.
+    const canBindIpv6 = await new Promise<boolean>((resolve) => {
+      const probe = net.createServer()
+      probe.once('error', () => resolve(false))
+      probe.listen(0, '::1', () => probe.close(() => resolve(true)))
+    })
     const { server, port } = await startCallbackServer()
     const code = waitForAuthCode(server, 2000)
     const viaIpv6 = await fetch(`http://[::1]:${port}/callback?code=v6-code`).then(
@@ -91,8 +100,9 @@ describe('FileOAuthProvider', () => {
     )
     server.close()
 
-    expect(viaIpv6 === 200 || viaIpv6 === 'refused').toBe(true)
-    if (viaIpv6 === 200) expect(await code).toBe('v6-code')
+    if (!canBindIpv6) return
+    expect(viaIpv6).toBe(200)
+    expect(await code).toBe('v6-code')
   })
 
   it('falls back to MCP_OAUTH_CALLBACK_PORT when no per-server oauth.callbackPort is set', () => {

--- a/tests/stat-token.test.ts
+++ b/tests/stat-token.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { statToken } from '../extensions/internal/stat-token.ts'
+
+/** The token is the change detector behind import expansion and memory-index reuse:
+ * a same-length edit changes mtime and nothing else, so mtime must be part of it.
+ * Every other rewrite fixture in the suite changes the size too, which a size-only
+ * token would also catch. */
+describe('statToken', () => {
+  const dirs: string[] = []
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('changes when only the mtime moves', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'stat-token-'))
+    dirs.push(dir)
+    const file = join(dir, 'a.md')
+    writeFileSync(file, 'same length')
+    const before = statToken(file)
+    const later = new Date(Date.now() + 60_000)
+    utimesSync(file, later, later)
+    expect(statToken(file)).not.toBe(before)
+  })
+
+  it('is stable while nothing changes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'stat-token-'))
+    dirs.push(dir)
+    const file = join(dir, 'a.md')
+    writeFileSync(file, 'same length')
+    expect(statToken(file)).toBe(statToken(file))
+  })
+})

--- a/tests/status-line-command.test.ts
+++ b/tests/status-line-command.test.ts
@@ -379,6 +379,11 @@ describe('statusLine command contract', () => {
     busHandlers.get('pi-code:plan-mode')?.({ active: true })
     await vi.advanceTimersByTimeAsync(400)
     expect(hoisted.runs.length).toBe(initial + 1)
+    // The re-run is worthless unless the script can see why: permission_mode is the
+    // field a status line reads to show plan mode.
+    const raw = hoisted.runs.at(-1)?.payload
+    const payload = typeof raw === 'string' ? JSON.parse(raw) : raw
+    expect(payload.permission_mode).toBe('plan')
   })
 })
 

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -484,6 +484,16 @@ describe('formatStatus', () => {
 
 describe('cancelBackgroundRun', () => {
   const invocation = { command: 'pi', args: ['--mode', 'json'], cwd: '/work/dir' }
+  // The fake child carries pid 4242, so an unspied cancel runs a real
+  // process.kill(-4242) against the host; every test here spies it. Any child left
+  // without a close is closed afterwards so the unref'd SIGKILL escalation timer
+  // cannot fire after the spy is restored.
+  beforeEach(() => {
+    vi.spyOn(process, 'kill').mockImplementation(() => true)
+  })
+  afterEach(() => {
+    for (const child of spawned.children) child.emit('close', 143)
+  })
 
   it('signals the run, reports cancelled state, and keeps it after the child exits', async () => {
     const { startBackgroundRun, cancelBackgroundRun, backgroundStatusText } = await loadBackground()
@@ -493,7 +503,7 @@ describe('cancelBackgroundRun', () => {
     })
 
     expect(cancelBackgroundRun(id as string)).toBe('cancelled')
-    expect(spawned.children[0].kill).toHaveBeenCalled()
+    expect(process.kill).toHaveBeenCalledWith(-4242, 'SIGTERM')
     expect(backgroundStatusText()).toContain('cancelled')
 
     // The child's non-zero exit is the cancellation; it must not read as a failure.
@@ -512,6 +522,15 @@ describe('cancelBackgroundRun', () => {
 })
 
 describe('cancelAllBackgroundRuns', () => {
+  // Same host guard as cancelBackgroundRun above: the fake pid would otherwise reach a
+  // real process.kill(-4242), and an unclosed child would leave the SIGKILL escalation
+  // timer armed past the spy's restore.
+  beforeEach(() => {
+    vi.spyOn(process, 'kill').mockImplementation(() => true)
+  })
+  afterEach(() => {
+    for (const child of spawned.children) child.emit('close', 143)
+  })
   const invocation = { command: 'pi', args: ['--mode', 'json'], cwd: '/work/dir' }
 
   it('signals every live child, marks them cancelled, and reports the count', async () => {
@@ -522,7 +541,7 @@ describe('cancelAllBackgroundRuns', () => {
     expect(activeBackgroundRuns()).toBe(2)
 
     expect(cancelAllBackgroundRuns()).toBe(2)
-    for (const child of spawned.children) expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(vi.mocked(process.kill).mock.calls.filter(([pid, signal]) => pid === -4242 && signal === 'SIGTERM')).toHaveLength(2)
     expect(backgroundStatusText()).not.toContain('running')
 
     // A cancelled child still holds its slot until it actually dies (SIGTERM may be ignored).
@@ -539,7 +558,7 @@ describe('cancelAllBackgroundRuns', () => {
     startBackgroundRun('scout', 'live-run', invocation, () => {})
 
     expect(cancelAllBackgroundRuns()).toBe(1)
-    expect(spawned.children[1].kill).toHaveBeenCalledWith('SIGTERM')
+    expect(vi.mocked(process.kill).mock.calls.filter(([pid, signal]) => pid === -4242 && signal === 'SIGTERM')).toHaveLength(1)
   })
 
   it('signals the process group, not just the direct child', async () => {

--- a/tests/subagent-gate.test.ts
+++ b/tests/subagent-gate.test.ts
@@ -11,6 +11,12 @@ describe('projectAgentGate', () => {
     expect(projectAgentGate(1, false, false, true)).toBe('refuse')
   })
 
+  it('still refuses them headless when the caller declines the prompt: a model parameter cannot grant trust', () => {
+    // confirmProjectAgents is model-supplied; the only cell that distinguishes
+    // "trusted" from "trusted or the model said not to ask".
+    expect(projectAgentGate(1, false, false, false)).toBe('refuse')
+  })
+
   it('confirms untrusted project agents interactively, even if the caller tried to skip the prompt', () => {
     expect(projectAgentGate(1, false, true, true)).toBe('confirm')
     expect(projectAgentGate(1, false, true, false)).toBe('confirm')

--- a/tests/web-more.test.ts
+++ b/tests/web-more.test.ts
@@ -249,8 +249,13 @@ describe('web_fetch responses', () => {
 
   it('sends the pi user agent, a timeout signal, and a pinned lookup to the transport', async () => {
     fetchMock.mockResolvedValue(respond('ok', { contentType: 'text/plain' }))
+    const timeoutSignal = vi.spyOn(AbortSignal, 'timeout')
     await setup().fetchUrl('https://example.com/a')
     const opts = fetchMock.mock.calls[0][1]
+    // `instanceof AbortSignal` is also true of a signal that never fires; the bound is
+    // the 20s timeout, and only a signal produced by AbortSignal.timeout carries it.
+    expect(timeoutSignal).toHaveBeenCalledWith(20_000)
+    expect(opts.signal).toBe(timeoutSignal.mock.results[0]?.value)
     expect(opts.userAgent).toBe('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) pi-code-web/0.1')
     // The transport never follows redirects and never re-resolves: the loop passes a lookup
     // already pinned to the validated address.


### PR DESCRIPTION
A read of every test in `tests/` against the production line it targets found twelve assertions that could not distinguish the code from a specific wrong version of it. Each fix names its mutant, and each was run against it: ten killed; the remaining two are host hazards rather than oracle gaps. No production code changes.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)

## Guards whose blocked side was proven with the wrong fixture

- **Import root boundary** (`context-imports.test.ts`): every "outside" fixture was an unrelated temp dir, which `startsWith(root)` also rejects. `proj` versus `proj-private` now pins the separator; without it a repo at `/home/u/proj` could `@../proj-private/notes.md`.
- **Project env sanitizer wiring** (`env-settings.test.ts`): `sanitizeProjectEnv` was unit-tested but nothing pinned that `session_start` routes a project's env through it. A trusted repository setting `CLAUDE_CONFIG_DIR` now proves it is dropped end to end.
- **Project-agent gate** (`subagent-gate.test.ts`): the untrusted + headless + `confirmProjectAgents: false` cell was the one that separates "trusted" from "trusted, or the model said not to ask". A model-supplied parameter cannot grant trust.
- **Timed-out Stop hook** (`hooks-more.test.ts`): the hung script emitted nothing, which cannot block with or without the timed-out filter. A block decision on stdout before the hang is the shape that proves the filter.

## Assertions satisfied by an unrelated reason

- **Disposed-ctx SubagentStop** (`hooks-more.test.ts`): the test emitted `phase: 'start'`, which the listener returns on before the guarded block, so the throwing getters were never called. `phase: 'stop'` with a `SubagentStop` config reaches them.
- **IPv6 OAuth callback** (`mcp-oauth.test.ts`): accepted "refused", which is exactly the hang the second listener exists to prevent. The test now probes whether `::1` is bindable and, where it is, requires 200.
- **Fetch timeout** (`web-more.test.ts`): `instanceof AbortSignal` is true of a signal that never fires. The 20s bound is now asserted through `AbortSignal.timeout` and the signal handed to the transport must be the one it produced.
- **Plan-mode status line** (`status-line-command.test.ts`): the re-run was asserted by count only; the payload now has to carry `permission_mode: 'plan'`.
- **Model-hidden command** (`commands.test.ts`): only the model side was proven. The user's own `/secret` is now invoked and must run.
- **Stat token** (`stat-token.test.ts`, new): every rewrite fixture in the suite changed the size too, so the mtime half of the token was never the discriminator. A same-length, mtime-only change now pins it.

## Host hazard

**Background cancel tests** (`subagent-agents-background.test.ts`): the fake child carries `pid: 4242` and `process.kill` was unspied in two describes, so each cancel ran a real `process.kill(-4242, 'SIGTERM')` against the host, and the `child.kill` assertions passed only because that threw `ESRCH` and the fallback fired. Both describes now spy `process.kill`, assert the group signal that the fake pid exists to model, and close every child afterwards so the unref'd SIGKILL escalation timer cannot fire after the spy is restored.