### PR TITLE
Fix seven Round 5 defects: connect race, Windows cancel, hook validation, OAuth crash

### DIFF
--- a/extensions/hooks/index.ts
+++ b/extensions/hooks/index.ts
@@ -703,7 +703,11 @@ export default function hooksExtension(pi: ExtensionAPI) {
     // Claude's custom_instructions: the /compact arguments on a manual run, empty
     // on an automatic one; pi carries them on the event directly.
     const payload = { hook_event_name: 'PreCompact', trigger: trigger.value, custom_instructions: event.customInstructions ?? '' }
-    const results = await runNotifyHooks(matchingCommands(config.PreCompact, trigger.names), payload, boundRunner(ctx))
+    // Filtered here the way runNotifyHooks filters, so `results[index]` and
+    // `commands[index]` name the same hook: indexing the unfiltered list named the
+    // wrong command in the notice whenever an `if`-carrying hook preceded the blocker.
+    const commands = matchingCommands(config.PreCompact, trigger.names).filter((command) => passesIfFilter(command, undefined))
+    const results = await runNotifyHooks(commands, payload, boundRunner(ctx))
     surfaceSystemMessages(results, (message) => ctx.ui.notify(message, 'warning'))
     // Claude: "Exit with code 2 to block compaction. For a manual /compact, the stderr
     // message is shown to the user. You can also block by returning JSON with
@@ -713,7 +717,7 @@ export default function hooksExtension(pi: ExtensionAPI) {
       const parsed = tryParseJson(result.stdout)
       const blocked = result.code === 2 && !result.timedOut ? { reason: result.stderr.trim() || 'Compaction blocked by hook' } : jsonBlockVerdict(parsed, 'Compaction blocked by hook')
       if (!blocked) continue
-      ctx.ui.notify(`Compaction blocked by ${matchingCommands(config.PreCompact, trigger.names)[index]?.command ?? 'hook'}: ${blocked.reason}`, 'warning')
+      ctx.ui.notify(`Compaction blocked by ${commands[index]?.command ?? 'hook'}: ${blocked.reason}`, 'warning')
       return { cancel: true }
     }
   })

--- a/extensions/hooks/matcher.ts
+++ b/extensions/hooks/matcher.ts
@@ -93,7 +93,13 @@ function isRunnableHook(hook: HookCommand): boolean {
   if (hook.type === 'http') return typeof hook.url === 'string' && /^https?:\/\//.test(hook.url)
   if (hook.type === 'prompt' || hook.type === 'agent') return typeof hook.prompt === 'string' && hook.prompt.length > 0
   if (hook.type === 'mcp_tool') return typeof hook.server === 'string' && typeof hook.tool === 'string'
-  return typeof hook.command === 'string' && (hook.type === undefined || hook.type === 'command')
+  // A command hook needs a non-empty command, and exec-form args must all be strings:
+  // spawn('') throws ERR_INVALID_ARG_VALUE and a number has no replaceAll for argument
+  // substitution, both inside the runner's Promise executor, so the event's handler
+  // rejected instead of the hook reporting spawnFailed.
+  if (typeof hook.command !== 'string' || hook.command.length === 0) return false
+  if (hook.args !== undefined && !(Array.isArray(hook.args) && hook.args.every((arg) => typeof arg === 'string'))) return false
+  return hook.type === undefined || hook.type === 'command'
 }
 
 /** The synthetic identity of a non-shell hook entry: an http/prompt/agent/mcp_tool

--- a/extensions/hooks/runners.ts
+++ b/extensions/hooks/runners.ts
@@ -6,7 +6,6 @@
 
 import { type ChildProcess, spawn } from 'node:child_process'
 import * as fs from 'node:fs'
-import * as path from 'node:path'
 import type { Api, Model } from '@earendil-works/pi-ai'
 import { runAgent } from '../internal/agent-run.js'
 import { callMcpTool } from '../internal/mcp-call.js'

--- a/extensions/hooks/runners.ts
+++ b/extensions/hooks/runners.ts
@@ -11,6 +11,7 @@ import type { Api, Model } from '@earendil-works/pi-ai'
 import { runAgent } from '../internal/agent-run.js'
 import { callMcpTool } from '../internal/mcp-call.js'
 import { completeText } from '../internal/model-complete.js'
+import { killProcessTree } from '../internal/process-tree.js'
 import { resolveShell } from '../internal/shell-resolve.js'
 import { errorMessage } from '../internal/values.js'
 import { type HookCommand, httpUrlAllowed, isBackgroundHook } from './config.js'
@@ -96,30 +97,9 @@ const MAX_HOOK_OUTPUT = 1_000_000
 /** Conventional exit code for a killed-on-timeout command, as `timeout(1)` reports it. */
 const TIMEOUT_EXIT_CODE = 124
 
-/**
- * Kill the shell and everything it spawned. `sh -c 'a; b'` forks, so signalling the
- * direct child alone leaves a grandchild alive holding stdout/stderr.
- */
+/** Kill the shell and everything it spawned; see internal/process-tree. */
 function killTree(child: ChildProcess): void {
-  if (process.platform === 'win32') {
-    // Windows has no process groups: taskkill /T ends the shell's whole tree. By
-    // absolute path, so a writable PATH entry cannot stand in for it. If taskkill itself
-    // cannot start, the direct kill is all that is left.
-    const taskkill = path.join(process.env.SystemRoot ?? String.raw`C:\Windows`, 'System32', 'taskkill.exe')
-    if (child.pid) spawn(taskkill, ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true }).on('error', () => child.kill('SIGKILL'))
-    else child.kill('SIGKILL')
-    return
-  }
-  try {
-    // Negative pid targets the whole process group, which `detached` gave the shell.
-    if (child.pid) {
-      process.kill(-child.pid, 'SIGKILL')
-      return
-    }
-  } catch {
-    // Group already reaped, or the platform refused it; fall through to the direct kill.
-  }
-  child.kill('SIGKILL')
+  killProcessTree(child, 'SIGKILL')
 }
 
 /** Create the plugin data directory the moment its path is handed to a child. Claude

--- a/extensions/internal/mcp-oauth.ts
+++ b/extensions/internal/mcp-oauth.ts
@@ -248,7 +248,17 @@ export function waitForAuthCode(server: http.Server, timeoutMs: number, expected
     // abandoned or resolved out of band, the event loop can still drain.
     timer.unref?.()
     server.on('request', (request, response) => {
-      const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+      // Node's parser passes an absolute-form target through unvalidated, and a throw
+      // from a 'request' listener is not caught by node:http: it was an
+      // uncaughtException during the login window, from any local process that could
+      // reach the port.
+      let url: URL
+      try {
+        url = new URL(request.url ?? '/', 'http://127.0.0.1')
+      } catch {
+        response.writeHead(400).end()
+        return
+      }
       // Only the redirect path settles the login. A stray request (a favicon fetch, a
       // local port scan, or a forged redirect from another process or an open web page)
       // is answered but ignored, so it can neither inject a code nor abort the login by

--- a/extensions/internal/process-tree.ts
+++ b/extensions/internal/process-tree.ts
@@ -13,11 +13,12 @@ export function killProcessTree(child: ChildProcess, signal: NodeJS.Signals, pla
   if (platform === 'win32') {
     // Windows has no process groups: taskkill /T ends the whole tree, and it has no
     // graceful signal, so SIGTERM and SIGKILL both force. By absolute path, so a
-    // writable PATH entry cannot stand in for it. If taskkill itself cannot start,
-    // the direct kill is all that is left.
+    // writable PATH entry cannot stand in for it. If taskkill itself cannot start, or
+    // there is no pid to hand it, the direct kill with the requested signal is all
+    // that is left (Node maps either signal to TerminateProcess there).
     const taskkill = path.join(process.env.SystemRoot ?? String.raw`C:\Windows`, 'System32', 'taskkill.exe')
-    if (child.pid) spawn(taskkill, ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true }).on('error', () => child.kill('SIGKILL'))
-    else child.kill('SIGKILL')
+    if (child.pid) spawn(taskkill, ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true }).on('error', () => child.kill(signal))
+    else child.kill(signal)
     return
   }
   try {

--- a/extensions/internal/process-tree.ts
+++ b/extensions/internal/process-tree.ts
@@ -1,0 +1,38 @@
+/**
+ * Kill a detached child and everything it spawned. `sh -c 'a; b'` forks, and so does
+ * a child pi running a build, so signalling the direct child alone leaves a grandchild
+ * alive holding stdout/stderr. One copy for hooks and both subagent runners: the three
+ * private copies had drifted, and only the hooks one handled Windows, so a subagent
+ * cancel there killed the direct child only.
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process'
+import * as path from 'node:path'
+
+export function killProcessTree(child: ChildProcess, signal: NodeJS.Signals, platform: NodeJS.Platform = process.platform): void {
+  if (platform === 'win32') {
+    // Windows has no process groups: taskkill /T ends the whole tree, and it has no
+    // graceful signal, so SIGTERM and SIGKILL both force. By absolute path, so a
+    // writable PATH entry cannot stand in for it. If taskkill itself cannot start,
+    // the direct kill is all that is left.
+    const taskkill = path.join(process.env.SystemRoot ?? String.raw`C:\Windows`, 'System32', 'taskkill.exe')
+    if (child.pid) spawn(taskkill, ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true }).on('error', () => child.kill('SIGKILL'))
+    else child.kill('SIGKILL')
+    return
+  }
+  try {
+    // Negative pid targets the whole process group, which `detached` gave the child.
+    // A child that never spawned has no pid and no group; the direct kill is all there is.
+    if (child.pid) {
+      process.kill(-child.pid, signal)
+      return
+    }
+  } catch {
+    // Group already reaped, or the platform refused it; fall through to the direct kill.
+  }
+  try {
+    child.kill(signal)
+  } catch {
+    // already gone
+  }
+}

--- a/extensions/mcp/config.ts
+++ b/extensions/mcp/config.ts
@@ -10,6 +10,7 @@ import { claudeConfigDir } from '../internal/config-dir.js'
 import type { OAuthServerConfig } from '../internal/mcp-oauth.js'
 import { type InstalledPlugin, pluginComponentPath } from '../internal/plugins.js'
 import { findNearestFile } from '../internal/project-root.js'
+import { errorMessage } from '../internal/values.js'
 
 export interface StdioServerConfig {
   type?: 'stdio'
@@ -107,8 +108,10 @@ export function loadConfigFrom(files: string[]): Record<string, ServerConfig> {
     try {
       const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'))
       Object.assign(servers, parsed.mcpServers ?? {})
-    } catch {
-      // missing or invalid file: skip silently, /mcp reports what loaded
+    } catch (error) {
+      // A missing file is the normal case. A present file that does not parse is
+      // not: one trailing comma silently disabled every server in it.
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') console.warn(`pi-code-mcp: ignoring ${file}: ${errorMessage(error)}`)
     }
   }
   return servers
@@ -132,7 +135,8 @@ function projectRecord(home: string, cwd: string): { mcpServers?: Record<string,
   try {
     const claudeJson = JSON.parse(fs.readFileSync(claudeJsonPath(home), 'utf-8'))
     return claudeJson.projects?.[cwd] ?? {}
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') console.warn(`pi-code-mcp: ignoring ${claudeJsonPath(home)}: ${errorMessage(error)}`)
     return {}
   }
 }

--- a/extensions/mcp/index.ts
+++ b/extensions/mcp/index.ts
@@ -85,6 +85,12 @@ function authUiFor(ctx: ExtensionContext): AuthUi | undefined {
 
 export default async function mcpExtension(pi: ExtensionAPI) {
   const clients = new Map<string, Client>()
+  // Names with a connect in flight. A name enters `clients` only once its connect
+  // resolves, and shutdown clears that map without awaiting anything in flight, so
+  // without this set a session switch during a slow connect (or a backoff sleep) let
+  // the next session_start connect the same name again; the first client then resolved
+  // into an entry the second overwrote and was never closed.
+  const connecting = new Set<string>()
   // The session's OAuth UI seams, captured at session_start. The reconnect paths below
   // run outside that handler, and passing undefined there made an INTERACTIVE session
   // report the headless "cannot log in" advice on a re-auth it could actually perform.
@@ -194,7 +200,7 @@ export default async function mcpExtension(pi: ExtensionAPI) {
   async function reconnectWithBackoff(name: string, config: ServerConfig): Promise<void> {
     for (let attempt = 0; attempt < 5; attempt++) {
       await new Promise((resolve) => setTimeout(resolve, 1000 * 2 ** attempt))
-      if (shuttingDown || clients.has(name)) return
+      if (shuttingDown || clients.has(name) || connecting.has(name)) return
       await connectServers({ [name]: config }, sessionAuthUi, true)
       if (clients.has(name)) return
     }
@@ -415,10 +421,15 @@ export default async function mcpExtension(pi: ExtensionAPI) {
         console.warn(`pi-code-mcp: skipping duplicate server name ${name}`)
         continue
       }
+      // The one guard for every connect path (session_start scopes, backoff, auth
+      // reconnect): a name still connecting from the previous session is adopted when
+      // that connect resolves, not connected again.
+      if (connecting.has(name)) continue
       // Seed in config order before connecting: parallel connects settle in completion
       // order, and /mcp plus the session summary iterate the map's insertion order.
       status.set(name, { state: 'connecting', tools: 0 })
       serverConfigs.set(name, config)
+      connecting.add(name)
       pending.push([name, config])
     }
     await Promise.all(
@@ -428,6 +439,14 @@ export default async function mcpExtension(pi: ExtensionAPI) {
           // First connections retry transient failures (Claude: up to three times for
           // HTTP/SSE); the backoff reconnect below carries its own schedule instead.
           const client = noRetry ? await connect(name, config, authUi, sessionDirs) : await connectWithRetries(name, config, authUi, sessionDirs)
+          // A session switch resets shuttingDown before this resolves and adopts the
+          // client; still set, pi is exiting and the shutdown handler already closed
+          // every client it could see, so this late one must close itself.
+          if (shuttingDown) {
+            await withTimeout(client.close(), 3000, 'close').catch(() => {})
+            status.delete(name)
+            return
+          }
           clients.set(name, client)
           const tools = await withTimeout(listAllTools(client), connectTimeoutMs(), `list tools ${name}`)
           registerTools(name, config, tools)
@@ -465,6 +484,8 @@ export default async function mcpExtension(pi: ExtensionAPI) {
             clients.delete(name)
             void leaked.close().catch(() => {})
           }
+        } finally {
+          connecting.delete(name)
         }
       }),
     )

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -45,7 +45,9 @@ export interface OutputStyle {
 /** A frontmatter field as text, or '' when absent or not scalar. */
 function field(frontmatter: Record<string, unknown>, key: string): string {
   const value = frontmatter[key]
-  return typeof value === 'string' ? value.trim() : typeof value === 'number' || typeof value === 'boolean' ? String(value) : ''
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return ''
 }
 
 /** Parse an output-style markdown file into its name, description, and body. pi's

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -22,7 +22,7 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import { type ExtensionAPI, parseFrontmatter } from '@earendil-works/pi-coding-agent'
 import { atomicWriteFile } from './internal/atomic-write.js'
 import { isFlagEnabled } from './internal/command-file.js'
 import { claudeConfigDir } from './internal/config-dir.js'
@@ -42,16 +42,17 @@ export interface OutputStyle {
   forceForPlugin: boolean
 }
 
-function field(frontmatter: string, key: string): string {
-  const match = new RegExp(String.raw`^\s*${key}\s*:\s*(.+)$`, 'm').exec(frontmatter)
-  return match ? match[1].trim().replace(/^["']|["']$/g, '') : ''
+/** A frontmatter field as text, or '' when absent or not scalar. */
+function field(frontmatter: Record<string, unknown>, key: string): string {
+  const value = frontmatter[key]
+  return typeof value === 'string' ? value.trim() : typeof value === 'number' || typeof value === 'boolean' ? String(value) : ''
 }
 
-/** Parse an output-style markdown file into its name, description, and body. */
+/** Parse an output-style markdown file into its name, description, and body. pi's
+ * own YAML frontmatter parser, as the command loader uses: a line regex captured to
+ * end of line, so `"Terse" # short` came back as `Terse" # short`. */
 export function parseStyle(content: string, fallbackName: string): OutputStyle {
-  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)
-  const frontmatter = match ? match[1] : ''
-  const body = match ? content.slice(match[0].length) : content
+  const { frontmatter, body } = parseFrontmatter(content)
   return {
     name: field(frontmatter, 'name') || fallbackName,
     description: field(frontmatter, 'description'),

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -10,6 +10,7 @@ import { randomUUID } from 'node:crypto'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { killProcessTree } from '../internal/process-tree.js'
 import { errorMessage } from '../internal/values.js'
 import { spawnChild } from './run.js'
 
@@ -315,19 +316,7 @@ function driveRun(run: BackgroundRun, invocation: BackgroundSpawn, onComplete: (
   }
   const proc = spawned.proc
   run.live = true
-  const killGroup = (signal: NodeJS.Signals): void => {
-    try {
-      // A child that never spawned has no pid and no group; the direct kill is all there is.
-      if (proc.pid) process.kill(-proc.pid, signal)
-      else proc.kill(signal)
-    } catch {
-      try {
-        proc.kill(signal)
-      } catch {
-        // already gone
-      }
-    }
-  }
+  const killGroup = (signal: NodeJS.Signals): void => killProcessTree(proc, signal)
   run.kill = () => {
     killGroup('SIGTERM')
     // A child ignoring SIGTERM would hold its cap slot and process forever.

--- a/extensions/subagent/run.ts
+++ b/extensions/subagent/run.ts
@@ -17,6 +17,7 @@ import type { AgentToolResult } from '@earendil-works/pi-agent-core'
 import type { Message } from '@earendil-works/pi-ai'
 import { withFileMutationQueue } from '@earendil-works/pi-coding-agent'
 
+import { killProcessTree } from '../internal/process-tree.js'
 import { runSubagentStartHooks } from '../internal/subagent-hooks.js'
 import { type AgentConfig, resolveModelAlias } from './agents.js'
 import { agentHooksEnv, agentInvocationArgs, agentMemoryPromptSection, childPromptBody, taskWithStartContext, unresolvedToolsError, withMemoryTools } from './child.js'
@@ -348,19 +349,7 @@ async function runSingleAgentInner(options: RunAgentOptions): Promise<SingleResu
         resolve(1)
       })
 
-      const killGroup = (sig: NodeJS.Signals): void => {
-        try {
-          // A child that never spawned has no pid and no group; the direct kill is all there is.
-          if (proc.pid) process.kill(-proc.pid, sig)
-          else proc.kill(sig)
-        } catch {
-          try {
-            proc.kill(sig)
-          } catch {
-            /* already gone */
-          }
-        }
-      }
+      const killGroup = (sig: NodeJS.Signals): void => killProcessTree(proc, sig)
       if (signal) {
         onAbort = () => {
           wasAborted = true

--- a/tests/hooks-more.test.ts
+++ b/tests/hooks-more.test.ts
@@ -642,6 +642,32 @@ describe('loadHooks malformed config shapes', () => {
     expect(matchingCommands(config.PreToolUse, 'Bash').map((c) => c.command)).toEqual(['guard'])
   })
 
+  it('drops an exec-form hook with an empty command or a non-string arg instead of throwing per call', () => {
+    // spawn('') throws ERR_INVALID_ARG_VALUE and substituteArguments(42) has no
+    // replaceAll; both threw inside the runner's Promise executor, so the event's
+    // handler rejected instead of the hook reporting spawnFailed.
+    const dir = tempDir('hooks-cfg-')
+    const file = join(dir, 'settings.json')
+    writeFileSync(
+      file,
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              hooks: [
+                { command: '', args: ['x'] },
+                { command: 'ok', args: [42] },
+                { command: 'fine', args: ['a'] },
+              ],
+            },
+          ],
+        },
+      }),
+    )
+    const config = loadHooks([file])
+    expect(matchingCommands(config.PreToolUse, 'Bash').map((c) => c.command)).toEqual(['fine'])
+  })
+
   it('ignores an event whose matchers are not an array', () => {
     const dir = tempDir('hooks-cfg-')
     const file = join(dir, 'settings.json')
@@ -1530,6 +1556,15 @@ describe('hooks extension notify-style events', () => {
     await vi.advanceTimersByTimeAsync(1500)
     await pending
     expect(ext.sent).toEqual([])
+  })
+
+  it('names the blocking PreCompact hook, not the if-carrying one that was skipped before it', async () => {
+    // runNotifyHooks drops `if`-carrying hooks, so results index the filtered list; the
+    // notice indexed the unfiltered one and named the skipped hook instead.
+    const ext = await withHooks({ PreCompact: [{ hooks: [{ command: 'skipped', if: 'Bash(x)' }, { command: 'blocker' }] }] })
+    script('blocker', { code: 2, stderr: ['context still needed'] })
+    await ext.beforeCompact('manual')
+    expect(ext.notes).toEqual([{ msg: 'Compaction blocked by blocker: context still needed', level: 'warning' }])
   })
 
   it('runs PreCompact hooks matching the compaction trigger', async () => {

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -1350,10 +1350,52 @@ describe('mcp failure reporting', () => {
     resolvers[0]?.() // the first session's connect finishes after that session is gone
     await vi.advanceTimersByTimeAsync(0)
     expect(harness.notifications.length).toBe(before)
+  })
 
-    resolvers[1]?.() // the live session's own late connect still publishes
+  it('does not connect a name a second time when a session switch lands during its connect', async () => {
+    // Only a resolved connect put a name in `clients`, and shutdown cleared the map
+    // without awaiting anything in flight, so the next session_start saw a free name
+    // and spawned a second server. The first connect then resolved into a map entry the
+    // second overwrote: never closed, its process alive until pi exited.
+    const resolvers: Array<() => void> = []
+    hoisted.control.connect = () => new Promise<void>((r) => resolvers.push(r))
+    withTools([{ name: 'go' }])
+    vi.useFakeTimers()
+
+    const harness = await setup({ user: { slow: { command: 'x' } } })
+    const first = harness.sessionStart()
+    await vi.advanceTimersByTimeAsync(5_000)
+    await first
+    await harness.shutdown()
+    const second = harness.sessionStart()
+    await vi.advanceTimersByTimeAsync(5_000)
+    await second
+    expect(resolvers).toHaveLength(1)
+
+    resolvers[0]?.() // the one connect finishes into the live session
     await vi.advanceTimersByTimeAsync(0)
-    expect(harness.notifications.length).toBe(before + 1)
+    expect(await statusLinesOf(harness)).toEqual(['slow: connected (1 tools)'])
+    expect(hoisted.closed).toHaveLength(0)
+  })
+
+  it('closes a client whose connect resolves after pi began shutting down', async () => {
+    // With no next session to adopt it, the late client is invisible to the shutdown
+    // handler that already ran; left alone it would idle its process past pi's exit.
+    const resolvers: Array<() => void> = []
+    hoisted.control.connect = () => new Promise<void>((r) => resolvers.push(r))
+    withTools([{ name: 'go' }])
+    vi.useFakeTimers()
+
+    const harness = await setup({ user: { slow: { command: 'x' } } })
+    const booting = harness.sessionStart()
+    await vi.advanceTimersByTimeAsync(5_000)
+    await booting
+    await harness.shutdown()
+
+    resolvers[0]?.()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(hoisted.closed).toHaveLength(1)
+    expect(await statusLinesOf(harness)).not.toContain('slow: connected (1 tools)')
   })
 
   it('returns from session_start without waiting for a hung server, in an interactive session', async () => {

--- a/tests/mcp-oauth.test.ts
+++ b/tests/mcp-oauth.test.ts
@@ -80,6 +80,29 @@ describe('FileOAuthProvider', () => {
     expect(provider.clientMetadata.token_endpoint_auth_method).toBe('none')
   })
 
+  it('answers a malformed request target with 400 instead of throwing out of the listener', async () => {
+    // Node's parser passes an absolute-form target through unvalidated; `new URL` on
+    // one with an out-of-range port throws, and a throw from a 'request' listener is
+    // not caught by node:http: it was an uncaughtException during the login window.
+    const { server, port } = await startCallbackServer()
+    const code = waitForAuthCode(server, 2000)
+    code.catch(() => {})
+    const status = await new Promise<string>((resolve, reject) => {
+      const socket = net.connect(port, '127.0.0.1', () => {
+        socket.write('GET http://x:99999/ HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n')
+      })
+      let raw = ''
+      socket.on('data', (chunk) => {
+        raw += chunk.toString()
+      })
+      socket.on('end', () => resolve(raw.split('\r\n')[0] ?? ''))
+      socket.on('error', reject)
+    })
+    server.close()
+
+    expect(status).toContain(' 400 ')
+  })
+
   it('answers the callback on both loopback families, since localhost may resolve to either', async () => {
     // The redirect URL names localhost. On a host with IPv6 the browser may reach ::1
     // while the listener sat on 127.0.0.1 alone, and the login would hang on a connection

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -281,11 +281,15 @@ describe('mcp adapter helpers', () => {
     expect((merged.b as { command: string }).command).toBe('override')
   })
 
-  it('skips missing and invalid config files', () => {
+  it('skips missing and invalid config files, warning only about the invalid one', () => {
+    // One catch swallowed ENOENT and a parse error alike, so a trailing comma in a
+    // project .mcp.json disabled every server in it with nothing in the log.
     const dir = mkdtempSync(join(tmpdir(), 'mcp-test-'))
     const broken = join(dir, 'broken.json')
     writeFileSync(broken, '{not json')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(loadConfigFrom([join(dir, 'absent.json'), broken])).toEqual({})
+    expect(warn.mock.calls.map((call) => String(call[0]))).toEqual([expect.stringContaining(broken)])
   })
 
   it('separates always-loaded user config from trust-gated project config', () => {

--- a/tests/output-styles.test.ts
+++ b/tests/output-styles.test.ts
@@ -40,6 +40,13 @@ describe('parseStyle', () => {
     expect(parseStyle('---\nkeep-coding-instructions: maybe\n---\nB', 'x').keepCodingInstructions).toBe(false)
   })
 
+  it('parses the frontmatter as YAML, so a trailing comment does not leak into a value', () => {
+    // The regex reader captured to end of line and stripped one quote from each end:
+    // `"Terse" # short` came back as `Terse" # short`.
+    const style = parseStyle('---\nname: Diagrams\ndescription: "Terse" # keep it short\n---\nBody', 'x')
+    expect(style.description).toBe('Terse')
+  })
+
   it('parses CRLF frontmatter (Windows-authored files)', () => {
     const md = '---\r\nname: Terse\r\ndescription: Few words\r\n---\r\nBe terse.\r\n'
     expect(parseStyle(md, 'fallback')).toEqual({ name: 'Terse', description: 'Few words', body: 'Be terse.', keepCodingInstructions: false, forceForPlugin: false })

--- a/tests/process-tree.test.ts
+++ b/tests/process-tree.test.ts
@@ -1,0 +1,67 @@
+import type { ChildProcess } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const spawned = vi.hoisted(() => ({ calls: [] as Array<{ file: string; args: string[] }>, child: undefined as EventEmitter | undefined }))
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  spawn: (file: string, args: string[]) => {
+    spawned.calls.push({ file, args })
+    spawned.child = new EventEmitter()
+    return spawned.child
+  },
+}))
+
+const { killProcessTree } = await import('../extensions/internal/process-tree.ts')
+
+const fakeChild = (pid: number | undefined) => ({ pid, kill: vi.fn() }) as unknown as ChildProcess & { kill: ReturnType<typeof vi.fn> }
+
+describe('killProcessTree', () => {
+  afterEach(() => {
+    spawned.calls.length = 0
+  })
+
+  it('signals the whole process group on POSIX and leaves the direct kill alone', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const child = fakeChild(4242)
+    killProcessTree(child, 'SIGTERM', 'linux')
+    expect(kill).toHaveBeenCalledWith(-4242, 'SIGTERM')
+    expect(child.kill).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the direct kill when the group signal is refused', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' })
+    })
+    const child = fakeChild(4242)
+    killProcessTree(child, 'SIGKILL', 'darwin')
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+
+  it('kills a child that never got a pid directly', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const child = fakeChild(undefined)
+    killProcessTree(child, 'SIGTERM', 'linux')
+    expect(kill).not.toHaveBeenCalled()
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('ends the tree with taskkill by absolute path on Windows, whatever the signal', () => {
+    // A subagent cancel used to signal only the direct child here; the hooks copy was
+    // the only one that knew Windows has no process groups.
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const child = fakeChild(777)
+    killProcessTree(child, 'SIGTERM', 'win32')
+    expect(kill).not.toHaveBeenCalled()
+    expect(spawned.calls).toEqual([{ file: join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'taskkill.exe'), args: ['/pid', '777', '/T', '/F'] }])
+    expect(child.kill).not.toHaveBeenCalled()
+  })
+
+  it('force-kills the direct child on Windows when taskkill itself cannot start', () => {
+    const child = fakeChild(777)
+    killProcessTree(child, 'SIGTERM', 'win32')
+    spawned.child?.emit('error', new Error('ENOENT'))
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+})

--- a/tests/process-tree.test.ts
+++ b/tests/process-tree.test.ts
@@ -58,10 +58,17 @@ describe('killProcessTree', () => {
     expect(child.kill).not.toHaveBeenCalled()
   })
 
-  it('force-kills the direct child on Windows when taskkill itself cannot start', () => {
+  it('kills the direct child with the requested signal on Windows when taskkill itself cannot start', () => {
     const child = fakeChild(777)
     killProcessTree(child, 'SIGTERM', 'win32')
     spawned.child?.emit('error', new Error('ENOENT'))
-    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('kills a pid-less child directly with the requested signal on Windows too', () => {
+    const child = fakeChild(undefined)
+    killProcessTree(child, 'SIGTERM', 'win32')
+    expect(spawned.calls).toEqual([])
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
   })
 })

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -482,6 +482,10 @@ describe('formatStatus', () => {
   })
 })
 
+/** How many times the fake child's whole tree was signalled: the POSIX group kill,
+ * or on Windows (no process groups) a taskkill /T spawn for its pid. */
+const treeSignals = (signal: NodeJS.Signals): number => (process.platform === 'win32' ? spawned.calls.filter((call) => call.args.join(' ') === '/pid 4242 /T /F').length : vi.mocked(process.kill).mock.calls.filter(([pid, sig]) => pid === -4242 && sig === signal).length)
+
 describe('cancelBackgroundRun', () => {
   const invocation = { command: 'pi', args: ['--mode', 'json'], cwd: '/work/dir' }
   // The fake child carries pid 4242, so an unspied cancel runs a real
@@ -503,7 +507,7 @@ describe('cancelBackgroundRun', () => {
     })
 
     expect(cancelBackgroundRun(id as string)).toBe('cancelled')
-    expect(process.kill).toHaveBeenCalledWith(-4242, 'SIGTERM')
+    expect(treeSignals('SIGTERM')).toBe(1)
     expect(backgroundStatusText()).toContain('cancelled')
 
     // The child's non-zero exit is the cancellation; it must not read as a failure.
@@ -541,7 +545,7 @@ describe('cancelAllBackgroundRuns', () => {
     expect(activeBackgroundRuns()).toBe(2)
 
     expect(cancelAllBackgroundRuns()).toBe(2)
-    expect(vi.mocked(process.kill).mock.calls.filter(([pid, signal]) => pid === -4242 && signal === 'SIGTERM')).toHaveLength(2)
+    expect(treeSignals('SIGTERM')).toBe(2)
     expect(backgroundStatusText()).not.toContain('running')
 
     // A cancelled child still holds its slot until it actually dies (SIGTERM may be ignored).
@@ -558,7 +562,7 @@ describe('cancelAllBackgroundRuns', () => {
     startBackgroundRun('scout', 'live-run', invocation, () => {})
 
     expect(cancelAllBackgroundRuns()).toBe(1)
-    expect(vi.mocked(process.kill).mock.calls.filter(([pid, signal]) => pid === -4242 && signal === 'SIGTERM')).toHaveLength(1)
+    expect(treeSignals('SIGTERM')).toBe(1)
   })
 
   it('signals the process group, not just the direct child', async () => {
@@ -570,7 +574,7 @@ describe('cancelAllBackgroundRuns', () => {
     try {
       startBackgroundRun('scout', 'grp', invocation, () => {})
       cancelAllBackgroundRuns()
-      expect(killSpy).toHaveBeenCalledWith(-4242, 'SIGTERM')
+      expect(treeSignals('SIGTERM')).toBe(1)
     } finally {
       killSpy.mockRestore()
     }

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -1787,7 +1787,9 @@ describe('foreground abort process group', () => {
       ;(spawnedChildren[0] as { pid?: number }).pid = 424242
       controller.abort()
       await expect(pending).rejects.toThrow('Subagent was aborted')
-      expect(groupKills).toContainEqual([-424242, 'SIGTERM'])
+      // Windows has no process groups: the tree ends through taskkill /T instead.
+      if (process.platform === 'win32') expect(spawnCalls.map((c) => c.args)).toContainEqual(['/pid', '424242', '/T', '/F'])
+      else expect(groupKills).toContainEqual([-424242, 'SIGTERM'])
     } finally {
       killSpy.mockRestore()
     }


### PR DESCRIPTION
Seven defects from the Round 5 register, each verified against its callers before the fix, each paired with a test that fails without it and a mutant it kills (nine mutants; one initial survivor exposed a redundant guard, which was removed so the remaining guard is the single one).

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change

## Resource leaks and crashes

**In-flight MCP connects are tracked across a session switch** (`mcp/index.ts`). A name entered `clients` only when its connect resolved, and shutdown cleared the map without awaiting anything in flight, so `/new` during a slow stdio cold start (or a backoff sleep) let the next `session_start` connect the same name again. The first connect then resolved into an entry the second overwrote: never closed, its process alive until pi exited. A `connecting` set is consulted by the one guard every connect path shares; a name still connecting from the previous session is adopted when it resolves. A connect that resolves after pi began exiting closes itself, since the shutdown handler already ran and could not see it.

**A malformed OAuth callback request gets a 400 instead of crashing pi** (`internal/mcp-oauth.ts`). Node's parser passes an absolute-form target through unvalidated; `new URL` on one with an out-of-range port threw, and a throw from a `request` listener is not caught by `node:http`. Any local process that could reach the loopback port during the login window took pi down with an `uncaughtException`. The test reproduces it end to end with a raw socket.

**A subagent cancel reaches grandchildren on Windows** (`internal/process-tree.ts`, `subagent/run.ts`, `subagent/background.ts`, `hooks/runners.ts`). The group kill existed three times and only the hooks copy knew Windows has no process groups, so a subagent cancel there signalled the direct child only and a build the agent started kept running. One `killProcessTree` carries the `taskkill /T` path with its absolute-path and error fallbacks, and the POSIX group signal with its direct-kill fallback.

## Configuration that failed in the wrong way

**Exec-form hooks are validated** (`hooks/matcher.ts`). `spawn('')` throws `ERR_INVALID_ARG_VALUE` and a numeric `args` element has no `replaceAll`; both threw inside the runner's Promise executor, so the event's handler rejected instead of the hook reporting `spawnFailed`. A command hook now needs a non-empty command and all-string args.

**The PreCompact block notice names the right hook** (`hooks/index.ts`). It indexed the unfiltered command list after `runNotifyHooks` had dropped `if`-carrying hooks, naming the skipped hook whenever one preceded the blocker.

**A present-but-unparseable MCP config warns** (`mcp/config.ts`). One catch swallowed `ENOENT` and a parse error alike, so a trailing comma in a project `.mcp.json` silently disabled every server in it. Missing stays silent.

**Output-style frontmatter is parsed as YAML** (`output-styles.ts`). A per-line regex captured to end of line and stripped one quote from each end, so `description: "Terse" # short` read as `Terse" # short`. pi's own frontmatter parser, which the command loader already uses, replaces it.