### PR TITLE
Fix two Round 5 defects: settings placement and an orphaned background worktree

### DIFF
--- a/extensions/internal/settings-chain.ts
+++ b/extensions/internal/settings-chain.ts
@@ -52,10 +52,17 @@ export function claudeSettingsChain(cwd: string, home: string, includeProject: b
   const files = [path.join(claudeConfigDir(home), 'settings.json')]
   if (!includeProject) return files
   files.push(path.join(cwd, '.claude', 'settings.json'))
-  const localDir = localSettingsDir(cwd, home, platform, owned)
-  if (localDir !== cwd) files.push(path.join(cwd, '.claude', 'settings.local.json'))
-  files.push(path.join(localDir, '.claude', 'settings.local.json'))
+  const local = localSettingsFile(cwd, home, platform, owned)
+  if (path.dirname(path.dirname(local)) !== cwd) files.push(path.join(cwd, '.claude', 'settings.local.json'))
+  files.push(local)
   return files
+}
+
+/** The settings.local.json the chain reads last, which is also where a setting a
+ * command persists (an output-style choice, an MCP consent) must be written for the
+ * chain to read it back: a file at any other level is never consulted. */
+export function localSettingsFile(cwd: string, home: string, platform: NodeJS.Platform = process.platform, owned: (paths: string[]) => boolean = ownedByUser): string {
+  return path.join(localSettingsDir(cwd, home, platform, owned), '.claude', 'settings.local.json')
 }
 
 /** Every readable settings object in the chain, in order, so the last one a caller

--- a/extensions/internal/settings-chain.ts
+++ b/extensions/internal/settings-chain.ts
@@ -52,9 +52,12 @@ export function claudeSettingsChain(cwd: string, home: string, includeProject: b
   const files = [path.join(claudeConfigDir(home), 'settings.json')]
   if (!includeProject) return files
   files.push(path.join(cwd, '.claude', 'settings.json'))
-  const local = localSettingsFile(cwd, home, platform, owned)
-  if (path.dirname(path.dirname(local)) !== cwd) files.push(path.join(cwd, '.claude', 'settings.local.json'))
-  files.push(local)
+  // Compared as the directory the placement rule returned, not re-derived from a
+  // joined path: path.join normalizes separators, so a cwd given POSIX-style on
+  // Windows would never equal its own joined form and the legacy entry would repeat.
+  const localDir = localSettingsDir(cwd, home, platform, owned)
+  if (localDir !== cwd) files.push(path.join(cwd, '.claude', 'settings.local.json'))
+  files.push(path.join(localDir, '.claude', 'settings.local.json'))
   return files
 }
 

--- a/extensions/mcp/policy.ts
+++ b/extensions/mcp/policy.ts
@@ -6,9 +6,8 @@
 
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import { claudeConfigDir } from '../internal/config-dir.js'
 import { managedSettingsFile } from '../internal/managed-settings.js'
-import { findNearestFile } from '../internal/project-root.js'
+import { claudeSettingsChain } from '../internal/settings-chain.js'
 import { errorMessage } from '../internal/values.js'
 import { interpolateEnv, type ServerConfig } from './config.js'
 
@@ -38,11 +37,17 @@ export function projectServerPolicy(cwd: string, home: string, projectApproved: 
     }
   }
   const names = (value: unknown): string[] => (Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [])
-  const userSettings = read(path.join(claudeConfigDir(home), 'settings.json'))
-  const projectSettings = read(findNearestFile(cwd, path.join('.claude', 'settings.json')) ?? path.join(cwd, '.claude', 'settings.json'))
-  const localSettings = read(findNearestFile(cwd, path.join('.claude', 'settings.local.json')) ?? path.join(cwd, '.claude', 'settings.local.json'))
-  const disabled = new Set([...names(userSettings.disabledMcpjsonServers), ...names(projectSettings.disabledMcpjsonServers), ...names(localSettings.disabledMcpjsonServers)])
-  const consentSources = projectApproved ? [userSettings, localSettings] : [userSettings]
+  // The files come from the one settings chain, so placement follows Claude's rules
+  // everywhere: the project's settings.json is read from cwd only (never an ancestor),
+  // and settings.local.json from the main checkout, with the chain's legacy cwd copy
+  // read too. Resolving them by nearest-file here gave a subdirectory session an
+  // ancestor's project file and a worktree session its own local file instead.
+  const [userFile, projectFile, ...localFiles] = claudeSettingsChain(cwd, home, true)
+  const userSettings = read(userFile)
+  const projectSettings = read(projectFile)
+  const localSettings = localFiles.map(read)
+  const disabled = new Set([...names(userSettings.disabledMcpjsonServers), ...names(projectSettings.disabledMcpjsonServers), ...localSettings.flatMap((settings) => names(settings.disabledMcpjsonServers))])
+  const consentSources = projectApproved ? [userSettings, ...localSettings] : [userSettings]
   const consented = new Set(consentSources.flatMap((settings) => names(settings.enabledMcpjsonServers)))
   const consentAll = consentSources.some((settings) => settings.enableAllProjectMcpServers === true)
   return { disabled, consented, consentAll }

--- a/extensions/output-styles.ts
+++ b/extensions/output-styles.ts
@@ -29,8 +29,8 @@ import { claudeConfigDir } from './internal/config-dir.js'
 import { readManagedSettings } from './internal/managed-settings.js'
 import { installedPlugins, pluginComponentPath } from './internal/plugins.js'
 import { isProjectApproved } from './internal/project-approval.js'
-import { ancestorDirs, findNearestDir, findNearestFile } from './internal/project-root.js'
-import { claudeSettingsChain, readSettingsChain } from './internal/settings-chain.js'
+import { ancestorDirs } from './internal/project-root.js'
+import { claudeSettingsChain, localSettingsFile, readSettingsChain } from './internal/settings-chain.js'
 import { isDirectory } from './internal/values.js'
 
 export interface OutputStyle {
@@ -205,11 +205,10 @@ export default function outputStylesExtension(pi: ExtensionAPI) {
     // Precedence low to high: builtin, plugin, then the user's and project's own
     // dirs, so a same-named user or project style overrides a plugin's.
     styles = loadStyles([BUILTIN_STYLES_DIR, ...pluginStyleDirs(home), ...styleDirs(ctx.cwd, home, trusted)])
-    // Persist the choice where the read chain will find it again: the nearest local
-    // settings file, else inside the nearest .claude directory, else at cwd.
-    const nearestLocal = findNearestFile(ctx.cwd, path.join('.claude', 'settings.local.json'))
-    const claudeDir = findNearestDir(ctx.cwd, '.claude') ?? path.join(ctx.cwd, '.claude')
-    localSettingsPath = nearestLocal ?? path.join(claudeDir, 'settings.local.json')
+    // Persist the choice to the file the read chain reads last, so it is read back:
+    // the nearest local file or .claude directory could sit at an intermediate
+    // ancestor the chain never consults.
+    localSettingsPath = localSettingsFile(ctx.cwd, home)
     // Claude's force-for-plugin: the first loaded forced plugin style applies
     // automatically, overriding the outputStyle setting.
     const forced = forcedPluginStyle(loadStyles(pluginStyleDirs(home)))

--- a/extensions/subagent/modes.ts
+++ b/extensions/subagent/modes.ts
@@ -152,18 +152,6 @@ export async function runBackgroundMode(params: SubagentParamsStatic, context: B
     return backgroundCapResult(makeDetails)
   }
   const runCwd = params.cwd ?? defaultCwd
-  // The same isolation boundary as the foreground path: no worktree, no run.
-  let worktree: AgentWorktree | undefined
-  if (agent.isolation === 'worktree') {
-    const created = await createAgentWorktree(runCwd, agent.name)
-    if ('error' in created) {
-      return {
-        content: [{ type: 'text', text: `isolation: worktree could not be created for ${agent.name}: ${created.error}` }],
-        details: makeDetails('single')([]),
-      }
-    }
-    worktree = created
-  }
   // Anchor project/local memory at the session project (defaultCwd), which is the one
   // projectApproved gated; see the foreground path for why runCwd must not be used.
   const memorySection = agentMemoryPromptSection(agent, defaultCwd, projectApproved)
@@ -175,6 +163,21 @@ export async function runBackgroundMode(params: SubagentParamsStatic, context: B
     // Claude: the agent body replaces the default system prompt (see the
     // foreground path).
     args.push('--system-prompt', tmpPrompt.filePath)
+  }
+  // The same isolation boundary as the foreground path: no worktree, no run. Created
+  // after the temp prompt, so a prompt write that throws has nothing to leak; the cap
+  // refusal below removes it again.
+  let worktree: AgentWorktree | undefined
+  if (agent.isolation === 'worktree') {
+    const created = await createAgentWorktree(runCwd, agent.name)
+    if ('error' in created) {
+      removeTmpPrompt(tmpPrompt)
+      return {
+        content: [{ type: 'text', text: `isolation: worktree could not be created for ${agent.name}: ${created.error}` }],
+        details: makeDetails('single')([]),
+      }
+    }
+    worktree = created
   }
   // The id is preset so SubagentStart hooks run pre-spawn with the id the run
   // will actually carry, and their context lands before the child's first prompt.
@@ -216,8 +219,10 @@ export async function runBackgroundMode(params: SubagentParamsStatic, context: B
     presetId,
   )
   if (id === null) {
-    // Lost the cap race to a parallel batch: the atomic check inside startBackgroundRun refused.
+    // Lost the cap race to a parallel batch: the atomic check inside startBackgroundRun
+    // refused. A pristine worktree is removed by the same cleanup a finished run uses.
     removeTmpPrompt(tmpPrompt)
+    if (worktree) await cleanupAgentWorktree(runCwd, worktree).catch(() => {})
     return backgroundCapResult(makeDetails)
   }
   pi.events.emit(SUBAGENT_CHANNEL, { phase: 'start', agentType: agent.name, agentId: id })

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -1356,6 +1356,32 @@ describe('mcp failure reporting', () => {
     expect(harness.notifications.length).toBe(before + 1)
   })
 
+  it('reads project settings from cwd only and the local file from the main checkout, as the settings chain does', async () => {
+    // projectServerPolicy resolved both files with findNearestFile: a subdirectory
+    // session picked up an ancestor's settings.json (the chain reads cwd only, per
+    // Claude's "start Claude Code there"), and a worktree session read its own
+    // settings.local.json where the chain reads the main checkout's.
+    const { projectServerPolicy } = await import('../extensions/mcp/policy.ts')
+    const { mkdirSync, mkdtempSync, writeFileSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+    const parent = mkdtempSync(join(tmpdir(), 'policy-'))
+    const main = join(parent, 'main')
+    mkdirSync(join(main, '.git', 'worktrees', 'feature'), { recursive: true })
+    mkdirSync(join(main, '.claude'), { recursive: true })
+    writeFileSync(join(main, '.claude', 'settings.json'), JSON.stringify({ disabledMcpjsonServers: ['root-only'] }))
+    writeFileSync(join(main, '.claude', 'settings.local.json'), JSON.stringify({ enabledMcpjsonServers: ['consented-at-root'] }))
+    const sub = join(main, 'packages', 'app')
+    mkdirSync(sub, { recursive: true })
+    const tree = join(parent, 'feature')
+    mkdirSync(tree)
+    writeFileSync(join(tree, '.git'), `gitdir: ${join(main, '.git', 'worktrees', 'feature')}\n`)
+
+    const home = mkdtempSync(join(tmpdir(), 'policy-home-'))
+    expect(projectServerPolicy(sub, home, true).disabled.has('root-only')).toBe(false)
+    if (process.platform !== 'win32') expect(projectServerPolicy(tree, home, true).consented.has('consented-at-root')).toBe(true)
+  })
+
   it('returns from session_start without waiting for a hung server, in an interactive session', async () => {
     // Claude: "MCP startup is non-blocking by default: servers connect in the
     // background and their tools become available as they finish." Before this,

--- a/tests/output-styles.test.ts
+++ b/tests/output-styles.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -236,6 +236,31 @@ describe('extension wiring', () => {
     writeFileSync(join(cwd, '.claude', 'settings.local.json'), JSON.stringify({ outputStyle: name }))
     return cwd
   }
+
+  it.skipIf(process.platform === 'win32')('persists the choice to the main checkout, where the settings chain reads it back', async () => {
+    // Persisting to the nearest settings.local.json (or the nearest .claude dir) could
+    // write a file at an intermediate ancestor that claudeSettingsChain never reads.
+    const parent = tempDir()
+    const main = join(parent, 'main')
+    mkdirSync(join(main, '.git', 'worktrees', 'feature'), { recursive: true })
+    mkdirSync(join(main, '.claude'), { recursive: true })
+    const tree = join(parent, 'feature')
+    mkdirSync(join(tree, '.claude', 'output-styles'), { recursive: true })
+    writeFileSync(join(tree, '.claude', 'output-styles', 'style.md'), '---\nname: Explain\n---\nExplain everything.')
+    writeFileSync(join(tree, '.git'), `gitdir: ${join(main, '.git', 'worktrees', 'feature')}\n`)
+    const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>()
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>()
+    outputStyles({
+      on: (name: string, fn: (event: unknown, ctx: unknown) => Promise<unknown>) => handlers.set(name, fn),
+      registerCommand: (name: string, opts: { handler: (args: string, ctx: unknown) => Promise<void> }) => commands.set(name, opts),
+    } as never)
+    const ctx = { cwd: tree, hasUI: true, isProjectTrusted: () => true, ui: { notify: () => {}, confirm: async () => true, select: async () => 'Explain' } }
+    await handlers.get('session_start')?.({}, ctx)
+    await commands.get('output-style')?.handler('', ctx)
+
+    expect(existsSync(join(tree, '.claude', 'settings.local.json'))).toBe(false)
+    expect(JSON.parse(readFileSync(join(main, '.claude', 'settings.local.json'), 'utf-8')).outputStyle).toBe('Explain')
+  })
 
   it('reports non-interactive mode and an empty style list from the picker', async () => {
     const cwd = tempDir()

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -1832,6 +1832,19 @@ describe('isolation: worktree execution', () => {
     expect(JSON.stringify(result.content)).not.toContain('worktree kept')
   })
 
+  it('removes the worktree it created when the background cap refuses the run', async () => {
+    // The worktree was created before the atomic cap check inside startBackgroundRun,
+    // and a refusal removed only the temp prompt: the directory and its agent/<name>-<id>
+    // branch stayed on disk with nothing referencing them.
+    discoverAgentsMock.mockReturnValue({ agents: [isoAgent()], projectAgentsDir: null })
+    startBackgroundRunMock.mockReturnValueOnce(null)
+    const repo = makeRepo()
+    const result = await execute('c1', { background: true, agent: 'iso', task: 'one too many' }, undefined, undefined, { ...trustedCtx, cwd: repo })
+    expect(text(result)).toContain('Too many background runs')
+    expect(execFileSync('git', ['worktree', 'list', '--porcelain'], { cwd: repo }).toString()).not.toContain('agent/iso')
+    expect(execFileSync('git', ['branch', '--list', 'agent/iso-*'], { cwd: repo }).toString().trim()).toBe('')
+  })
+
   it('keeps a dirty worktree and reports where the changes live', async () => {
     discoverAgentsMock.mockReturnValue({ agents: [isoAgent()], projectAgentsDir: null })
     const repo = makeRepo()


### PR DESCRIPTION
Two defects from the Round 5 register, each paired with a test that fails without the fix and a mutant it kills.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change

**MCP consent files and the output-style persist path follow the settings chain** (`internal/settings-chain.ts`, `mcp/policy.ts`, `output-styles.ts`). `projectServerPolicy` found `settings.json` and `settings.local.json` by nearest file, so a subdirectory session read an ancestor's project settings (the chain reads cwd only, per Claude's "to use a file committed at the repository root, start Claude Code there") and a worktree session read its own local file where the chain reads the main checkout's. `/output-style` persisted to the nearest local file or `.claude` directory, which can sit at an intermediate ancestor the chain never consults, so the choice was written and never read back. Both now derive their files from the chain; `localSettingsFile` is the one place the local file's placement is decided.

**A background worktree the cap refusal orphaned is removed** (`subagent/modes.ts`). The worktree was created before the temp-prompt write and before the atomic cap check inside `startBackgroundRun`; a refusal removed only the prompt, so the directory and its `agent/<name>-<id>` branch stayed on disk with nothing referencing them. The prompt is written first, so a throw there leaks nothing, and a refused run removes the worktree with the same pristine-only cleanup a finished run uses. The test drives real git.