### PR TITLE
Release 1.0.64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-code",
-  "version": "1.0.63",
+  "version": "1.0.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-code",
-      "version": "1.0.63",
+      "version": "1.0.64",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-code",
-  "version": "1.0.63",
+  "version": "1.0.64",
   "description": "Claude Code experience for the pi coding agent: reads your .claude config (rules, commands, skills, hooks, output styles, MCP servers, agents) and adds todo, checkpoints, memory, web, subagents, and goals",
   "keywords": [
     "pi",


### PR DESCRIPTION
Patch bump: ten commits since v1.0.63, all defect fixes, test-oracle work, doc corrections and internal consolidation. No new feature or shipped artifact.

## Fixed

- **Checkpoints cover only the files the session edited** (#253). Snapshots ran `git add -A` against `cwd`, sizing every checkpoint by the working directory rather than by the edits: a session started in `$HOME` committed `~/Library/Caches` and `~/.npm/_cacache` on every prompt, and because the shadow repo is keyed to the session file, each new session wrote a further complete copy with no object sharing. On an 801-file tree with one file edited, a checkpoint now captures 1 file rather than 502 and occupies 28 KB rather than 2196 KB. An edit to an ignored file no longer ends checkpointing for the rest of the session, and a tracked file deleted between prompts no longer costs the run its checkpoint. *Behavior change: files modified by bash commands are no longer restorable through `/rewind`, matching the documented upstream limitation.*
- **Seven Round 5 defects** (#245): a connect race, Windows cancellation, hook validation, and an OAuth crash.
- **Settings placement and an orphaned background worktree** (#246).
- **Seven defects surfaced by a full code scan** (#242).
- **Nine places where docs or comments contradicted the code** (#243, #250).

## Changed

- pi's agent directory resolves through `getAgentDir` everywhere (#247).
- Duplicated helpers consolidated: env numbers, regex escape, model resolution, settings reads (#249).

## Tests

- Twelve test oracles strengthened where a named production mutant survived (#244).
- Fourteen test gaps closed, each against a named mutant (#248).

Verified locally before tagging, matching the publish workflow's own gates: `npm run check` green (2515 tests), tag/`package.json` parity for `v1.0.64`, and `npm pack` produces a 98-file tarball whose `extensions/git-checkpoint.ts` contains the #253 change.
