### PR TITLE
Close fourteen test gaps from the Round 5 register, each against a named mutant

### DIFF
--- a/tests/background.test.ts
+++ b/tests/background.test.ts
@@ -161,6 +161,9 @@ describe('background run lifecycle', () => {
     expect(done?.state).toBe('done')
     expect(done?.exitCode).toBe(0)
     expect(done?.turns).toBe(2)
+    // Claude marks a maxTurns-capped run's output as partial; the only place the flag is
+    // asserted true, so dropping the assignment was invisible.
+    expect(done?.partial).toBe(true)
   })
 
   it('holds the cap slot for a cancelled child until it dies, then escalates to SIGKILL', () => {

--- a/tests/context-imports.test.ts
+++ b/tests/context-imports.test.ts
@@ -188,6 +188,9 @@ describe('collectImports', () => {
 
   it('ignores an unreadable import and does not treat emails as imports', () => {
     const dir = tempDir()
+    // The file the email's domain would name exists, so a regex that accepted a
+    // non-whitespace character before the @ would import it and fail here.
+    writeFileSync(join(dir, 'example.com'), 'MAIL SERVER NOTES')
     expect(collectImports('@missing.md and user@example.com', dir, dir, [dir], new Set())).toEqual([])
   })
 

--- a/tests/git-checkpoint.test.ts
+++ b/tests/git-checkpoint.test.ts
@@ -104,6 +104,12 @@ describe('checkpoint retention', () => {
     writeFileSync(join(home, '.claude', 'settings.json'), JSON.stringify({ cleanupPeriodDays: 7 }))
 
     expect(checkpointRetentionDays(home)).toBe(7)
+    // A non-positive value keeps the default: with 0 honored, every non-live repo would
+    // be swept at the next session start.
+    for (const bad of [0, -3, 'seven', null]) {
+      writeFileSync(join(home, '.claude', 'settings.json'), JSON.stringify({ cleanupPeriodDays: bad }))
+      expect(checkpointRetentionDays(home)).toBe(CHECKPOINT_RETENTION_DAYS)
+    }
     expect(checkpointRetentionDays(mkdtempSync(join(tmpdir(), 'gcs-empty-home-')))).toBe(CHECKPOINT_RETENTION_DAYS)
   })
 })
@@ -352,6 +358,22 @@ describe('pruneCheckpointRepos', () => {
     expect(existsSync(old)).toBe(false)
     expect(existsSync(fresh)).toBe(true)
     rmSync(root, { recursive: true, force: true })
+  })
+
+  it('prunes with the configured cleanupPeriodDays at session start, not the constant', async () => {
+    // The reader is unit-tested and the pruner takes the days as an argument; nothing
+    // proved session_start hands one to the other.
+    const t = setup()
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ cleanupPeriodDays: 1 }))
+    const root = join(process.env.PI_CODING_AGENT_DIR as string, 'checkpoints')
+    const stale = mkRepo(root, 'stale-session', 2)
+    const fresh = mkRepo(root, 'fresh-session', 0)
+
+    await t.handlers.get('session_start')?.({ reason: 'startup' }, t.makeCtx([], [], []))
+
+    expect(existsSync(stale)).toBe(false)
+    expect(existsSync(fresh)).toBe(true)
   })
 
   it('never removes the repo of the live session and tolerates a missing root', () => {

--- a/tests/mcp-more.test.ts
+++ b/tests/mcp-more.test.ts
@@ -117,6 +117,10 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
     }
     close(): Promise<void> {
       hoisted.closed.push(this)
+      // The real StreamableHTTP transport fires onclose synchronously from close();
+      // production relies on that ordering (the map delete precedes the close so the
+      // onclose guard skips a backoff reconnect), so the fake must too.
+      ;(this as { onclose?: () => void }).onclose?.()
       return hoisted.control.close(this)
     }
     setNotificationHandler(schema: unknown, handler: () => void | Promise<void>): void {
@@ -638,6 +642,16 @@ describe('mcp transport selection', () => {
     expect(harness.toolNames()).toEqual(['keep_go'])
   })
 
+  it('matches an allow entry after ${VAR} expansion of its serverUrl', async () => {
+    // No policy fixture carried a variable, so the expansion on the allow side was
+    // droppable without a test noticing.
+    setEnv('MCP_HOST', 'https://api.example')
+    withManaged({ allowedMcpServers: [{ serverUrl: '${MCP_HOST}/mcp' }] })
+    withTools([{ name: 'go' }])
+    const harness = await setupStarted({ user: { keep: { type: 'http', url: 'https://api.example/mcp' }, drop: { type: 'http', url: 'https://other.example/mcp' } } })
+    expect(harness.toolNames()).toEqual(['keep_go'])
+  })
+
   it('interpolates env vars in the command and args', async () => {
     setEnv('MCP_BIN', '/opt/bin/server')
     withTools([{ name: 'go' }])
@@ -841,6 +855,46 @@ describe('mcp transport selection', () => {
     const [line] = await statusLinesOf(harness)
     expect(line.startsWith('remote: failed: ')).toBe(true)
     expect(line.endsWith(' (0 tools)')).toBe(true)
+  })
+})
+
+describe('auth reconnect ordering', () => {
+  it('does not pop a second login dialog from the backoff path after a declined re-login', async () => {
+    // reconnectForAuth deletes the client from the map before closing it, so the
+    // transport's synchronous onclose does not schedule a backoff reconnect. With the
+    // order swapped, a declined re-login is followed one second later by another
+    // interactive attempt: a second confirm the user already answered.
+    withTools([{ name: 'go' }])
+    hoisted.control.connect = async (transport) => {
+      if ((transport.options as { authProvider?: unknown }).authProvider === undefined) {
+        throw Object.assign(new Error('needs login'), { code: 401 })
+      }
+    }
+    let confirmCount = 0
+    const confirm = async (): Promise<boolean> => {
+      confirmCount++
+      return confirmCount === 1 // the first login is accepted, the re-login declined
+    }
+    const harness = await setup({ user: { remote: { url: 'https://remote.example/mcp' } }, confirm })
+    await harness.sessionStart()
+    expect(await statusLinesOf(harness)).toEqual(['remote: connected (1 tools)'])
+    expect(confirmCount).toBe(1)
+    vi.useFakeTimers()
+
+    let first = true
+    hoisted.control.callTool = async () => {
+      if (first) {
+        first = false
+        throw Object.assign(new Error('token expired'), { code: 401 })
+      }
+      return { content: [{ type: 'text', text: 'ok' }] } as never
+    }
+    // The re-login is declined, so the retried call finds no client: the tool call fails.
+    await expect(harness.tools[0].execute('call-1', {})).rejects.toThrow('not connected')
+    expect(confirmCount).toBe(2)
+
+    await vi.advanceTimersByTimeAsync(40_000)
+    expect(confirmCount).toBe(2)
   })
 })
 
@@ -2673,10 +2727,21 @@ describe('mcp automatic reconnection', () => {
     vi.useFakeTimers()
 
     dropLastClient()
-    // Delays 1+2+4+8+16 = 31s cover all five attempts.
-    await vi.advanceTimersByTimeAsync(31_000)
+    // Each attempt waits twice as long as the last: 1, 2, 4, 8 and 16 seconds. Asserted
+    // at each boundary, so a constant delay (five attempts inside five seconds) or a
+    // shortened one cannot pass by reaching the same total.
+    for (const [elapsed, attempts] of [
+      [999, 0],
+      [1, 1],
+      [2_000, 2],
+      [4_000, 3],
+      [8_000, 4],
+      [16_000, 5],
+    ] as const) {
+      await vi.advanceTimersByTimeAsync(elapsed)
+      expect(hoisted.transports.length - before).toBe(attempts)
+    }
     const afterFive = hoisted.transports.length
-    expect(afterFive - before).toBe(5)
 
     // No sixth attempt, and the server reports failed.
     await vi.advanceTimersByTimeAsync(120_000)

--- a/tests/model-complete.test.ts
+++ b/tests/model-complete.test.ts
@@ -48,6 +48,18 @@ describe('assistantText', () => {
 })
 
 describe('completeText', () => {
+  it('returns every text part of the reply joined, not only the first', async () => {
+    // Every other reply fixture is a single text part, so content[0].text would pass them.
+    setCompleteBackend(async () =>
+      msg([
+        { type: 'text', text: 'first, ' },
+        { type: 'thinking', text: 'x' },
+        { type: 'text', text: 'second' },
+      ]),
+    )
+    await expect(completeText({} as never, 'p')).resolves.toMatchObject({ text: 'first, second' })
+  })
+
   it('retries runtime creation after a rejected first attempt instead of caching the failure', async () => {
     // ModelRuntime.create can reject once (a credential store read that fails on a
     // transient error). Caching that rejected promise turned one bad moment into a

--- a/tests/notify.test.ts
+++ b/tests/notify.test.ts
@@ -139,6 +139,27 @@ describe('notify', () => {
     hoisted.home = ''
   })
 
+  it('sends both the bell and the desktop notification for iterm2_with_bell', async () => {
+    hoisted.home = mkdtempSync(join(tmpdir(), 'notify-home-'))
+    mkdirSync(join(hoisted.home, '.claude'), { recursive: true })
+    writeFileSync(join(hoisted.home, '.claude', 'settings.json'), JSON.stringify({ preferredNotifChannel: 'iterm2_with_bell' }))
+    process.stdout.isTTY = true
+    delete process.env.WT_SESSION
+    delete process.env.KITTY_WINDOW_ID
+    const writes = captureWrites()
+
+    const d = drive()
+    await d.sessionStart({ cwd: hoisted.home })
+    await d.agentEnd()
+    const out = writes.join('')
+    expect(out).toContain('\x1b]777')
+    // The OSC 777 sequence is terminated by a BEL byte of its own, so a plain
+    // toContain cannot see the bell; two BELs means the sequence's terminator plus the
+    // explicit bell the 'both' channel adds.
+    expect(out.split('\x07').length - 1).toBe(2)
+    hoisted.home = ''
+  })
+
   it('emits nothing when notifications are disabled', async () => {
     hoisted.home = mkdtempSync(join(tmpdir(), 'notify-home-'))
     mkdirSync(join(hoisted.home, '.claude'), { recursive: true })

--- a/tests/output-guard.test.ts
+++ b/tests/output-guard.test.ts
@@ -52,6 +52,9 @@ describe('capForContext', () => {
 
     expect(capped.startsWith('\u4f60')).toBe(true)
     expect(Buffer.byteLength(capped, 'utf-8')).toBeLessThan(DEFAULT_MAX_BYTES * 1.1)
+    // The cut lands mid-character; the streaming decoder holds the partial sequence
+    // back instead of emitting a replacement character.
+    expect(capped).not.toContain('\uFFFD')
   })
 
   it('reports the original size and line count in the notice', () => {

--- a/tests/plan-mode.test.ts
+++ b/tests/plan-mode.test.ts
@@ -695,6 +695,8 @@ describe('execution mode stall exit', () => {
     expect(await s.emit('before_agent_start')).toBeUndefined()
     const notice = s.sent.at(-1)
     expect(notice?.content).toContain('2. Second step')
+    // The notice, not just the injection, filters out the step already marked done.
+    expect(notice?.content).not.toContain('1. First step')
   })
 
   it('keeps executing while every run makes progress', async () => {

--- a/tests/question.test.ts
+++ b/tests/question.test.ts
@@ -569,6 +569,27 @@ describe('multiple questions per call', () => {
     expect(result.content[0].text).toContain('cancelled')
   })
 
+  it('keeps asking after a blank typed answer: only a cancel ends the batch', async () => {
+    // askOne documents that a submitted empty answer is an (empty) answer, not a
+    // cancel, so one accidental blank Enter must not drop questions 2-4.
+    const answers = [
+      { answer: '', wasCustom: true },
+      { answer: 'Beta', wasCustom: false, index: 2 },
+    ]
+    let calls = 0
+    const ctx = { hasUI: true, mode: 'tui', ui: { custom: async () => answers[calls++] } }
+    const params = {
+      questions: [
+        { question: 'First?', options: OPTIONS },
+        { question: 'Second?', options: OPTIONS },
+      ],
+    }
+    const result = await setup().execute('call-1', params as never, undefined, undefined, ctx as never)
+
+    expect(calls).toBe(2)
+    expect(result.content[0].text).toContain('Second?')
+  })
+
   it('still accepts the single-question shape', async () => {
     const result = await setup().execute('call-1', { question: 'Pick one', options: OPTIONS } as never, undefined, undefined, uiCtx({ answer: 'Alpha', wasCustom: false, index: 1 }) as never)
     expect(result.content[0].text).toBe('User selected: 1. Alpha')

--- a/tests/subagent-execute.test.ts
+++ b/tests/subagent-execute.test.ts
@@ -1443,6 +1443,19 @@ describe('chain mode', () => {
 describe('parallel mode', () => {
   const tasksOf = (...names: string[]) => names.map((task) => ({ agent: 'scout', task }))
 
+  it('runs at most four of eight tasks at once', async () => {
+    // The helper is pinned with literal limits elsewhere; this pins the wiring, which a
+    // Promise.all or a raised MAX_CONCURRENCY would both break.
+    const tasks = Array.from({ length: 8 }, (_, i) => ({ agent: 'scout', task: `t${i}` }))
+    for (const { task } of tasks) script(task, { stdout: [say('ok')], delay: 300 })
+
+    const pending = execute('c1', { tasks }, undefined, undefined, trustedCtx)
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(spawnCalls).toHaveLength(4)
+    await pending
+    expect(spawnCalls).toHaveLength(8)
+  })
+
   it('refuses more than eight parallel tasks before spawning anything', async () => {
     const tasks = Array.from({ length: 9 }, (_, i) => ({ agent: 'scout', task: `t${i}` }))
 

--- a/tests/thinking.test.ts
+++ b/tests/thinking.test.ts
@@ -142,6 +142,17 @@ describe('thinking extension', () => {
     expect(t.level()).toBe('low')
   })
 
+  it('leaves a level the user changed meanwhile alone when the next input arrives', () => {
+    // The restore fires only while this extension still owns the level (it equals the
+    // escalation target). A user who moved it elsewhere after a blocked prompt keeps
+    // their choice; without the guard it would be reset to the pre-escalation level.
+    const t = wire('low')
+    t.input('please ultrathink') // low -> max, prompt then blocked: no settle
+    t.setThinkingLevel('high') // the user picks a level of their own
+    t.input('a plain prompt')
+    expect(t.level()).toBe('high')
+  })
+
   it('restores a blocked escalation on the next input, without waiting for a settle', () => {
     // A hook can block the prompt that escalated: no turn runs, so no agent_settled ever
     // fires to restore the level. The next input is the signal the prior prompt is gone;


### PR DESCRIPTION
R5-11 through R5-16 of the Round 5 register: assertions the scan showed could not distinguish the code from a specific wrong version. Every new or strengthened oracle was run against its mutant; fourteen killed. No production code changes.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)

## Previously uncovered paths

- **Background worktree on a cap refusal** (`subagent-execute.test.ts`, real git): the worktree a refused run created is removed and its branch is gone.
- **Checkpoint retention wiring** (`git-checkpoint.test.ts`): `cleanupPeriodDays` reaches the pruner through `session_start`, and `0`, a negative or a non-numeric value keeps the default rather than sweeping every repo.
- **Auth reconnect ordering** (`mcp-more.test.ts`): the fake client now fires `onclose` synchronously, as the SDK transport does, so a test can prove that a declined re-login is not followed one second later by a second login dialog from the backoff path.
- **Backoff schedule** (`mcp-more.test.ts`): attempts are asserted at each doubling boundary, so a constant delay reaching the same total cannot pass.
- **Policy `${VAR}` expansion** (`mcp-more.test.ts`): an allow entry matches after expansion of its `serverUrl`.
- **Parallel concurrency** (`subagent-execute.test.ts`): at most four of eight tasks are in flight at once.

## One-sided guards, now two-sided

A blank typed answer does not end a question batch; a maxTurns-capped background run is marked partial; `completeText` joins every text part; the capped single line carries no `U+FFFD`; the email fixture file exists so the negative import case is real; the stall notice omits the finished step; a thinking level the user changed meanwhile is left alone; `iterm2_with_bell` rings the bell as well as notifying.

*One mutant survived its first test:* the OSC 777 desktop sequence is terminated by a BEL byte, so a plain `toContain('\x07')` was satisfied by the notification alone. The test now counts two BELs, the terminator plus the explicit bell.