### PR TITLE
Consolidate duplicated helpers: env numbers, regex escape, model resolution, settings reads

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -49,6 +49,7 @@ import { type CommandExec, expandDynamicContent, resolvePowershellBinary, spanEx
 import { claudeConfigDir } from './internal/config-dir.js'
 import { claudeEffortLevel } from './internal/effort.js'
 import { managedSettingsFile, readManagedSettings } from './internal/managed-settings.js'
+import { findModel } from './internal/model-lookup.js'
 import { capForContext } from './internal/output-guard.js'
 import { matchesPathRules } from './internal/path-rules.js'
 import { type InstalledPlugin, installedPlugins, pluginComponentPath } from './internal/plugins.js'
@@ -58,7 +59,7 @@ import { agentNamesIn, matchesAgentRules, matchesDomainRules, matchesSkillRules 
 import { claudeSettingsChain } from './internal/settings-chain.js'
 import { fileToolTarget } from './internal/tool-target.js'
 import { createTurnOverride } from './internal/turn-override.js'
-import { errorMessage, isDirectory } from './internal/values.js'
+import { errorMessage, isDirectory, parseNumericEnv } from './internal/values.js'
 
 /** Just enough of pi's Model to match and restore; getAvailable returns these. */
 interface ModelLike {
@@ -73,8 +74,7 @@ interface ModelLike {
  * subagent uses). `inherit` and an unresolvable name leave the model unchanged. */
 function resolveCommandModel(model: string | undefined, available: ReadonlyArray<ModelLike>): ModelLike | undefined {
   if (!model || model.toLowerCase() === 'inherit') return undefined
-  const needle = model.toLowerCase()
-  return available.find((m) => m.id.toLowerCase() === needle) ?? available.find((m) => m.id.toLowerCase().includes(needle) || (m.name ?? '').toLowerCase().includes(needle))
+  return findModel(model, available)
 }
 
 /** Substitute ${CLAUDE_*} into a path rule. A variable that expands to an absolute
@@ -277,8 +277,8 @@ const DEFAULT_TOOL_CHAR_BUDGET = 15_000
  * 1% of the model's context window (1% of the tokens at ~4 characters per token
  * is window / 25), else Claude's documented default. */
 export function slashCommandBudget(contextWindow: number | undefined, env: Record<string, string | undefined> = process.env): number {
-  const override = Number.parseInt(env.SLASH_COMMAND_TOOL_CHAR_BUDGET ?? '', 10)
-  if (Number.isInteger(override) && override > 0) return override
+  const override = parseNumericEnv(env.SLASH_COMMAND_TOOL_CHAR_BUDGET)
+  if (override !== undefined && Number.isInteger(override) && override > 0) return override
   if (contextWindow && contextWindow > 0) return Math.floor(contextWindow / 25)
   return DEFAULT_TOOL_CHAR_BUDGET
 }

--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -19,6 +19,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext, getAgentDir } from '@earendil-works/pi-coding-agent'
 import { claudeConfigDir } from './internal/config-dir.js'
+import { readSettingsChain } from './internal/settings-chain.js'
 import { contentText, errorMessage } from './internal/values.js'
 
 const CUSTOM_TYPE = 'git-checkpoint'
@@ -44,12 +45,9 @@ export const CHECKPOINT_RETENTION_DAYS = 30
  * setting about the user's own disk belongs; a non-positive or unreadable value keeps the
  * default rather than sweeping everything away. */
 export function checkpointRetentionDays(home: string = os.homedir()): number {
-  try {
-    const parsed: unknown = JSON.parse(fs.readFileSync(path.join(claudeConfigDir(home), 'settings.json'), 'utf-8'))
-    const declared = (parsed as { cleanupPeriodDays?: unknown }).cleanupPeriodDays
+  for (const parsed of readSettingsChain([path.join(claudeConfigDir(home), 'settings.json')])) {
+    const declared = parsed.cleanupPeriodDays
     if (typeof declared === 'number' && Number.isFinite(declared) && declared > 0) return declared
-  } catch {
-    // No user settings, or unreadable: the default period stands.
   }
   return CHECKPOINT_RETENTION_DAYS
 }

--- a/extensions/git-checkpoint.ts
+++ b/extensions/git-checkpoint.ts
@@ -19,7 +19,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { type ExtensionAPI, type ExtensionCommandContext, type ExtensionContext, getAgentDir } from '@earendil-works/pi-coding-agent'
 import { claudeConfigDir } from './internal/config-dir.js'
-import { readSettingsChain } from './internal/settings-chain.js'
+import { readSettingsFile } from './internal/settings-chain.js'
 import { contentText, errorMessage } from './internal/values.js'
 
 const CUSTOM_TYPE = 'git-checkpoint'
@@ -45,10 +45,8 @@ export const CHECKPOINT_RETENTION_DAYS = 30
  * setting about the user's own disk belongs; a non-positive or unreadable value keeps the
  * default rather than sweeping everything away. */
 export function checkpointRetentionDays(home: string = os.homedir()): number {
-  for (const parsed of readSettingsChain([path.join(claudeConfigDir(home), 'settings.json')])) {
-    const declared = parsed.cleanupPeriodDays
-    if (typeof declared === 'number' && Number.isFinite(declared) && declared > 0) return declared
-  }
+  const declared = readSettingsFile(path.join(claudeConfigDir(home), 'settings.json'))?.cleanupPeriodDays
+  if (typeof declared === 'number' && Number.isFinite(declared) && declared > 0) return declared
   return CHECKPOINT_RETENTION_DAYS
 }
 

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -9,7 +9,7 @@ import * as path from 'node:path'
 import { readManagedSettings } from '../internal/managed-settings.js'
 import { type InstalledPlugin, pluginComponentPath, substitutePluginVars } from '../internal/plugins.js'
 import { claudeSettingsChain, readSettingsChain } from '../internal/settings-chain.js'
-import { errorMessage, isRecord } from '../internal/values.js'
+import { errorMessage, escapeRegExp, isRecord } from '../internal/values.js'
 
 export interface HookCommand {
   type?: string
@@ -159,7 +159,7 @@ export function readAllowedHttpHookUrls(files: string[], managed: Record<string,
 export function httpUrlAllowed(url: string, allowlist: string[] | undefined): boolean {
   if (allowlist === undefined) return true
   return allowlist.some((pattern) => {
-    const literal = pattern.split('*').map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`))
+    const literal = pattern.split('*').map(escapeRegExp)
     return new RegExp(`^${literal.join('.*')}$`).test(url)
   })
 }

--- a/extensions/hooks/index.ts
+++ b/extensions/hooks/index.ts
@@ -109,7 +109,7 @@ import { watchSettingsFiles } from '../internal/settings-watch.js'
 import { isSkillHooksEvent, SKILL_HOOKS_CHANNEL } from '../internal/skill-hooks.js'
 import { isSubagentPhaseEvent, SUBAGENT_CHANNEL } from '../internal/subagent-events.js'
 import { setSubagentStartHookRunner } from '../internal/subagent-hooks.js'
-import { contentText } from '../internal/values.js'
+import { contentText, parseNumericEnv } from '../internal/values.js'
 import { claudeToolInput, claudeToolName, claudeToolResponse, piToolOutput } from './claude-tools.js'
 import { formatHooksSummary, type HookCommand, type HookMatcher, type HooksConfig, hookFiles, isBackgroundHook, loadHooks, loadManagedHooks, loadPluginHooks, mergeAgentEnvHooks, mergeSkillHooks, readAllowedHttpHookUrls, readDisableAllHooks, readSettingsDisableAllHooks } from './config.js'
 import { blockedToolCall, jsonBlockVerdict, postToolFeedback, promptContext, runPreToolUse, runUserPromptSubmit, surfaceSystemMessages, tryParseJson } from './decisions.js'
@@ -142,9 +142,9 @@ const DEFAULT_STOP_HOOK_BLOCK_CAP = 8
  * zero-cap that would suppress the very first block), else the default for a negative
  * or malformed value. */
 export function stopHookBlockCap(env: Record<string, string | undefined> = process.env): number {
-  const override = Number.parseInt(env.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP ?? '', 10)
+  const override = parseNumericEnv(env.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP)
   if (override === 0) return Number.POSITIVE_INFINITY
-  return Number.isInteger(override) && override > 0 ? override : DEFAULT_STOP_HOOK_BLOCK_CAP
+  return override !== undefined && Number.isInteger(override) && override > 0 ? override : DEFAULT_STOP_HOOK_BLOCK_CAP
 }
 
 async function runNotifyHooks(commands: HookCommand[], payload: unknown, runner: HookRunner): Promise<HookRunResult[]> {

--- a/extensions/internal/bash-rules.ts
+++ b/extensions/internal/bash-rules.ts
@@ -11,8 +11,7 @@
  */
 
 import { hasSubstitution, splitSegments } from './shell-split.js'
-
-const escapeRegExp = (text: string): string => text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+import { escapeRegExp } from './values.js'
 
 /**
  * One rule against one command segment, per Claude's permission table:

--- a/extensions/internal/command-file.ts
+++ b/extensions/internal/command-file.ts
@@ -19,6 +19,7 @@ import * as path from 'node:path'
 import { parseFrontmatter } from '@earendil-works/pi-coding-agent'
 
 import { CLAUDE_TOOL_MAP } from './claude-tool-names.js'
+import { escapeRegExp } from './values.js'
 
 /** The pi file tools a Claude path rule can govern. */
 export type PathRuleTool = 'read' | 'edit' | 'write'
@@ -331,8 +332,6 @@ function splitArgs(args: string): string[] {
   }
   return out
 }
-
-const escapeRegExp = (text: string): string => text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 
 /** One alternation covering every argument placeholder plus the two escape forms.
  * Alternation order is load-bearing: escapes first (so `\$1` never expands), the

--- a/extensions/internal/goal-evaluator.ts
+++ b/extensions/internal/goal-evaluator.ts
@@ -6,6 +6,8 @@
  * so goal.ts stays the lifecycle wiring and each contract is pinned on its own.
  */
 
+import { parseNumericEnv } from './values.js'
+
 /** Claude caps a goal condition at 4,000 characters. */
 export const GOAL_CONDITION_MAX_CHARS = 4000
 
@@ -238,9 +240,8 @@ export const MAX_IDLE_CHECKINS = 3
  * goal: CLAUDE_CODE_GOAL_CHECKIN_MINUTES (0 turns check-ins off, junk falls back to
  * the default) scaled by Claude's doubling. */
 export function checkinIntervalMs(env: Record<string, string | undefined>, delivered: number): number {
-  const raw = env.CLAUDE_CODE_GOAL_CHECKIN_MINUTES
-  const parsed = raw === undefined || raw.trim() === '' ? Number.NaN : Number(raw)
-  const minutes = Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_CHECKIN_MINUTES
+  const parsed = parseNumericEnv(env.CLAUDE_CODE_GOAL_CHECKIN_MINUTES)
+  const minutes = parsed !== undefined && parsed >= 0 ? parsed : DEFAULT_CHECKIN_MINUTES
   return minutes * 60_000 * 2 ** Math.min(delivered, MAX_CHECKIN_DOUBLINGS)
 }
 

--- a/extensions/internal/model-lookup.ts
+++ b/extensions/internal/model-lookup.ts
@@ -11,10 +11,17 @@ export interface ModelLookupContext<M> {
   modelRegistry?: { getAvailable?: () => ReadonlyArray<{ id: string; name?: string }> }
 }
 
+/** The one fuzzy model rule every surface shares (goal, prompt hooks, commands,
+ * subagent aliases): an exact id (case-insensitive) first, then a substring of the
+ * id or the display name. Three private copies had diverged, so `model: opus` could
+ * resolve differently per surface. */
+export function findModel<M extends { id: string; name?: string }>(needle: string, available: ReadonlyArray<M>): M | undefined {
+  const wanted = needle.toLowerCase()
+  return available.find((model) => model.id.toLowerCase() === wanted) ?? available.find((model) => model.id.toLowerCase().includes(wanted) || model.name?.toLowerCase().includes(wanted))
+}
+
 export function resolveModelOverride<M>(ctx: ModelLookupContext<M>, override: string | undefined): M | undefined {
   if (!override) return ctx.model
   const available = ctx.modelRegistry?.getAvailable?.() ?? []
-  const needle = override.toLowerCase()
-  const match = available.find((model) => model.id.toLowerCase() === needle) ?? available.find((model) => model.id.toLowerCase().includes(needle) || model.name?.toLowerCase().includes(needle))
-  return (match as M | undefined) ?? ctx.model
+  return (findModel(override, available) as M | undefined) ?? ctx.model
 }

--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -14,14 +14,13 @@
  */
 
 import * as path from 'node:path'
+import { escapeRegExp } from './values.js'
 
 export interface PathAnchors {
   cwd: string
   projectRoot: string
   home: string
 }
-
-const escapeRegExp = (text: string): string => text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 
 /** Cap on brace-expanded alternatives per pattern, mirroring Claude's ~1000
  * budget; an over-budget pattern is used unexpanded. */

--- a/extensions/internal/settings-chain.ts
+++ b/extensions/internal/settings-chain.ts
@@ -68,6 +68,15 @@ export function localSettingsFile(cwd: string, home: string, platform: NodeJS.Pl
   return path.join(localSettingsDir(cwd, home, platform, owned), '.claude', 'settings.local.json')
 }
 
+/** One settings file as a JSON object, or undefined when missing, unparseable or not
+ * an object: the single-file case of the chain, for the user-only settings a
+ * repository must not influence (a notification channel, a question timeout, a
+ * retention period). */
+export function readSettingsFile(file: string): Record<string, unknown> | undefined {
+  const first = readSettingsChain([file]).next()
+  return first.done ? undefined : first.value
+}
+
 /** Every readable settings object in the chain, in order, so the last one a caller
  * sees for a key is the one that wins. A file that is missing, unparseable, or not a
  * JSON object is skipped: a corrupt settings.json must not end the chain, or the

--- a/extensions/internal/settings-watch.ts
+++ b/extensions/internal/settings-watch.ts
@@ -6,6 +6,7 @@
  */
 
 import * as fs from 'node:fs'
+import { parseNumericEnv } from './values.js'
 
 // Captured at module load: the poll must run on real time even under a test's
 // fake timers (the stat watcher it replaced lived in libuv and was immune too);
@@ -29,7 +30,8 @@ function snapshot(file: string): string | undefined {
  * small, so re-reading them on the poll is negligible. The interval is
  * env-tunable for tests. */
 export function watchSettingsFiles(files: string[], reload: () => void): () => void {
-  const interval = Number(process.env.PI_CODE_SETTINGS_WATCH_INTERVAL_MS) || 2000
+  const configured = parseNumericEnv(process.env.PI_CODE_SETTINGS_WATCH_INTERVAL_MS)
+  const interval = configured !== undefined && configured > 0 ? configured : 2000
   let last = files.map(snapshot)
   const timer = realSetInterval(() => {
     const next = files.map(snapshot)

--- a/extensions/internal/shell-resolve.ts
+++ b/extensions/internal/shell-resolve.ts
@@ -70,7 +70,9 @@ export function resolvePowershellBinary(platform: string = process.platform, env
 function isProjectTooling(dir: string, cwd: string): boolean {
   const relative = path.relative(cwd, dir)
   if (relative === '') return true
-  if (relative.startsWith('..') || path.isAbsolute(relative)) return false
+  // Lexical containment: `..tools/...` is a directory inside cwd, only `..` itself or
+  // `../...` leaves it (the shape claude-rules.ts's containment check spells out).
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return false
   return relative.split(path.sep).some((segment) => PROJECT_TOOLING_DIRS.has(segment))
 }
 

--- a/extensions/internal/values.ts
+++ b/extensions/internal/values.ts
@@ -36,3 +36,20 @@ export function contentText(content: unknown, separator = ''): string {
     .map((part) => part.text)
     .join(separator)
 }
+
+/** Escape a string for literal use inside a RegExp. One copy: five private ones had
+ * the same body and would have drifted the first time one of them was fixed. */
+export function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+}
+
+/** A numeric environment value, or undefined when blank or not a number. Accepts the
+ * spellings docs/mcp.md promises (`2e3`, `64_000`); the caller decides the range and
+ * whether fractions are meaningful, so no flooring here. */
+export function parseNumericEnv(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined
+  const cleaned = raw.replaceAll('_', '')
+  if (cleaned.trim() === '') return undefined
+  const value = Number(cleaned)
+  return Number.isFinite(value) ? value : undefined
+}

--- a/extensions/mcp/policy.ts
+++ b/extensions/mcp/policy.ts
@@ -8,7 +8,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { managedSettingsFile } from '../internal/managed-settings.js'
 import { claudeSettingsChain } from '../internal/settings-chain.js'
-import { errorMessage } from '../internal/values.js'
+import { errorMessage, escapeRegExp } from '../internal/values.js'
 import { interpolateEnv, type ServerConfig } from './config.js'
 
 export interface ProjectServerPolicy {
@@ -132,10 +132,7 @@ export function mcpAllowDeny(scopeFiles: string[] = [], managedFile: string = ma
 
 /** `*` in a policy URL pattern matches any run of characters; everything else is literal. */
 function wildcardRegExp(pattern: string): RegExp {
-  const source = pattern
-    .split('*')
-    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`))
-    .join('.*')
+  const source = pattern.split('*').map(escapeRegExp).join('.*')
   return new RegExp(`^${source}$`)
 }
 

--- a/extensions/mcp/transport.ts
+++ b/extensions/mcp/transport.ts
@@ -18,6 +18,7 @@ import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/webso
 import { ListRootsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { FileOAuthProvider, type OAuthServerConfig } from '../internal/mcp-oauth.js'
 import { resolveShell } from '../internal/shell-resolve.js'
+import { parseNumericEnv } from '../internal/values.js'
 import { expandCwd, type HttpServerConfig, interpolateEnv, type ServerConfig, type StdioServerConfig } from './config.js'
 import { runInteractiveOAuth, serializeInteractiveOAuth } from './oauth-flow.js'
 
@@ -36,19 +37,12 @@ const DEFAULT_STDIO_CALL_IDLE_TIMEOUT_MS = 1_800_000
 
 /** Claude's numeric env vars accept scientific notation and digit-separator spellings
  * (2e3 as 2000, 64_000 as 64000). A non-numeric value is undefined, not zero. */
-function parseNumericEnv(raw: string): number | undefined {
-  const cleaned = raw.replaceAll('_', '')
-  if (cleaned.trim() === '') return undefined
-  const value = Number(cleaned)
-  return Number.isFinite(value) ? Math.floor(value) : undefined
-}
-
 /** A positive-integer env override, or the default when unset or unparseable. */
 function envTimeout(name: string, fallback: number): number {
   const raw = process.env[name]
   if (raw === undefined) return fallback
   const value = parseNumericEnv(raw)
-  return value !== undefined && value > 0 ? value : fallback
+  return value !== undefined && value > 0 ? Math.floor(value) : fallback
 }
 
 // Claude honors MCP_TIMEOUT (connect) and MCP_TOOL_TIMEOUT (per-call), both in ms.

--- a/extensions/notify.ts
+++ b/extensions/notify.ts
@@ -16,12 +16,12 @@
  */
 
 import { execFile } from 'node:child_process'
-import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
 import { claudeConfigDir } from './internal/config-dir.js'
+import { readSettingsChain } from './internal/settings-chain.js'
 
 /** How a finished turn is announced, from Claude's `preferredNotifChannel`. */
 export type NotifChannel = 'desktop' | 'bell' | 'both' | 'off'
@@ -56,12 +56,8 @@ export function isAway(lastInputAt: number | undefined, now: number, thresholdMs
  * preference, so only user scope is read; a checked-out repo does not get to silence
  * or change your notifications. */
 function readPreferredNotifChannel(home: string): unknown {
-  try {
-    const settings = JSON.parse(fs.readFileSync(path.join(claudeConfigDir(home), 'settings.json'), 'utf-8'))
-    return settings?.preferredNotifChannel
-  } catch {
-    return undefined
-  }
+  for (const settings of readSettingsChain([path.join(claudeConfigDir(home), 'settings.json')])) return settings.preferredNotifChannel
+  return undefined
 }
 
 function windowsToastScript(title: string, body: string): string {

--- a/extensions/notify.ts
+++ b/extensions/notify.ts
@@ -21,7 +21,7 @@ import * as path from 'node:path'
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
 
 import { claudeConfigDir } from './internal/config-dir.js'
-import { readSettingsChain } from './internal/settings-chain.js'
+import { readSettingsFile } from './internal/settings-chain.js'
 
 /** How a finished turn is announced, from Claude's `preferredNotifChannel`. */
 export type NotifChannel = 'desktop' | 'bell' | 'both' | 'off'
@@ -56,8 +56,7 @@ export function isAway(lastInputAt: number | undefined, now: number, thresholdMs
  * preference, so only user scope is read; a checked-out repo does not get to silence
  * or change your notifications. */
 function readPreferredNotifChannel(home: string): unknown {
-  for (const settings of readSettingsChain([path.join(claudeConfigDir(home), 'settings.json')])) return settings.preferredNotifChannel
-  return undefined
+  return readSettingsFile(path.join(claudeConfigDir(home), 'settings.json'))?.preferredNotifChannel
 }
 
 function windowsToastScript(title: string, body: string): string {

--- a/extensions/question.ts
+++ b/extensions/question.ts
@@ -13,7 +13,7 @@ import { Editor, type EditorTheme, Key, matchesKey, Text, truncateToWidth } from
 import { Type } from 'typebox'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { readManagedSettings } from './internal/managed-settings.js'
-import { readSettingsChain } from './internal/settings-chain.js'
+import { readSettingsFile } from './internal/settings-chain.js'
 
 interface OptionWithDesc {
   label: string
@@ -96,8 +96,7 @@ export function askUserQuestionTimeoutMs(home: string = os.homedir()): number | 
   const managed = readManagedSettings() as { askUserQuestionTimeout?: unknown }
   const fromManaged = parseAskUserQuestionTimeout(managed.askUserQuestionTimeout)
   if (fromManaged !== undefined) return fromManaged
-  for (const parsed of readSettingsChain([path.join(claudeConfigDir(home), 'settings.json')])) return parseAskUserQuestionTimeout(parsed.askUserQuestionTimeout)
-  return undefined
+  return parseAskUserQuestionTimeout(readSettingsFile(path.join(claudeConfigDir(home), 'settings.json'))?.askUserQuestionTimeout)
 }
 
 function checkbox(checked: boolean | undefined): string {

--- a/extensions/question.ts
+++ b/extensions/question.ts
@@ -6,7 +6,6 @@
  * Multiple questions per call are not batched; ask sequentially.
  */
 
-import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import type { ExtensionAPI, ExtensionContext, Theme } from '@earendil-works/pi-coding-agent'
@@ -14,6 +13,7 @@ import { Editor, type EditorTheme, Key, matchesKey, Text, truncateToWidth } from
 import { Type } from 'typebox'
 import { claudeConfigDir } from './internal/config-dir.js'
 import { readManagedSettings } from './internal/managed-settings.js'
+import { readSettingsChain } from './internal/settings-chain.js'
 
 interface OptionWithDesc {
   label: string
@@ -96,12 +96,8 @@ export function askUserQuestionTimeoutMs(home: string = os.homedir()): number | 
   const managed = readManagedSettings() as { askUserQuestionTimeout?: unknown }
   const fromManaged = parseAskUserQuestionTimeout(managed.askUserQuestionTimeout)
   if (fromManaged !== undefined) return fromManaged
-  try {
-    const parsed = JSON.parse(fs.readFileSync(path.join(claudeConfigDir(home), 'settings.json'), 'utf-8')) as { askUserQuestionTimeout?: unknown }
-    return parseAskUserQuestionTimeout(parsed.askUserQuestionTimeout)
-  } catch {
-    return undefined
-  }
+  for (const parsed of readSettingsChain([path.join(claudeConfigDir(home), 'settings.json')])) return parseAskUserQuestionTimeout(parsed.askUserQuestionTimeout)
+  return undefined
 }
 
 function checkbox(checked: boolean | undefined): string {

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -11,6 +11,7 @@ import { getAgentDir, parseFrontmatter, stripFrontmatter } from '@earendil-works
 // is not merely ignored, it narrows the child's registry.
 import { parseToolGrants } from '../internal/command-file.js'
 import { claudeConfigDir } from '../internal/config-dir.js'
+import { findModel } from '../internal/model-lookup.js'
 import { installedPlugins, pluginComponentPath } from '../internal/plugins.js'
 import { ancestorDirs, findNearestDir } from '../internal/project-root.js'
 import { errorMessage } from '../internal/values.js'
@@ -65,10 +66,9 @@ function parseModelAlias(raw: unknown): string | undefined {
 /** Resolve a Claude tier alias to a concrete model id the user can actually run.
  * Returning undefined leaves the child on the session model, which is what the
  * unresolvable case degraded to before and still does. */
-export function resolveModelAlias(alias: string | undefined, available: ReadonlyArray<{ id: string; provider?: string }>): string | undefined {
+export function resolveModelAlias(alias: string | undefined, available: ReadonlyArray<{ id: string; name?: string; provider?: string }>): string | undefined {
   if (!alias || alias === 'inherit') return undefined
-  const needle = alias.toLowerCase()
-  return available.find((model) => model.id.toLowerCase().includes(needle))?.id
+  return findModel(alias, available)?.id
 }
 
 /** pi's extended thinking levels; Claude's effort values are a subset, so they map 1:1. */

--- a/extensions/subagent/params.ts
+++ b/extensions/subagent/params.ts
@@ -23,8 +23,7 @@ export const ChainItem = Type.Object({
 })
 
 const AgentScopeSchema = StringEnum(['user', 'project', 'both'] as const, {
-  description: 'Which agent directories to use. Default: "user". Use "both" to include project-local agents.',
-  default: 'user',
+  description: 'Which agent directories to use. Omitted, an approved project resolves to "both" and an unapproved one to "user"; "both" includes project-local agents.',
 })
 
 export const SubagentParams = Type.Object({

--- a/extensions/web.ts
+++ b/extensions/web.ts
@@ -16,6 +16,7 @@ import { Type } from 'typebox'
 import { htmlToMarkdown, removeTags } from './internal/html-markdown.js'
 import { completeText } from './internal/model-complete.js'
 import { capForContext } from './internal/output-guard.js'
+import { parseNumericEnv } from './internal/values.js'
 import { httpFetch } from './internal/web-transport.js'
 
 const SEARCH_ENDPOINT = 'https://html.duckduckgo.com/html/?q='
@@ -265,10 +266,8 @@ async function fetchText(rawUrl: string, crossHost: CrossHost, transport = httpF
 const FETCH_CACHE_TTL_DEFAULT_MS = 15 * 60 * 1000
 
 function fetchCacheTtlMs(): number {
-  const raw = process.env.CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS
-  if (raw === undefined || raw.trim() === '') return FETCH_CACHE_TTL_DEFAULT_MS
-  const parsed = Number(raw)
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : FETCH_CACHE_TTL_DEFAULT_MS
+  const parsed = parseNumericEnv(process.env.CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS)
+  return parsed !== undefined && parsed >= 0 ? parsed : FETCH_CACHE_TTL_DEFAULT_MS
 }
 const FETCH_CACHE_MAX_ENTRIES = 50
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1103,6 +1103,8 @@ describe('slashCommandBudget', () => {
     expect(slashCommandBudget(200_000, { SLASH_COMMAND_TOOL_CHAR_BUDGET: '4000' })).toBe(4000)
     // 1% of the window's tokens at ~4 chars per token is window / 25.
     expect(slashCommandBudget(200_000, {})).toBe(8000)
+    expect(slashCommandBudget(undefined, { SLASH_COMMAND_TOOL_CHAR_BUDGET: '64_000' })).toBe(64_000)
+    expect(slashCommandBudget(undefined, { SLASH_COMMAND_TOOL_CHAR_BUDGET: '2e3' })).toBe(2000)
     expect(slashCommandBudget(undefined, {})).toBe(15_000)
   })
 

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -96,6 +96,9 @@ describe('runPromptHook', () => {
 describe('stopHookBlockCap', () => {
   it('defaults to 8 and honors a positive integer CLAUDE_CODE_STOP_HOOK_BLOCK_CAP override', () => {
     expect(stopHookBlockCap({})).toBe(8)
+    // The same grammar every other numeric env var accepts: exponent and underscores.
+    expect(stopHookBlockCap({ CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: '1e1' })).toBe(10)
+    expect(stopHookBlockCap({ CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: '1_2' })).toBe(12)
     expect(stopHookBlockCap({ CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: '3' })).toBe(3)
     // Negative or malformed values fall back to the default rather than capping at 0.
     expect(stopHookBlockCap({ CLAUDE_CODE_STOP_HOOK_BLOCK_CAP: '-2' })).toBe(8)

--- a/tests/shell-resolve.test.ts
+++ b/tests/shell-resolve.test.ts
@@ -138,6 +138,15 @@ describe.each(RESOLVERS)('%s refuses a binary planted in the project', (_name, p
     expect(resolve({ PATH: [local, venv].join(delimiter) }, cwd)).toBeUndefined()
   })
 
+  it('skips one under a project directory whose name begins with two dots', () => {
+    // `relative.startsWith('..')` read `..tools/node_modules/...` as outside the
+    // launch directory, so a copy planted there was accepted as the user's install.
+    const cwd = tempDir()
+    const inside = entryIn(join(cwd, '..tools', 'node_modules', 'bin'))
+    plant(inside)
+    expect(resolve({ PATH: inside }, cwd)).toBeUndefined()
+  })
+
   it('walks past a planted one to a genuine install further along PATH', () => {
     // The planted copy comes FIRST: a resolver that abandoned the lookup on seeing one,
     // rather than skipping that entry, would fail here. The launch directory IS the

--- a/tests/subagent-agents-background.test.ts
+++ b/tests/subagent-agents-background.test.ts
@@ -910,6 +910,16 @@ describe('resolveModelAlias', () => {
     { id: 'gpt-oss:20b', provider: 'ollama' },
   ]
 
+  it('advertises no agentScope default, since an approved project resolves to both', async () => {
+    // The schema said default "user"; execute resolves an omitted scope to "both" for an
+    // approved project, and pi does not apply schema defaults, so the description was
+    // the only thing the model saw and it was wrong.
+    const { SubagentParams } = await import('../extensions/subagent/params.ts')
+    const scope = (SubagentParams as unknown as { properties: { agentScope: { default?: unknown; description: string } } }).properties.agentScope
+    expect(scope.default).toBeUndefined()
+    expect(scope.description).toContain('approved project')
+  })
+
   it('resolves a Claude tier alias to an authenticated model id', () => {
     expect(resolveModelAlias('sonnet', available)).toBe('claude-sonnet-4-5')
     expect(resolveModelAlias('Opus', available)).toBe('claude-opus-4-1')
@@ -918,6 +928,19 @@ describe('resolveModelAlias', () => {
   it('returns undefined when the tier is not available, so the session model is used', () => {
     expect(resolveModelAlias('haiku', available)).toBeUndefined()
     expect(resolveModelAlias('sonnet', [{ id: 'gpt-oss:20b', provider: 'ollama' }])).toBeUndefined()
+  })
+
+  it('prefers an exact id over an id that merely contains the alias, and matches on the display name', () => {
+    // The three model resolvers had diverged: this one matched by id substring only, so
+    // `claude-opus-4-1` could resolve to `claude-opus-4-1-mini` by list order, and a
+    // name-only match (`model: opus` against a provider id) never resolved.
+    const models = [
+      { id: 'claude-opus-4-1-mini', provider: 'anthropic' },
+      { id: 'claude-opus-4-1', provider: 'anthropic' },
+      { id: 'vendor/x-7', name: 'Claude Sonnet 4.5', provider: 'vendor' },
+    ]
+    expect(resolveModelAlias('claude-opus-4-1', models)).toBe('claude-opus-4-1')
+    expect(resolveModelAlias('sonnet', models)).toBe('vendor/x-7')
   })
 
   it('treats inherit as the session model rather than a tier to look up', () => {


### PR DESCRIPTION
Round 5 register items R5-18 through R5-21 (the parts with a behavioural consequence), each behavioural change paired with a test that fails without it and a mutant it kills (five killed).

- [x] `npm run check` passes (Biome, strict tsc, Vitest)
- [x] Tests cover the change

## Wrong results on valid input

**Every numeric env var accepts the spellings the docs promise** (`internal/values.ts` and seven readers). `docs/mcp.md` says numeric values accept `2e3` and `64_000`; only the MCP budgets did. `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` and `SLASH_COMMAND_TOOL_CHAR_BUDGET` went through `parseInt`, so `1e1` read as 1, and three more readers through bare `Number()`. One `parseNumericEnv`, with range and flooring left to each caller so fractional check-in minutes stay meaningful.

**Model names resolve the same way on every surface** (`internal/model-lookup.ts`, `commands.ts`, `subagent/agents.ts`). Three copies had diverged: goal and prompt hooks matched an exact id first then an id-or-name substring, subagent aliases an id substring only, so `claude-opus-4-1` could resolve to `claude-opus-4-1-mini` by list order and a name-only match never resolved. `findModel` is the one rule.

**A project directory named `..tools` is inside the launch directory** (`internal/shell-resolve.ts`). `relative.startsWith('..')` read `..tools/node_modules/...` as outside cwd, the lexical trap `claude-rules.ts` already spells out, so a shell binary planted there was accepted as the user's install.

**The subagent schema no longer advertises a default the code does not apply** (`subagent/params.ts`). It said `agentScope` defaults to `"user"`; `execute` resolves an omitted scope to `"both"` for an approved project, and pi does not fill schema defaults, so that description was all the model saw.

## Pure dedupe

`escapeRegExp` had five byte-identical copies plus two inlined into the wildcard matchers; the checkpoint retention, question timeout and notification channel readers each re-implemented "parse the user settings.json, skip when missing or broken", which `readSettingsChain` over the one file already is.