### PR TITLE
Put fourteen doc blocks on the declarations they describe, and state comments as constraints

### DIFF
--- a/extensions/context-imports.ts
+++ b/extensions/context-imports.ts
@@ -743,9 +743,6 @@ function additionalDirsAddition(extras: Array<{ path: string; content: string; d
   return addition
 }
 
-/** The `## Imported context (@)` section for every resolved @import, with the
- * budget-exhaustion notice, announcing each as an `include`. Empty when nothing
- * was imported. */
 /** The refusal notice: every existing file an @import named that its importer may not
  * reach. Claude asks about these through an approval dialog and loads the ones you
  * allow; pi-code refuses them, and this is what says so. Silence was the real defect:
@@ -759,6 +756,9 @@ function refusedImportsAddition(refused: Set<string>): string {
   return `\n\n## Imports not loaded (@)\n\nThese files resolve outside what the file importing them may read, so their contents are not in context:\n\n${list}`
 }
 
+/** The `## Imported context (@)` section for every resolved @import, with the
+ * budget-exhaustion notice, announcing each as an `include`. Empty when nothing
+ * was imported. */
 function importedAddition(imported: ImportedFile[], budget: ImportBudget, home: string, projectRoot: string, announce: (event: InstructionLoadEvent) => void): string {
   if (imported.length === 0) return ''
   const section = imported.map((entry) => `### ${entry.path}\n\n${stripBlockComments(entry.body)}`).join('\n\n')

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -224,9 +224,6 @@ function mergeHooksJson(config: HooksConfig, raw: string, source: string, source
   }
 }
 
-/** Each enabled plugin's hooks (hooks/hooks.json, or wherever the manifest points),
- * with ${CLAUDE_PLUGIN_ROOT}/${CLAUDE_PLUGIN_DATA} substituted before parsing so a
- * hook can name its bundled scripts by real path. */
 /** The substitution here lands inside raw JSON, so values must arrive escaped:
  * an unescaped Windows root injected \U-style sequences, the parse threw, and
  * every hook the plugin declared silently vanished. */
@@ -270,6 +267,9 @@ function withoutUserConfigShellCommands(raw: string, source: string): string {
   return dropped ? JSON.stringify(parsed) : raw
 }
 
+/** Each enabled plugin's hooks (hooks/hooks.json, or wherever the manifest points),
+ * with ${CLAUDE_PLUGIN_ROOT}/${CLAUDE_PLUGIN_DATA} substituted before parsing so a
+ * hook can name its bundled scripts by real path. */
 export function loadPluginHooks(config: HooksConfig, plugins: InstalledPlugin[], sources?: Map<HookMatcher, string>): void {
   for (const plugin of plugins) {
     const declared = plugin.manifest.hooks

--- a/extensions/hooks/config.ts
+++ b/extensions/hooks/config.ts
@@ -209,10 +209,9 @@ function mergeHooksJson(config: HooksConfig, raw: string, source: string, source
   }
   for (const [event, matchers] of Object.entries(parsed?.hooks ?? {})) {
     if (!Array.isArray(matchers)) continue
-    // Entries are validated here rather than where they run: a hand-edited settings
-    // file that writes `hooks` as an object instead of a list used to throw out of
-    // the tool_call handler, and pi turns that into an error result, so every tool
-    // call for the rest of the session failed with an opaque type error.
+    // Entries are validated here rather than where they run: a malformed entry that
+    // throws from the tool_call handler becomes an error result there, so every tool
+    // call for the rest of the session fails with an opaque type error.
     const usable = matchers.filter((entry) => isUsableMatcher(entry, source, event))
     if (usable.length === 0) continue
     if (origin !== undefined) stampOrigin(usable, origin)

--- a/extensions/hooks/decisions.ts
+++ b/extensions/hooks/decisions.ts
@@ -170,15 +170,6 @@ export interface PreToolUseOutcome extends HookDecision {
   context?: string[]
 }
 
-/** Run PreToolUse hooks for a tool, in parallel as Claude does; the first blocking
- * verdict in config order wins. The payload reports the Claude vocabulary: the MCP
- * alias for MCP tools, and the documented name and tool_input shape for pi's
- * built-ins (see claude-tools). Every hook sees the original tool input;
- * hookSpecificOutput.updatedInput replaces the input in place as each hook
- * completes, translated back to the pi shape for a built-in (an incomplete rewrite
- * keeps the original input rather than corrupting it), so with several rewrites
- * the last to finish takes effect (the docs leave multi-rewrite ordering
- * unspecified). */
 /** Apply a hook's updatedInput rewrite in place, translating a built-in rewrite
  * back to the pi shape; an incomplete built-in rewrite keeps the original input
  * rather than corrupting it. */
@@ -215,6 +206,15 @@ function preToolContexts(results: HookRunResult[]): string[] {
   })
 }
 
+/** Run PreToolUse hooks for a tool, in parallel as Claude does; the first blocking
+ * verdict in config order wins. The payload reports the Claude vocabulary: the MCP
+ * alias for MCP tools, and the documented name and tool_input shape for pi's
+ * built-ins (see claude-tools). Every hook sees the original tool input;
+ * hookSpecificOutput.updatedInput replaces the input in place as each hook
+ * completes, translated back to the pi shape for a built-in (an incomplete rewrite
+ * keeps the original input rather than corrupting it), so with several rewrites
+ * the last to finish takes effect (the docs leave multi-rewrite ordering
+ * unspecified). */
 export async function runPreToolUse(config: HooksConfig, toolName: string, toolInput: unknown, runner: HookRunner, claudeName?: string, onSystemMessage?: SystemMessageSink, anchors?: PathAnchors): Promise<PreToolUseOutcome> {
   const cwd = anchors?.cwd ?? process.cwd()
   const translatedName = claudeName ?? claudeToolName(toolName)

--- a/extensions/hooks/matcher.ts
+++ b/extensions/hooks/matcher.ts
@@ -194,18 +194,17 @@ export function passesIfFilter(hook: HookCommand, target: IfFilterTarget | undef
 
 /** One `if` pattern against a call's arguments. Claude evaluates the rule "against
  * the tool name and arguments together" in permission-rule syntax, so each tool uses
- * the same specifier engine its permission rules use:
+ * the same specifier engine its permission rules use: a command pattern for Bash, a
+ * `domain:` host for WebFetch, an agent name for Agent, a skill name for Skill, and a
+ * path rule for the file tools. A tool with no specifier syntax matches nothing,
+ * which is also what an unparseable rule does.
  *
  * PAIRED WITH commands.ts's tool_call guard, which dispatches the same tools to the
  * same matchers for `allowed-tools` scopes. The two are deliberately NOT merged: bash
  * differs on purpose (an allow scope requires every segment to match, an `if` filter is
  * best effort and errs toward running the hook), and merging would hide that. They are
  * two lists that must agree, so a new scoped tool has to be added in both places; the
- * shared roster is ARG_RULE_TOOLS in internal/command-file.ts.
- * a command pattern for Bash, a
- * `domain:` host for WebFetch, an agent name for Agent, a skill name for Skill, and a
- * path rule for the file tools. A tool with no specifier syntax matches nothing,
- * which is also what an unparseable rule does. */
+ * shared roster is ARG_RULE_TOOLS in internal/command-file.ts. */
 function matchesToolPattern(piName: string, input: Record<string, unknown> | null, pattern: string, anchors: PathAnchors): boolean {
   const str = (value: unknown): string => (typeof value === 'string' ? value : '')
   switch (piName) {

--- a/extensions/hooks/runners.ts
+++ b/extensions/hooks/runners.ts
@@ -41,10 +41,6 @@ export interface HookRunResult {
 }
 /** Runs one configured hook entry, whatever its type; boundRunner dispatches. */
 export type HookRunner = (hook: HookCommand, payload: unknown, timeoutMs: number) => Promise<HookRunResult>
-/** The shell path specifically; the statusline reuses it for its own command. With an
- * `args` array it becomes the exec path: `command` is spawned directly with those args.
- * `onChild` hands the caller a kill for the spawned tree, so a background hook that is
- * still running at session end can be reaped (Claude kills async hooks at teardown). */
 /** How one command hook is spawned, beyond the payload and its budget. Grouped rather
  * than trailing off the parameter list: the exec form, the shell choice and the
  * declaring plugin are all per-hook fields that arrive together from one HookCommand. */
@@ -119,6 +115,10 @@ function shellInvocation(command: string, shell: string | undefined): { file: st
   return resolved ? { file: resolved.file, spawnArgs: resolved.argsFor(command) } : undefined
 }
 
+/** The shell path specifically; the statusline reuses it for its own command. With an
+ * `args` array it becomes the exec path: `command` is spawned directly with those args.
+ * `onChild` hands the caller a kill for the spawned tree, so a background hook that is
+ * still running at session end can be reaped (Claude kills async hooks at teardown). */
 export const runHookCommand: HookCommandRunner = (command, payload, timeoutMs, { projectDir, args, onChild, shell, plugin, sessionId } = {}) =>
   new Promise((resolve) => {
     // /bin/sh by absolute path off Windows, so the shell can't be resolved through an

--- a/extensions/internal/agent-run.ts
+++ b/extensions/internal/agent-run.ts
@@ -36,7 +36,7 @@ export function setAgentRunner(fn: AgentRunner | undefined): void {
   runner = fn
 }
 
-/** Whether a runner is registered, so agent hooks can be reported as runnable. */
+/** Test seam: whether a runner is registered. */
 export function hasAgentRunner(): boolean {
   return runner !== undefined
 }

--- a/extensions/internal/claude-tool-names.ts
+++ b/extensions/internal/claude-tool-names.ts
@@ -1,13 +1,10 @@
 /**
  * The one place pi tool names and Claude tool names are paired.
  *
- * Two independent tables used to encode this: a Claude->pi map for resolving
- * `allowed-tools` entries, and a pi->Claude map for hook payloads and matchers.
- * They disagreed. The second one listed six tools, so a hook matcher written in
- * Claude's vocabulary never fired for `web_fetch`, `subagent`, `question`, `todo`,
- * `slash_command`, `web_search` or `plan_mode_complete`, even though the first table
- * had known those pairings all along. Both directions now derive from this list, so
- * a tool cannot be nameable in one direction and invisible in the other.
+ * Both directions (the Claude->pi map that resolves `allowed-tools` entries, and the
+ * pi->Claude map behind hook payloads and matchers) derive from this one list, so a
+ * tool cannot be nameable in one direction and invisible in the other: two separate
+ * tables let a hook matcher written in Claude's vocabulary miss seven tools.
  *
  * Canonical names are the tools reference's own spellings. `claude: null` marks a pi
  * tool the reference has no counterpart for: it stays untranslated in payloads, and

--- a/extensions/internal/external-imports.ts
+++ b/extensions/internal/external-imports.ts
@@ -36,7 +36,7 @@ export function externalImportKey(cwd: string): string {
   }
 }
 
-/** The store file. A seam: the tests point it at a temp directory. */
+/** The store file, inside pi's agent directory (tests relocate that through PI_CODING_AGENT_DIR). */
 export function externalImportStorePath(agentDir: string = getAgentDir()): string {
   return path.join(agentDir, 'pi-code-external-imports.json')
 }

--- a/extensions/internal/managed-settings.ts
+++ b/extensions/internal/managed-settings.ts
@@ -17,7 +17,7 @@ import { isRecord } from './values.js'
 /** The OS managed-settings.json path Claude Code documents per platform. */
 export function managedSettingsPath(platform: NodeJS.Platform = process.platform): string {
   if (platform === 'darwin') return '/Library/Application Support/ClaudeCode/managed-settings.json'
-  // The legacy C:\ProgramData\ClaudeCode path was dropped in Claude Code v2.1.75.
+  // Claude reads the Windows file from Program Files; the older ProgramData location is not consulted.
   if (platform === 'win32') return String.raw`C:\Program Files\ClaudeCode\managed-settings.json`
   return '/etc/claude-code/managed-settings.json'
 }

--- a/extensions/internal/mcp-oauth.ts
+++ b/extensions/internal/mcp-oauth.ts
@@ -61,8 +61,8 @@ function storeFileFor(serverName: string, endpoint?: string): string {
     .digest('hex')
     .slice(0, 8)
   // Collapse disallowed runs to a single hyphen, then strip leading and trailing
-  // hyphens by index. The old /^-+|-+$/g trim rescanned on every hyphen of a long run
-  // (its trailing-anchored branch backtracks per start position), which is quadratic.
+  // hyphens by index: a trailing-anchored regex trim rescans per hyphen of a long run
+  // (quadratic).
   const collapsed = serverName.replace(/[^A-Za-z0-9_-]+/g, '-')
   let start = 0
   let end = collapsed.length

--- a/extensions/internal/path-rules.ts
+++ b/extensions/internal/path-rules.ts
@@ -103,9 +103,9 @@ function bracketClass(body: string): string | null {
   // JavaScript will build: RegExp throws "Range out of order in character class". The
   // `-` cannot simply be escaped, since `[a-z]` is the whole point of the syntax, so the
   // class is validated by construction and an unbuildable one is treated exactly as an
-  // unterminated `[` already is: the pattern is invalid and matches nothing. Without
-  // this the throw escaped compileGlobs, which does not catch, and took the permission
-  // check that called it with it.
+  // unterminated `[` already is: the pattern is invalid and matches nothing. It must
+  // not throw: compileGlobs does not catch, and the permission check that called it
+  // would fail with it.
   return isBuildableClass(source) ? source : null
 }
 
@@ -195,9 +195,7 @@ function resolveRule(rule: string, anchors: PathAnchors): string {
   return path.join(anchors.cwd, rel)
 }
 
-/** One rule glob precompiled for repeated matching: its anchored regex, and whether
- * it applies to the basename (a slashless pattern, gitignore-style) or the full
- * root-relative path. */
+/** One rule glob precompiled for repeated matching: its anchored regex. */
 export interface CompiledGlob {
   regex: RegExp
 }
@@ -211,13 +209,13 @@ export function globCompileStats(): { compiled: number; evaluated: number } {
   return { compiled: globsCompiled, evaluated: globsEvaluated }
 }
 
-/** Rule `paths:` globs compiled once for repeated matching, with claude-rules'
- * pathMatchesGlobs semantics: `./` and leading `/` anchors are stripped, a trailing
- * slash scopes to the directory's contents, and blank entries drop out. */
 /** Claude's shared list budget: rule patterns past ~1000 compiled entries are
  * ignored rather than compiled without bound. */
 const LIST_PATTERN_BUDGET = 1000
 
+/** Rule `paths:` globs compiled once for repeated matching, with claude-rules'
+ * pathMatchesGlobs semantics: `./` and leading `/` anchors are stripped, a trailing
+ * slash scopes to the directory's contents, and blank entries drop out. */
 export function compileGlobs(globs: string[]): CompiledGlob[] {
   const compiled: CompiledGlob[] = []
   for (const raw of globs) {
@@ -243,8 +241,6 @@ export function matchesCompiledGlobs(relPath: string, globs: CompiledGlob[]): bo
   return globs.some((glob) => glob.regex.test(posix))
 }
 
-/** Whether the accessed file matches at least one rule. No rules means no match:
- * a granted-but-scoped tool with an empty scope set stays blocked, never open. */
 /** Both comparison sides in posix form. On Windows, resolve stamps the drive on
  * the target while join-built rules stay drive-less, and backslash separators
  * collide with glob syntax, so unnormalized rules could never match. */
@@ -272,6 +268,8 @@ export function stripRuleDrive(rule: string, windows: boolean): string {
   return rule.replace(/^([A-Za-z]):\//, '/').replace(/^\/[A-Za-z]\//, '/')
 }
 
+/** Whether the accessed file matches at least one rule. No rules means no match:
+ * a granted-but-scoped tool with an empty scope set stays blocked, never open. */
 export function matchesPathRules(filePath: string, rules: string[], anchors: PathAnchors): boolean {
   const target = toPosix(path.resolve(anchors.cwd, filePath))
   return rules.some((rule) => {

--- a/extensions/internal/plugins.ts
+++ b/extensions/internal/plugins.ts
@@ -258,11 +258,6 @@ function resolvePlugin(home: string, cacheDir: string, marketplace: string, plug
   return { name, root, dataDir: path.join(claudeConfigDir(home), 'plugins', 'data', id), manifest, ...(userConfig ? { userConfig } : {}) }
 }
 
-/** The two plugin path variables, textually substituted into plugin-shipped
- * config (hook commands, MCP server definitions, command bodies). A caller
- * substituting into text that is still raw JSON must pass an escapeValue that
- * JSON-escapes: a Windows root (C:\Users\...) inserted verbatim injects invalid
- * escape sequences and the subsequent parse throws. */
 /** A plugin component path, resolved inside the plugin root. Claude "rejects a component
  * path that resolves outside the plugin root, such as `../shared-utils`", so an escaping
  * entry yields undefined and its caller skips that component. The check is lexical, which
@@ -277,6 +272,11 @@ export function pluginComponentPath(plugin: Pick<InstalledPlugin, 'name' | 'root
   return resolved
 }
 
+/** The two plugin path variables, textually substituted into plugin-shipped
+ * config (hook commands, MCP server definitions, command bodies). A caller
+ * substituting into text that is still raw JSON must pass an escapeValue that
+ * JSON-escapes: a Windows root (C:\Users\...) inserted verbatim injects invalid
+ * escape sequences and the subsequent parse throws. */
 export function substitutePluginVars(value: string, plugin: InstalledPlugin, escapeValue: (substituted: string) => string = (substituted) => substituted): string {
   return value
     .replaceAll('${CLAUDE_PLUGIN_ROOT}', escapeValue(plugin.root))

--- a/extensions/internal/project-approval.ts
+++ b/extensions/internal/project-approval.ts
@@ -118,13 +118,6 @@ function runtimeLacksProjectTrust(ctx: { isProjectTrusted?: () => boolean; ui?: 
   return true
 }
 
-/**
- * Whether project-controlled config may be acted on.
- *
- * Refuses without a UI rather than deferring: pi reached this point without consulting
- * `defaultProjectTrust` at all, so there is no user preference to fall back on. A run
- * that cannot ask has not been approved.
- */
 /** The same decision as isProjectApproved, but never prompts: an undecided project
  * reads as unapproved. For surfaces that only display project config, like the
  * subagent roster, where a mid-turn dialog would be wrong. */
@@ -150,6 +143,13 @@ export function isGatedFileApproved(ctx: Pick<ApprovalContext, 'cwd' | 'isProjec
   return isProjectApprovedSilently(ctx, { ...deps, hasClaudeShaped: () => true })
 }
 
+/**
+ * Whether project-controlled config may be acted on.
+ *
+ * Refuses without a UI rather than deferring: pi reached this point without consulting
+ * `defaultProjectTrust` at all, so there is no user preference to fall back on. A run
+ * that cannot ask has not been approved.
+ */
 export async function isProjectApproved(ctx: ApprovalContext, deps: ApprovalDeps = defaultDeps): Promise<boolean> {
   if (runtimeLacksProjectTrust(ctx)) return false // pi predates project-trust support
   if (ctx.isProjectTrusted?.() !== true) return false // pi declined trust for this project

--- a/extensions/internal/project-root.ts
+++ b/extensions/internal/project-root.ts
@@ -16,11 +16,10 @@ import * as path from 'node:path'
 /** The project root marker. `.git` is a file in worktrees and submodules, a directory
  * in an ordinary clone.
  *
- * `package.json` used to count too, which made every package of a monorepo its own
- * project: its own memory directory, its own settings.local.json, its own
- * CLAUDE_PROJECT_DIR, its own trust decision. Claude's project is the repository, and
- * a repository can add a package.json wherever it likes, so a marker it controls was
- * also a marker it could move. */
+ * Only `.git`: a package.json marker would make every package of a monorepo its own
+ * project (its own memory directory, settings.local.json, CLAUDE_PROJECT_DIR and trust
+ * decision), and a repository can add a package.json wherever it likes, so a marker it
+ * controls is a marker it can move. Claude's project is the repository. */
 export const ROOT_MARKERS = ['.git']
 
 /** Project root at or above `from`, or undefined outside a repository. */

--- a/extensions/internal/tool-target.ts
+++ b/extensions/internal/tool-target.ts
@@ -1,11 +1,10 @@
 /**
  * Which file a tool call touched.
  *
- * Two extensions attach instruction files when a file tool touches a path they cover
- * (claude-rules for a path-scoped rule, context-imports for a nested CLAUDE.md), and
- * both got the same detail wrong: pi's edit and write tools accept `file_path` as an
- * alias for `path`, so a handler reading only `path` did nothing for a model that used
- * the alias. One reader, one place to be wrong.
+ * pi's read, edit and write tools accept `file_path` as an alias for `path`, so every
+ * reader of a file tool's target must accept both, and a handler reading only `path`
+ * does nothing for a model that used the alias. This is the one reader (claude-rules,
+ * context-imports and the command path-scope guard all go through it).
  */
 
 /** The tools that name a file pi-code acts on. */

--- a/extensions/internal/values.ts
+++ b/extensions/internal/values.ts
@@ -1,8 +1,7 @@
 /**
- * The shapes every extension here needed its own copy of: an error's message, a plain
- * object check, whether a path is a directory, and the text of a message content. Each
- * was written three to five times with the same body, and the error one appeared in
- * seventeen files.
+ * The small shared shapes: an error's message, a plain-object check, whether a path
+ * is a directory, the text of a message content, a regex escape, a numeric env
+ * value. One copy each; a private copy in an extension is the drift to look for.
  */
 
 import * as fs from 'node:fs'

--- a/extensions/mcp/index.ts
+++ b/extensions/mcp/index.ts
@@ -53,8 +53,7 @@ import { type AuthUi, callRequestOptions, callTimeoutMs, connect, connectTimeout
 
 export { managedSettingsPath, setManagedSettingsPath } from '../internal/managed-settings.js'
 // Re-exports for consumers: the module split keeps the extension's public surface
-// (imported by the test suite) reachable from this entry point unchanged. The managed
-// settings path helpers now live in the shared internal module.
+// (imported by the test suite) reachable from this entry point unchanged.
 export type { HttpServerConfig, ServerConfig, StdioServerConfig } from './config.js'
 export { expandCwd, interpolateEnv, loadConfigFrom, loadPluginServers, loadUserScope, projectConfigPaths, userConfigPaths, warnOnTypelessUrl } from './config.js'
 export type { McpToolInfo } from './listing.js'

--- a/extensions/memory.ts
+++ b/extensions/memory.ts
@@ -177,7 +177,7 @@ export function indexWouldOverflow(index: string, name: string, description: str
 /** Where the index stands against the read limits, measured on the loaded content
  * (frontmatter and comments stripped): 'over' past either bound, 'near' within
  * 10% of one, else 'ok'. Claude reminds near a limit and errors over it. */
-export function indexReadState(index: string): 'ok' | 'near' | 'over' {
+function indexReadState(index: string): 'ok' | 'near' | 'over' {
   const loaded = stripNonLoaded(index)
   const lines = loaded.split('\n').length
   const bytes = Buffer.byteLength(loaded, 'utf-8')

--- a/extensions/skills.ts
+++ b/extensions/skills.ts
@@ -35,10 +35,6 @@ import { claudeSettingsChain, readSettingsChain } from './internal/settings-chai
 import { SKILL_HOOKS_CHANNEL } from './internal/skill-hooks.js'
 import { errorMessage, isDirectory, isRecord } from './internal/values.js'
 
-/** Existing `.claude/skills` directories, user first then project. The project
- * directory is included only for approved projects: pi's loader surfaces every skill's
- * name and description to the model, so an untrusted repository would otherwise get
- * text into the prompt without the user ever agreeing to load its config. */
 /** The extra skill directories a manifest declares, as a list. A string is one entry,
  * a list is itself, anything else declares none. */
 function declaredSkillDirs(declared: unknown): string[] {
@@ -46,6 +42,10 @@ function declaredSkillDirs(declared: unknown): string[] {
   return typeof declared === 'string' ? [declared] : []
 }
 
+/** Existing `.claude/skills` directories, user first then project. The project
+ * directory is included only for approved projects: pi's loader surfaces every skill's
+ * name and description to the model, so an untrusted repository would otherwise get
+ * text into the prompt without the user ever agreeing to load its config. */
 export function skillDirs(cwd: string, home: string, trusted: boolean): string[] {
   // Claude's precedence: enterprise (the skills directory beside the managed
   // settings file) overrides personal, and personal overrides project; discovery

--- a/extensions/skills.ts
+++ b/extensions/skills.ts
@@ -113,7 +113,7 @@ function skillAt(root: string, dirName: string): { name: string; filePath: strin
 
 /** A Claude-contributed skill by the name pi's loader gives it. One directory
  * level, the standard layout. */
-export function findClaudeSkill(name: string, roots: string[]): FoundSkill | undefined {
+function findClaudeSkill(name: string, roots: string[]): FoundSkill | undefined {
   for (const root of roots) {
     let entries: fs.Dirent[]
     try {

--- a/extensions/subagent/agents.ts
+++ b/extensions/subagent/agents.ts
@@ -30,7 +30,7 @@ import { errorMessage } from '../internal/values.js'
 function parseToolsField(raw: unknown, granting: boolean): string[] | undefined | null {
   if (raw === undefined) return undefined
   // Shares the command parser's splitting, so a comma inside an argument scope stays
-  // inside it here too: `Bash(mv, write, cp)` used to hand the child pi's real `write`.
+  // inside it here too: split naively, `Bash(mv, write, cp)` grants the child pi's real `write`.
   if (raw !== null && !Array.isArray(raw) && typeof raw !== 'string') return null
   if (Array.isArray(raw) && raw.some((item) => typeof item !== 'string')) return null
   const grants = parseToolGrants(raw)

--- a/extensions/subagent/background.ts
+++ b/extensions/subagent/background.ts
@@ -210,8 +210,8 @@ export function resumeBackgroundRun(id: string, task: string, onComplete: (run: 
   run.spawn = { ...run.spawn, args: rebuilt.args }
   if (rebuilt.dir) run.rebuiltPromptDir = rebuilt.dir
   // The task prompt is always the final argument: both spawn paths push it last and the
-  // invocation helper only prepends. Matching a 'Task: ' prefix missed it whenever
-  // SubagentStart hooks placed their context ahead of it, so the resume re-ran the old task.
+  // invocation helper only prepends. A 'Task: ' prefix match is wrong whenever
+  // SubagentStart hooks placed their context ahead of it.
   const args = rebuilt.args.map((arg, index) => (index === rebuilt.args.length - 1 ? `Task: ${task}` : arg))
   run.state = 'running'
   run.task = task

--- a/extensions/subagent/child.ts
+++ b/extensions/subagent/child.ts
@@ -27,8 +27,6 @@ export const AGENT_HOOK_SYSTEM = [
   'Use "allow" to let the action proceed, "deny" to block it, "ask" to require the user to confirm.',
 ].join('\n')
 
-/** A throwaway agent config for one agent-hook run: read-only inspection tools, the
- * hook's model (a fast default when unset), and the decision-returning system prompt. */
 /** The agent a context: fork skill runs as when it names none: full toolset, no
  * extra system prompt (the child keeps pi's default), the skill content as the
  * task. */
@@ -43,6 +41,8 @@ export function forkAgent(request: Pick<AgentRunRequest, 'model' | 'systemPrompt
   }
 }
 
+/** A throwaway agent config for one agent-hook run: read-only inspection tools, the
+ * hook's model (a fast default when unset), and the decision-returning system prompt. */
 export function buildHookAgent(request: Pick<AgentRunRequest, 'model' | 'systemPrompt'>): AgentConfig {
   return {
     name: 'agent-hook',


### PR DESCRIPTION
Round 5 register item R5-22. Comments, two `export` keywords and nothing else; no behaviour change, no test change.

- [x] `npm run check` passes (Biome, strict tsc, Vitest)

- **Fourteen misplaced doc blocks** (`internal/path-rules.ts`, `internal/project-approval.ts`, `internal/plugins.ts`, `context-imports.ts`, `skills.ts`, `hooks/config.ts`, `hooks/runners.ts`, `hooks/decisions.ts`, `subagent/child.ts`): each sat above a neighbouring declaration, so a reader of that symbol got the wrong contract and the described one had none. The `CompiledGlob` doc described a `basename` field the interface does not have.
- **A spliced sentence** (`hooks/matcher.ts`): the "PAIRED WITH" paragraph had been inserted mid-sentence into the `if`-pattern doc; the list it interrupted is whole again and the pairing note follows it.
- **Eleven history comments restated as constraints** (`managed-settings.ts`, `mcp/index.ts`, `mcp-oauth.ts`, `project-root.ts`, `claude-tool-names.ts`, `values.ts`, `path-rules.ts`, `tool-target.ts`, `hooks/config.ts`, `subagent/agents.ts`, `subagent/background.ts`): "used to", "the old trim", "dropped in v2.1.75" and "now live in" become the rule the code must keep, without the story.
- **Two in-file-only exports dropped** (`skills.ts` `findClaudeSkill`, `memory.ts` `indexReadState`) and **two seam docs corrected** (`agent-run.ts`, `external-imports.ts`) that claimed test uses that do not exist.