### PR TITLE
Resolve pi's agent directory through getAgentDir everywhere

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -4,7 +4,7 @@ Connects Claude Code's MCP configuration and registers each server's tools in pi
 
 ## Configuration scopes
 
-- User: `~/.claude.json` (including the per-project `projects[cwd].mcpServers` local scope) and `~/.pi/agent/mcp.json`. The per-project `disabledMcpServers` toggle list mutes a user or plugin server without removing it.
+- User: `~/.claude.json` (including the per-project `projects[cwd].mcpServers` local scope) and `mcp.json` in pi's agent directory (`~/.pi/agent`, relocated by `PI_CODING_AGENT_DIR`). The per-project `disabledMcpServers` toggle list mutes a user or plugin server without removing it.
 - Project: `.mcp.json` and `.pi/mcp.json`, loaded once the project is approved; `enabledMcpjsonServers`/`disabledMcpjsonServers`/`enableAllProjectMcpServers` honored, with consent keys counted only from non-repo settings. Precedence on a name clash is local over project over user.
 - Plugin stdio servers get Claude's three path variables in their environment: `CLAUDE_PROJECT_DIR`, `CLAUDE_PLUGIN_ROOT` and `CLAUDE_PLUGIN_DATA` (the data directory is created when the path is handed over, which is Claude's "created on first reference").
 - **Divergence:** `CLAUDE_CODE_MCP_ALLOWLIST_ENV` has no effect here. pi-code always passes the SDK's baseline environment to a stdio server, with no opt-out.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -2,7 +2,7 @@
 
 Per-repository memories with a session-injected index. Source: [`extensions/memory.ts`](../extensions/memory.ts).
 
-- Memories live under `~/.pi/agent/memory`, keyed on the repository root, so subdirectory sessions and every worktree of one repository share a store (as Claude does; this is pi's own store, separate from Claude's).
+- Memories live under `memory/` in pi's agent directory (`~/.pi/agent`, relocated by `PI_CODING_AGENT_DIR`), keyed on the repository root, so subdirectory sessions and every worktree of one repository share a store (as Claude does; this is pi's own store, separate from Claude's).
 - The index is injected each session within Claude's 200-line/25KB bound; YAML frontmatter and block HTML comments are stripped before it counts or loads.
 - A save landing near the index read limit reminds Claude to shorten it; over the limit the write still succeeds and an error tells Claude to rewrite the index, per Claude's contract. A memory written with frontmatter gets a `modified:` ISO timestamp; the tool asks for Claude's documented `type` vocabulary (user/feedback/project/reference).
 - Honors `autoMemoryEnabled` (settings) and `CLAUDE_CODE_DISABLE_AUTO_MEMORY` (env) to turn it off, and `autoMemoryDirectory` (absolute or `~/`) to relocate the store; managed policy settings win over the file chain.

--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -17,7 +17,7 @@ import { createHash } from 'node:crypto'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from '@earendil-works/pi-coding-agent'
+import { type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext, getAgentDir } from '@earendil-works/pi-coding-agent'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { contentText, errorMessage } from './internal/values.js'
 
@@ -175,7 +175,7 @@ export default function gitCheckpointExtension(pi: ExtensionAPI) {
   async function ensureShadow(ctx: ExtensionContext): Promise<void> {
     workTree = ctx.cwd
     const sessionFile = (ctx.sessionManager as { getSessionFile?: () => string | undefined }).getSessionFile?.()
-    const checkpointsRoot = path.join(os.homedir(), '.pi', 'agent', 'checkpoints')
+    const checkpointsRoot = path.join(getAgentDir(), 'checkpoints')
     shadowDir = path.join(checkpointsRoot, sessionSlug(sessionFile))
     // A resumed session can arrive from a different directory than the one the shadow
     // snapshotted; restoring those commits here would silently overwrite unrelated

--- a/extensions/mcp/config.ts
+++ b/extensions/mcp/config.ts
@@ -6,6 +6,7 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { getAgentDir } from '@earendil-works/pi-coding-agent'
 import { claudeConfigDir } from '../internal/config-dir.js'
 import type { OAuthServerConfig } from '../internal/mcp-oauth.js'
 import { type InstalledPlugin, pluginComponentPath } from '../internal/plugins.js'
@@ -92,7 +93,9 @@ function claudeJsonPath(home: string): string {
 /** User-scoped MCP config (the user's own; safe to load without project trust). The .pi
  * tree is pi's own and is not relocated by CLAUDE_CONFIG_DIR. */
 export function userConfigPaths(home: string): string[] {
-  return [claudeJsonPath(home), path.join(home, '.pi', 'agent', 'mcp.json')]
+  // mcp.json lives in pi's agent directory, which PI_CODING_AGENT_DIR relocates; the
+  // other agent-directory readers (trust store, OAuth tokens) already follow it.
+  return [claudeJsonPath(home), path.join(getAgentDir(), 'mcp.json')]
 }
 
 /** Project-scoped MCP config, each file the nearest of its name at or above cwd

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -12,7 +12,7 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { StringEnum } from '@earendil-works/pi-ai'
-import { type ExtensionAPI, withFileMutationQueue } from '@earendil-works/pi-coding-agent'
+import { type ExtensionAPI, getAgentDir, withFileMutationQueue } from '@earendil-works/pi-coding-agent'
 import { Type } from 'typebox'
 import { atomicWriteFile } from './internal/atomic-write.js'
 import { claudeConfigDir } from './internal/config-dir.js'
@@ -63,7 +63,7 @@ function memoryProject(cwd: string): string {
 }
 
 export function memoryDir(cwd: string): string {
-  return path.join(os.homedir(), '.pi', 'agent', 'memory', projectSlug(memoryProject(cwd)))
+  return path.join(getAgentDir(), 'memory', projectSlug(memoryProject(cwd)))
 }
 
 /** The store location, honoring an `autoMemoryDirectory` override. Claude requires
@@ -142,7 +142,7 @@ export function stripNonLoaded(text: string): string {
 export function migrateLegacyStore(cwd: string): void {
   const current = memoryDir(cwd)
   if (fs.existsSync(current)) return
-  const base = path.join(os.homedir(), '.pi', 'agent', 'memory')
+  const base = path.join(getAgentDir(), 'memory')
   // projectSlug(cwd) differs from current only for a subdirectory session (current is
   // keyed on the repo root); for a repo-root session it equals current and is skipped.
   const candidates = [path.join(base, projectSlug(cwd)), path.join(base, legacySlug(cwd))]

--- a/tests/git-checkpoint-more.test.ts
+++ b/tests/git-checkpoint-more.test.ts
@@ -69,6 +69,7 @@ function setup() {
 
   const repo = mkdtempSync(join(tmpdir(), 'gcm-test-'))
   hoisted.home = mkdtempSync(join(tmpdir(), 'gcm-home-'))
+  process.env.PI_CODING_AGENT_DIR = join(hoisted.home, '.pi', 'agent')
   tempDirs.push(repo, hoisted.home)
 
   const shadowHome = hoisted.home
@@ -130,12 +131,17 @@ async function checkpointOneTurn(t: Harness, branch: any[] = [userEntry]): Promi
 const rewind = (t: Harness, options: CtxOptions) => t.commands.get('rewind')?.handler('', t.makeCtx(options))
 
 describe('shadow repo initialization', () => {
-  it('creates the bare repo under the session slug in the home directory', async () => {
+  it("creates the bare repo under the session slug in pi's agent directory, wherever PI_CODING_AGENT_DIR puts it", async () => {
+    // A distinct directory, not the fake home's ~/.pi/agent: the path used to be
+    // hardcoded there while the trust store and OAuth tokens followed the variable.
     const t = setup()
+    const agentDir = mkdtempSync(join(tmpdir(), 'gcm-agent-'))
+    process.env.PI_CODING_AGENT_DIR = agentDir
 
     await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx())
 
-    expect(existsSync(join(t.shadowHome, '.pi', 'agent', 'checkpoints', SESSION_FILE_NAME, 'HEAD'))).toBe(true)
+    expect(existsSync(join(agentDir, 'checkpoints', SESSION_FILE_NAME, 'HEAD'))).toBe(true)
+    expect(existsSync(join(t.shadowHome, '.pi', 'agent', 'checkpoints'))).toBe(false)
   })
 
   it('configures the checkpoint committer identity on a freshly created shadow repo', async () => {

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -46,6 +46,7 @@ function setup() {
 
   const repo = mkdtempSync(join(tmpdir(), 'gcs-test-'))
   hoisted.home = mkdtempSync(join(tmpdir(), 'gcs-home-'))
+  process.env.PI_CODING_AGENT_DIR = join(hoisted.home, '.pi', 'agent')
   tempDirs.push(repo, hoisted.home)
 
   const sessionFile = join(repo, 'session-test.jsonl')

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -293,8 +293,17 @@ describe('mcp adapter helpers', () => {
   })
 
   it('separates always-loaded user config from trust-gated project config', () => {
-    expect(userConfigPaths('/home')).toEqual([join('/home', '.claude.json'), join('/home', '.pi', 'agent', 'mcp.json')])
+    expect(userConfigPaths('/home')).toEqual([join('/home', '.claude.json'), join(process.env.PI_CODING_AGENT_DIR as string, 'mcp.json')])
     expect(projectConfigPaths('/proj')).toEqual([join('/proj', '.mcp.json'), join('/proj', '.pi', 'mcp.json')])
+  })
+
+  it('relocates mcp.json with PI_CODING_AGENT_DIR, like every other agent-directory reader', () => {
+    // memory, checkpoints and mcp.json hardcoded ~/.pi/agent while the trust store,
+    // OAuth tokens and user agents followed getAgentDir(): with the variable set, half
+    // of pi-code's state moved and half stayed.
+    const agentDir = mkdtempSync(join(tmpdir(), 'agent-dir-'))
+    process.env.PI_CODING_AGENT_DIR = agentDir
+    expect(userConfigPaths('/home')[1]).toBe(join(agentDir, 'mcp.json'))
   })
 
   it('resolves HOME-scope config under CLAUDE_CONFIG_DIR while leaving project scope alone', () => {
@@ -305,7 +314,7 @@ describe('mcp adapter helpers', () => {
     process.env.CLAUDE_CONFIG_DIR = cfg
     try {
       // .claude.json now lives inside the config dir; .pi is pi's own tree, untouched.
-      expect(userConfigPaths('/home')).toEqual([join(cfg, '.claude.json'), join('/home', '.pi', 'agent', 'mcp.json')])
+      expect(userConfigPaths('/home')).toEqual([join(cfg, '.claude.json'), join(process.env.PI_CODING_AGENT_DIR as string, 'mcp.json')])
       // The per-project local scope is read from the relocated .claude.json too.
       writeFileSync(join(cfg, '.claude.json'), JSON.stringify({ projects: { '/work/p': { mcpServers: { local: { command: 'l' } } } } }))
       expect(Object.keys(loadUserScope('/home', '/work/p'))).toEqual(['local'])

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -55,7 +55,9 @@ describe('memory helpers', () => {
     // Readable dashed path plus a short digest that keeps distinct paths distinct.
     expect(projectSlug('/Users/alex/Documents/pi-code')).toMatch(/^-Users-alex-Documents-pi-code-[0-9a-f]{8}$/)
     expect(projectSlug('C:\\Users\\alex\\Documents\\pi-code')).toMatch(/^C-Users-alex-Documents-pi-code-[0-9a-f]{8}$/)
-    expect(memoryDir('/tmp/x')).toContain(path.join('.pi', 'agent', 'memory', projectSlug('/tmp/x')))
+    // Under pi's agent directory, which PI_CODING_AGENT_DIR relocates (tests/setup.ts
+    // pins it to a temp root, so the developer's real ~/.pi/agent is never touched).
+    expect(memoryDir('/tmp/x')).toBe(path.join(process.env.PI_CODING_AGENT_DIR as string, 'memory', projectSlug('/tmp/x')))
   })
 
   it('keys the store on the repository root so subdirectory sessions share it', () => {
@@ -454,6 +456,7 @@ describe('migrateLegacyStore', () => {
     // having lost them.
     const home = mkdtempSync(join(tmpdir(), 'mem-home-'))
     hoisted.home = home
+    process.env.PI_CODING_AGENT_DIR = join(home, '.pi', 'agent')
     const cwd = '/proj/blocked'
     const legacy = join(home, '.pi', 'agent', 'memory', '-proj-blocked')
     mkdirSync(legacy, { recursive: true })
@@ -475,6 +478,7 @@ describe('migrateLegacyStore', () => {
   it('renames a pre-digest store to the current slug, once, without clobbering', () => {
     const home = mkdtempSync(join(tmpdir(), 'mem-home-'))
     hoisted.home = home
+    process.env.PI_CODING_AGENT_DIR = join(home, '.pi', 'agent')
     const cwd = '/proj/app'
     const legacy = join(home, '.pi', 'agent', 'memory', '-proj-app')
     mkdirSync(legacy, { recursive: true })
@@ -496,6 +500,7 @@ describe('migrateLegacyStore', () => {
   it('migrates a released digest-of-cwd store to the repo-root slug for a subdir session', () => {
     const home = mkdtempSync(join(tmpdir(), 'mem-home-'))
     hoisted.home = home
+    process.env.PI_CODING_AGENT_DIR = join(home, '.pi', 'agent')
     // A released version keyed the store on the raw subdirectory cwd; the current one
     // keys on the repository root, so the subdir session would otherwise orphan it.
     const repo = mkdtempSync(join(tmpdir(), 'mem-repo-'))

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -60,6 +60,11 @@ const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-code-tests-'))
 process.env.TMPDIR = tmpRoot
 process.env.TEMP = tmpRoot
 process.env.TMP = tmpRoot
+// pi's agent directory (memory, checkpoints, mcp.json, trust decisions, OAuth tokens)
+// resolves through the SDK's getAgentDir(), which a node:os mock in a test file does
+// not reach. Pointed at the per-file root unconditionally, so no suite can write into
+// the developer's real ~/.pi/agent whichever home it fakes.
+process.env.PI_CODING_AGENT_DIR = path.join(tmpRoot, 'pi-agent')
 
 afterAll(() => {
   fs.rmSync(tmpRoot, { recursive: true, force: true })

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -255,6 +255,14 @@ beforeEach(() => {
   execute = getExecute()
 })
 
+// Close every child a test left open. An aborted run's SIGTERM-to-SIGKILL escalation is
+// an unref'd 5s timer cleared only by the child's close; left armed it fires during a
+// later test, and on Windows that kill is a taskkill spawn the mock records into that
+// test's spawnCalls (two calls where it expected one, under shuffle).
+afterEach(() => {
+  for (const child of spawnedChildren) child.emit('close', 143)
+})
+
 // ---------------------------------------------------------------------------
 
 describe('agent hook runner', () => {
@@ -1852,7 +1860,8 @@ describe('isolation: worktree execution', () => {
     const repo = makeRepo()
     script('make changes', { stdout: [say('done editing')], delay: 150 })
     const pending = execute('c1', { agent: 'iso', task: 'make changes' }, undefined, undefined, { ...trustedCtx, cwd: repo })
-    await vi.waitFor(() => expect(spawnCalls.length).toBe(1))
+    // A real `git worktree add` precedes the spawn; a slow runner needs more than the 1s default.
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 10_000 })
     fs.writeFileSync(join(spawnCalls[0].options.cwd as string, 'dirty.txt'), 'work\n')
     const result = await pending
     expect(fs.existsSync(spawnCalls[0].options.cwd as string)).toBe(true)


### PR DESCRIPTION
The last defect of the Round 5 register, plus a test-isolation hazard it exposed.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change

**Memory, checkpoints and `mcp.json` follow `PI_CODING_AGENT_DIR`** (`memory.ts`, `git-checkpoint.ts`, `mcp/config.ts`). All three hardcoded `~/.pi/agent` while the trust store, OAuth tokens, user agents and the external-import store already followed pi's `getAgentDir()`, which the variable relocates: with it set, half of pi-code's state moved and half stayed. The default is the same directory, so a user who never set the variable sees no change. Each module has a relocation test against a distinct directory, so the variable is proven read rather than the home.

**No test can reach the developer's real agent directory any more** (`tests/setup.ts`). The SDK reads `node:os` itself, so a test file's `homedir` mock never reached `getAgentDir()`, and the suite was already writing to the real `~/.pi/agent/trust.json`: its mtime landed inside the last gate run made without the pin, and the run made with it left the file alone. The setup file now pins `PI_CODING_AGENT_DIR` to the per-file temp root unconditionally; suites whose expectations name their fake home pin it there.

Docs name the agent directory instead of the literal path.